### PR TITLE
implement Matrix.__getitem__() and Matrix(list) constructor

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -161,6 +161,18 @@ class Matrix:
     """A 3d , 4x4 transformation matrix.
 
     Used to move geometry in space.
+
+    The provided "matrix" parameter may be None, a gp_Trsf, or a nested list of
+    values.
+
+    If given a nested list, it is expected to be of the form:
+
+        [[m11, m12, m13, m14],
+         [m21, m22, m23, m24],
+         [m31, m32, m33, m34]]
+
+    A fourth row may be given, but it is expected to be: [0.0, 0.0, 0.0, 1.0]
+    since this is a transform matrix.
     """
 
     def __init__(self, matrix=None):
@@ -171,14 +183,16 @@ class Matrix:
             self.wrapped = matrix
         elif isinstance(matrix, list):
             self.wrapped = gp_Trsf()
-            if len(matrix) == 12:
-                self.wrapped.SetValues(*matrix)
-            elif len(matrix) == 16:
-                # Only use first 12 values - the last 4 must be [0, 0, 0, 1].
-                last4 = matrix[12:]
-                if last4 != [0., 0., 0., 1.]:
-                    raise ValueError("Expected the last 4 values to be [0,0,0,1], but got: {}".format(last4))
-                self.wrapped.SetValues(*matrix[0:12])
+            if len(matrix) == 3:
+                flattened = [e for row in matrix for e in row]
+                self.wrapped.SetValues(*flattened)
+            elif len(matrix) == 4:
+                # Only use first 3 rows - the last must be [0, 0, 0, 1].
+                lastRow = matrix[3]
+                if lastRow != [0., 0., 0., 1.]:
+                    raise ValueError("Expected the last row to be [0,0,0,1], but got: {}".format(lastRow))
+                flattened = [e for row in matrix[0:3] for e in row]
+                self.wrapped.SetValues(*flattened)
             else:
                 raise TypeError("Matrix constructor requires list of length 12 or 16")
         else:

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -115,6 +115,49 @@ class TestCadObjects(BaseTest):
         self.assertEqual(a, b)
         self.assertEqual(a, c)
 
+    def testMatrixCreationAndAccess(self):
+        def matrix_vals(m):
+            return [m[r,c] for r in range(4) for c in range(4)]
+        # default constructor creates a 4x4 identity matrix
+        m = Matrix()
+        identity = [1., 0., 0., 0.,
+                    0., 1., 0., 0.,
+                    0., 0., 1., 0.,
+                    0., 0., 0., 1.]
+        self.assertEqual(identity, matrix_vals(m))
+
+        vals4x4 = [1., 0., 0., 1.,
+                   0., 1., 0., 2.,
+                   0., 0., 1., 3.,
+                   0., 0., 0., 1.,]
+
+        # test constructor with 16-value input
+        m = Matrix(vals4x4)
+        self.assertEqual(vals4x4, matrix_vals(m))
+
+        # test constructor with 12-value input (the last 4 are an implied
+        # [0,0,0,1])
+        m = Matrix(vals4x4[0:12])
+        self.assertEqual(vals4x4, matrix_vals(m))
+
+        # Test 16-value input with invalid values for the last 4
+        invalid = [1., 0., 0., 1.,
+                   0., 1., 0., 2.,
+                   0., 0., 1., 3.,
+                   1., 2., 3., 4.,]
+        with self.assertRaises(ValueError):
+            Matrix(invalid)
+
+        # Test input with invalid size
+        with self.assertRaises(TypeError):
+            Matrix([1,2,3])
+
+        # test out-of-bounds access
+        m = Matrix()
+        with self.assertRaises(IndexError):
+            m[5, 5]
+
+
     def testTranslate(self):
         e = Edge.makeCircle(2, (1, 2, 3))
         e2 = e.translate(Vector(0, 0, 1))

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -117,19 +117,19 @@ class TestCadObjects(BaseTest):
 
     def testMatrixCreationAndAccess(self):
         def matrix_vals(m):
-            return [m[r,c] for r in range(4) for c in range(4)]
+            return [[m[r,c] for c in range(4)] for r in range(4)]
         # default constructor creates a 4x4 identity matrix
         m = Matrix()
-        identity = [1., 0., 0., 0.,
-                    0., 1., 0., 0.,
-                    0., 0., 1., 0.,
-                    0., 0., 0., 1.]
+        identity = [[1., 0., 0., 0.],
+                    [0., 1., 0., 0.],
+                    [0., 0., 1., 0.],
+                    [0., 0., 0., 1.]]
         self.assertEqual(identity, matrix_vals(m))
 
-        vals4x4 = [1., 0., 0., 1.,
-                   0., 1., 0., 2.,
-                   0., 0., 1., 3.,
-                   0., 0., 0., 1.,]
+        vals4x4 = [[1., 0., 0., 1.],
+                   [0., 1., 0., 2.],
+                   [0., 0., 1., 3.],
+                   [0., 0., 0., 1.]]
 
         # test constructor with 16-value input
         m = Matrix(vals4x4)
@@ -141,10 +141,10 @@ class TestCadObjects(BaseTest):
         self.assertEqual(vals4x4, matrix_vals(m))
 
         # Test 16-value input with invalid values for the last 4
-        invalid = [1., 0., 0., 1.,
-                   0., 1., 0., 2.,
-                   0., 0., 1., 3.,
-                   1., 2., 3., 4.,]
+        invalid = [[1., 0., 0., 1.],
+                   [0., 1., 0., 2.],
+                   [0., 0., 1., 3.],
+                   [1., 2., 3., 4.]]
         with self.assertRaises(ValueError):
             Matrix(invalid)
 


### PR DESCRIPTION
* Implement `Matrix.__getitem__()`, so individual values can be accessed with `matrix[row, column]` syntax. This is useful generally and is required for some cqparts testing of coordinate transforms.
* Matrix constructor accepts a list of values as input. The input can be all 16 values of the matrix or just the first 12. Since this is a transform matrix, the last row should always be `[0, 0, 0, 1]`.
* Matrix constructor throws a `TypeError` if an invalid input is given
* Test cases are added to test all of these things.

A couple notes:
* gp_Trsf value access is 1-indexed, but I used 0-indexing for the accessors to be consistent with everything python
* An alternative to accepting a flat list of values in the `Matrix` constructor would be to do what numpy does and accept a list of lists. Something like `[[a, b], [c, d]]` instead of `[a, b, c, d]`. I don't really have a preference, let me know your thoughts.