### PR TITLE
Pass exportShape()'s 'tolerance' param to exportStl()

### DIFF
--- a/cadquery/occ_impl/exporters.py
+++ b/cadquery/occ_impl/exporters.py
@@ -105,7 +105,7 @@ def exportShape(shape, exportType, fileLike, tolerance=0.1):
         if exportType == ExportTypes.STEP:
             shape.exportStep(outFileName)
         elif exportType == ExportTypes.STL:
-            shape.exportStl(outFileName)
+            shape.exportStl(outFileName, tolerance)
         else:
             raise ValueError("No idea how i got here")
 


### PR DESCRIPTION
For reference, see the freecad_impl version: 

https://github.com/dcowden/cadquery/blob/1c86a979a08fa201283d89ad2848650dbee1009d/cadquery/freecad_impl/exporters.py#L87

