### PR TITLE
BoundingBox tolerance default bugfix

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -790,10 +790,11 @@ class BoundBox(object):
         return None
 
     @classmethod
-    def _fromTopoDS(cls, shape, tol=TOL, optimal=False):
+    def _fromTopoDS(cls, shape, tol=None, optimal=False):
         '''
         Constructs a bounding box from a TopoDS_Shape
         '''
+        tol = TOL if tol is None else tol  # tol = TOL (by default)
         bbox = Bnd_Box()
         bbox.SetGap(tol)
         if optimal:


### PR DESCRIPTION
The `tol` default for `cadquery.BoundBox._fromTopoDS` was part of the signature.
Which means changing the tolerance in the module with something like:

```python
@mock.patch('cadquery.occ_impl.geom.TOL', 1e-7)
```

had no effect... but should work now.

note: this is a bit of a band-aid for #7