### PR TITLE
minor changes to Vector class constructor

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -28,7 +28,7 @@ class Vector(object):
         elif len(args) == 1:
             if isinstance(args[0], Vector):
                 fV = gp_Vec(args[0].wrapped.XYZ())
-            elif isinstance(args[0], tuple):
+            elif isinstance(args[0], tuple) or isinstance(args[0], list):
                 fV = gp_Vec(*args[0])
             elif isinstance(args[0], gp_Vec):
                 fV = gp_Vec(args[0].XYZ())
@@ -39,11 +39,12 @@ class Vector(object):
             elif isinstance(args[0], gp_XYZ):
                 fV = gp_Vec(args[0])
             else:
+                raise TypeError("Expected three floats, OCC Geom_, or 3-tuple")
                 fV = args[0]
         elif len(args) == 0:
             fV = gp_Vec(0, 0, 0)
         else:
-            raise ValueError("Expected three floats, OCC Geom_, or 3-tuple")
+            raise TypeError("Expected three floats, OCC Geom_, or 3-tuple")
 
         self._wrapped = fV
 

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -40,7 +40,6 @@ class Vector(object):
                 fV = gp_Vec(args[0])
             else:
                 raise TypeError("Expected three floats, OCC Geom_, or 3-tuple")
-                fV = args[0]
         elif len(args) == 0:
             fV = gp_Vec(0, 0, 0)
         else:

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -39,11 +39,11 @@ class Vector(object):
             elif isinstance(args[0], gp_XYZ):
                 fV = gp_Vec(args[0])
             else:
-                raise TypeError("Expected three floats, OCC Geom_, or 3-tuple")
+                raise TypeError("Expected three floats, OCC gp_, or 3-tuple")
         elif len(args) == 0:
             fV = gp_Vec(0, 0, 0)
         else:
-            raise TypeError("Expected three floats, OCC Geom_, or 3-tuple")
+            raise TypeError("Expected three floats, OCC gp_, or 3-tuple")
 
         self._wrapped = fV
 

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -28,7 +28,7 @@ class Vector(object):
         elif len(args) == 1:
             if isinstance(args[0], Vector):
                 fV = gp_Vec(args[0].wrapped.XYZ())
-            elif isinstance(args[0], tuple) or isinstance(args[0], list):
+            elif isinstance(args[0], (tuple, list)):
                 fV = gp_Vec(*args[0])
             elif isinstance(args[0], gp_Vec):
                 fV = gp_Vec(args[0].XYZ())


### PR DESCRIPTION
* Allow constructing with a list: `Vector([1, 2, 3])`
* change `ValueError` -> `TypeError`
* throw a `TypeError` if the argument isn't one of the recognized types. This helps catch mistakes earlier rather than later when the vector is used.