### PR TITLE
Initial implementation of tapered extrusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 - export PATH="$HOME/miniconda/bin:$HOME/miniconda/lib:$PATH";
 - hash -r;
 - conda config --set always_yes yes --set changeps1 no;
-- conda create -y -q -n test_cq -c pythonocc -c oce -c conda-forge -c dlr-sc pythonocc-core=0.18
+- conda create -y -q -n test_cq -c pythonocc -c oce -c conda-forge -c dlr-sc pythonocc-core=0.18.1
   pyparsing mock;
 - source ~/miniconda/bin/activate test_cq;
 - python -c 'import OCC.gp as gp; print(gp.gp_Vec())'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
     - set "PATH=%MINICONDA_DIRNAME%;%MINICONDA_DIRNAME%\\Scripts;%PATH%"
     - conda config --set always_yes yes
     - conda update -q conda
-    - conda create --quiet --name cqtest -c cadquery -c conda-forge -c pythonocc -c oce -c conda-forge -c dlr-sc pythonocc-core=0.18 python=%PYTHON_VERSION% pyparsing mock coverage codecov
+    - conda create --quiet --name cqtest -c cadquery -c conda-forge -c pythonocc -c oce -c conda-forge -c dlr-sc pythonocc-core=0.18.1 python=%PYTHON_VERSION% pyparsing mock coverage codecov
     - activate cqtest
     - pip install codecov
     - python setup.py install

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2397,7 +2397,7 @@ class Workplane(CQ):
 
         return self.newObject([newS])
 
-    def cutBlind(self, distanceToCut, clean=True):
+    def cutBlind(self, distanceToCut, clean=True, taper=None):
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
 
@@ -2408,6 +2408,7 @@ class Workplane(CQ):
         :type distanceToCut: float, >0 means in the positive direction of the workplane normal,
             <0 means in the negative direction
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param float taper: angle for optional tapered extrusion
         :raises: ValueError if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected
 
@@ -2417,7 +2418,7 @@ class Workplane(CQ):
             Cut Up to Surface
         """
         # first, make the object
-        toCut = self._extrude(distanceToCut)
+        toCut = self._extrude(distanceToCut, taper=taper)
 
         # now find a solid in the chain
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -464,7 +464,8 @@ class Shape(object):
         return [Solid(i) for i in self._entities('Solid')]
 
     def Area(self):
-        raise NotImplementedError
+        # when 2D density == 1, mass == area
+        return Shape.computeMass(self)
 
     def Volume(self):
         # when density == 1, mass == volume
@@ -1288,7 +1289,7 @@ class Solid(Shape, Mixin3D):
 
             :param outerWire: the outermost wire
             :param innerWires: a list of inner wires
-            :param vecNormal: a vector along which to extrude the wires, default=None
+            :param vecNormal: a vector along which to extrude the wires
             :param taper: taper angle, default=0
             :return: a Solid object
 

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1668,11 +1668,24 @@ class TestCadQuery(BaseTest):
 
     def testExtrude(self):
         """
-        Test symmetric extrude
+        Test extrude
         """
         r = 1.
         h = 1.
         decimal_places = 9.
+        
+        # extrude in one direction
+        s = Workplane("XY").circle(r).extrude(h, both=False)
+
+        top_face = s.faces(">Z")
+        bottom_face = s.faces("<Z")
+
+        # calculate the distance between the top and the bottom face
+        delta = top_face.val().Center().sub(bottom_face.val().Center())
+
+        self.assertTupleAlmostEquals(delta.toTuple(),
+                                     (0., 0., h),
+                                     decimal_places)
 
         # extrude symmetrically
         s = Workplane("XY").circle(r).extrude(h, both=True)
@@ -1686,6 +1699,28 @@ class TestCadQuery(BaseTest):
         self.assertTupleAlmostEquals(delta.toTuple(),
                                      (0., 0., 2. * h),
                                      decimal_places)
+        
+        # extrude with a positive taper
+        s = Workplane("XY").circle(r).extrude(h, taper=5)
+
+        top_face = s.faces(">Z")
+        bottom_face = s.faces("<Z")
+
+        # top and bottom face area
+        delta = top_face.val().Area() - bottom_face.val().Area()
+
+        self.assertTrue(delta < 0)
+        
+        # extrude with a negative taper
+        s = Workplane("XY").circle(r).extrude(h, taper=-5)
+
+        top_face = s.faces(">Z")
+        bottom_face = s.faces("<Z")
+
+        # top and bottom face area
+        delta = top_face.val().Area() - bottom_face.val().Area()
+
+        self.assertTrue(delta > 0)
 
     def testClose(self):
         # Close without endPoint and startPoint coincide.

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1699,9 +1699,15 @@ class TestCadQuery(BaseTest):
         self.assertTupleAlmostEquals(delta.toTuple(),
                                      (0., 0., 2. * h),
                                      decimal_places)
-        
+    
+    def testTaperedExtrudeCutBlind(self):
+      
+        h = 1.
+        r = 1.
+        t = 5
+      
         # extrude with a positive taper
-        s = Workplane("XY").circle(r).extrude(h, taper=5)
+        s = Workplane("XY").circle(r).extrude(h, taper=t)
 
         top_face = s.faces(">Z")
         bottom_face = s.faces("<Z")
@@ -1712,7 +1718,7 @@ class TestCadQuery(BaseTest):
         self.assertTrue(delta < 0)
         
         # extrude with a negative taper
-        s = Workplane("XY").circle(r).extrude(h, taper=-5)
+        s = Workplane("XY").circle(r).extrude(h, taper=-t)
 
         top_face = s.faces(">Z")
         bottom_face = s.faces("<Z")
@@ -1721,6 +1727,14 @@ class TestCadQuery(BaseTest):
         delta = top_face.val().Area() - bottom_face.val().Area()
 
         self.assertTrue(delta > 0)
+        
+        # cut a tapered hole
+        s = Workplane("XY").rect(2*r,2*r).extrude(2*h).faces('>Z').workplane()\
+        .rect(r,r).cutBlind(-h, taper=t)
+        
+        middle_face = s.faces('>Z[-2]')
+        
+        self.assertTrue(middle_face.val().Area() < 1)
 
     def testClose(self):
         # Close without endPoint and startPoint coincide.


### PR DESCRIPTION
Tapred `extrude` and `cutBlind` operations. Teaser pic: 
![afbeelding](https://user-images.githubusercontent.com/13981538/52442762-4cded600-2b24-11e9-8b66-68a8d8f922c0.png)

Related to #70 