### PR TITLE
Copy Plane.__eq__() from main dcowden/cadquery

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -245,6 +245,11 @@ class Plane(object):
     created automatically from faces.
     """
 
+    # equality tolerances
+    _eq_tolerance_origin = 1e-6
+    _eq_tolerance_dot = 1e-6
+
+
     @classmethod
     def named(cls, stdName, origin=(0, 0, 0)):
         """Create a predefined Plane based on the conventional names.
@@ -649,6 +654,22 @@ class Plane(object):
         self.lcs = local_coord_system
         self.rG = inverse
         self.fG = forward
+
+    # Equality
+    def __eq__(self, other):
+        def equality_iter():
+            cls = type(self)
+            yield isinstance(other, Plane)  # comparison is with another Plane
+            # origins are the same
+            yield abs(self.origin - other.origin) < cls._eq_tolerance_origin
+            # z-axis vectors are parallel (assumption: both are unit vectors)
+            yield abs(self.zDir.dot(other.zDir) - 1) < cls._eq_tolerance_dot
+            # x-axis vectors are parallel (assumption: both are unit vectors)
+            yield abs(self.xDir.dot(other.xDir) - 1) < cls._eq_tolerance_dot
+        return all(equality_iter())
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class BoundBox(object):

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -138,6 +138,12 @@ class Vector(object):
     def __sub__(self, v):
         return self.sub(v)
 
+    def __neg__(self):
+        return self * -1
+
+    def __abs__(self):
+        return self.Length
+
     def __repr__(self):
         return 'Vector: ' + str((self.x, self.y, self.z))
 

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -80,12 +80,24 @@ class Vector(object):
     def sub(self, v):
         return Vector(self.wrapped.Subtracted(v.wrapped))
 
+    def __sub__(self, v):
+        return self.sub(v)
+
     def add(self, v):
         return Vector(self.wrapped.Added(v.wrapped))
+
+    def __add__(self, v):
+        return self.add(v)
 
     def multiply(self, scale):
         """Return a copy multiplied by the provided scalar"""
         return Vector(self.wrapped.Multiplied(scale))
+
+    def __mul__(self, scale):
+        return self.multiply(scale)
+
+    def __truediv__(self, denom):
+        return self.multiply(1.0 / denom)
 
     def normalized(self):
         """Return a normalized version of this vector"""

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -108,6 +108,19 @@ class TestCadObjects(BaseTest):
         result = Vector(1, 2, 0) + Vector(0, 0, 3)
         self.assertTupleAlmostEquals((1.0, 2.0, 3.0), result.toTuple(), 3)
 
+    def testVectorOperators(self):
+        result = Vector(1, 1, 1) + Vector(2, 2, 2)
+        self.assertEqual(Vector(3, 3, 3), result)
+
+        result = Vector(1, 2, 3) - Vector(3, 2, 1)
+        self.assertEqual(Vector(-2, 0, 2), result)
+
+        result = Vector(1, 2, 3) * 2
+        self.assertEqual(Vector(2, 4, 6), result)
+
+        result = Vector(2, 4, 6) / 2
+        self.assertEqual(Vector(1, 2, 3), result)
+
     def testVectorEquals(self):
         a = Vector(1, 2, 3)
         b = Vector(1, 2, 3)

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -145,6 +145,51 @@ class TestCadObjects(BaseTest):
                                                gp_Pnt(1, 1, 0)).Edge())
         self.assertEqual(2, len(e.Vertices()))
 
+    def testPlaneEqual(self):
+        # default orientation
+        self.assertEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1))
+        )
+        # moved origin
+        self.assertEqual(
+            Plane(origin=(2,1,-1), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(2,1,-1), xDir=(1,0,0), normal=(0,0,1))
+        )
+        # moved x-axis
+        self.assertEqual(
+            Plane(origin=(0,0,0), xDir=(1,1,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,1,0), normal=(0,0,1))
+        )
+        # moved z-axis
+        self.assertEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,1,1)),
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,1,1))
+        )
+
+    def testPlaneNotEqual(self):
+        # type difference
+        for value in [None, 0, 1, 'abc']:
+            self.assertNotEqual(
+                Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+                value
+            )
+        # origin difference
+        self.assertNotEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,1), xDir=(1,0,0), normal=(0,0,1))
+        )
+        # x-axis difference
+        self.assertNotEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,1,0), normal=(0,0,1))
+        )
+        # z-axis difference
+        self.assertNotEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,1,1))
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -121,6 +121,12 @@ class TestCadObjects(BaseTest):
         result = Vector(2, 4, 6) / 2
         self.assertEqual(Vector(1, 2, 3), result)
 
+        self.assertEqual(Vector(-1, -1, -1), -Vector(1, 1, 1))
+
+        self.assertEqual(0, abs(Vector(0, 0, 0)))
+        self.assertEqual(1, abs(Vector(1, 0, 0)))
+        self.assertEqual((1+4+9)**0.5, abs(Vector(1, 2, 3)))
+
     def testVectorEquals(self):
         a = Vector(1, 2, 3)
         b = Vector(1, 2, 3)


### PR DESCRIPTION
This was initially implemented in dcowden/cadquery@63cdaae by @fragmuffin.

Note: this PR is based on top of PR #6. Also the discussion on vector equality tolerances in  #7 is probably relevant here too.