### PR TITLE
fix Vector.__eq__()

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -133,7 +133,7 @@ class Vector(object):
         return 'Vector: ' + str((self.x, self.y, self.z))
 
     def __eq__(self, other):
-        return self.x == other.x and self.y == other.y and self.z == other.z
+        return self.wrapped.IsEqual(other.wrapped, 0.00001, 0.00001)
     '''
     is not implemented in OCC
     def __ne__(self, other):

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -133,7 +133,7 @@ class Vector(object):
         return 'Vector: ' + str((self.x, self.y, self.z))
 
     def __eq__(self, other):
-        return self.wrapped == other.wrapped
+        return self.x == other.x and self.y == other.y and self.z == other.z
     '''
     is not implemented in OCC
     def __ne__(self, other):

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -108,6 +108,13 @@ class TestCadObjects(BaseTest):
         result = Vector(1, 2, 0) + Vector(0, 0, 3)
         self.assertTupleAlmostEquals((1.0, 2.0, 3.0), result.toTuple(), 3)
 
+    def testVectorEquals(self):
+        a = Vector(1, 2, 3)
+        b = Vector(1, 2, 3)
+        c = Vector(1, 2, 3.000001)
+        self.assertEqual(a, b)
+        self.assertEqual(a, c)
+
     def testTranslate(self):
         e = Edge.makeCircle(2, (1, 2, 3))
         e2 = e.translate(Vector(0, 0, 1))


### PR DESCRIPTION
I think the previous implementation was just doing a pointer comparison so two unique vectors with the same contents would not be considered equal.