### PR TITLE
cutThruAll based on BRepFeat_MakeDPrism

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -476,7 +476,7 @@ class CQ(object):
 
         :param searchStack: should objects on the stack be searched first.
         :param searchParents: should parents be searched?
-        :raises: ValueError if no solid is found in the current object or its parents,
+        :raises: ValueError if no face is found in the current object or its parents,
             and errorOnEmpty is True
         """
 
@@ -2521,6 +2521,15 @@ class Workplane(CQ):
 
         solidRef = self.findSolid()
         faceRef = self.findFace()
+
+        #if no faces on the stack take the nearest face parallel to the plane zDir
+        if not faceRef:
+            #first select all with faces with good orietation
+            sel = selectors.PerpendicularDirSelector(self.plane.zDir)
+            faces = sel.filter(solidRef.Faces())
+            #then select the closest
+            sel = selectors.NearestToPointSelector(self.plane.origin.toTuple())
+            faceRef = sel.filter(faces)[0]
 
         rv = []
         for solid in solidRef.Solids():

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2496,7 +2496,7 @@ class Workplane(CQ):
 
         return self.newObject([s])
 
-    def cutThruAll(self, positive=False, clean=True):
+    def cutThruAll(self, positive=False, clean=True, taper=0):
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
 
@@ -2519,7 +2519,8 @@ class Workplane(CQ):
 
         rv = []
         for solid in solidRef.Solids():
-            s = solid.dprism(faceRef, wires, thruAll=True, additive=False)
+            s = solid.dprism(faceRef, wires, thruAll=True, additive=False,
+                             taper=-taper)
 
             if clean:
                 s = s.clean()

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2136,8 +2136,7 @@ class Workplane(CQ):
         """
         # group wires together into faces based on which ones are inside the others
         # result is a list of lists
-        wireSets = sortWiresByBuildOrder(
-            list(self.ctx.pendingWires), self.plane, [])
+        wireSets = sortWiresByBuildOrder(list(self.ctx.pendingWires))
 
         # now all of the wires have been used to create an extrusion
         self.ctx.pendingWires = []
@@ -2539,7 +2538,7 @@ class Workplane(CQ):
         # result is a list of lists
         s = time.time()
         wireSets = sortWiresByBuildOrder(
-            list(self.ctx.pendingWires), self.plane, [])
+            list(self.ctx.pendingWires), [])
         # print "sorted wires in %d sec" % ( time.time() - s )
         # now all of the wires have been used to create an extrusion
         self.ctx.pendingWires = []
@@ -2603,7 +2602,7 @@ class Workplane(CQ):
         """
         # We have to gather the wires to be revolved
         wireSets = sortWiresByBuildOrder(
-            list(self.ctx.pendingWires), self.plane, [])
+            list(self.ctx.pendingWires))
 
         # Mark that all of the wires have been used to create a revolution
         self.ctx.pendingWires = []
@@ -2631,7 +2630,7 @@ class Workplane(CQ):
         # group wires together into faces based on which ones are inside the others
         # result is a list of lists
         s = time.time()
-        wireSets = sortWiresByBuildOrder(list(self.ctx.pendingWires), self.plane, [])
+        wireSets = sortWiresByBuildOrder(list(self.ctx.pendingWires))
         # print "sorted wires in %d sec" % ( time.time() - s )
         self.ctx.pendingWires = []  # now all of the wires have been used to create an extrusion
 

--- a/cadquery/occ_impl/exporters.py
+++ b/cadquery/occ_impl/exporters.py
@@ -184,7 +184,7 @@ class AmfWriter(object):
             v2.text = str(t[1])
             v3 = ET.SubElement(triangle, 'v3')
             v3.text = str(t[2])
-        
+
         amf = ET.ElementTree(amf).write(outFile, xml_declaration=True)
 
 
@@ -304,7 +304,7 @@ def getSVG(shape, opts=None):
     hlr.Update()
     hlr.Hide()
 
-    hlr_shapes = HLRBRep_HLRToShape(hlr.GetHandle())
+    hlr_shapes = HLRBRep_HLRToShape(hlr)
 
     visible = []
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -757,7 +757,7 @@ class Edge(Shape, Mixin1D):
         for ix, v in enumerate(listOfVector):
             pnts.SetValue(ix+1, v.toPnt())
 
-        spline_builder = GeomAPI_Interpolate(pnts.GetHandle(), periodic, tol)
+        spline_builder = GeomAPI_Interpolate(pnts, periodic, tol)
         if tangents:
           v1,v2 = tangents
           spline_builder.Load(v1.wrapped,v2.wrapped)
@@ -887,7 +887,7 @@ class Wire(Shape, Mixin1D):
         u_stop = geom_line.Value(sqrt(n_turns * ((2 * pi)**2 + pitch**2)))
         geom_seg = GCE2d_MakeSegment(u_start, u_stop).Value()
 
-        e = BRepBuilderAPI_MakeEdge(geom_seg, geom_surf.GetHandle()).Edge()
+        e = BRepBuilderAPI_MakeEdge(geom_seg, geom_surf).Edge()
 
         # 4. Convert to wire and fix building 3d geom from 2d geom
         w = BRepBuilderAPI_MakeWire(e).Wire()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1475,7 +1475,6 @@ class Solid(Shape, Mixin3D):
             feat = BRepFeat_MakeDPrism(shape,
                                        face.wrapped,
                                        basis,
-                                       #basis.normalAt().toDir(),
                                        taper*DEG2RAD,
                                        additive,
                                        False)

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -839,10 +839,15 @@ class TestCadQuery(BaseTest):
         r = s.rect(2.0, 2.0).rect(
             1.3, 1.3, forConstruction=True).vertices().circle(0.125).extrude(0.5)
 
-        # side hole, thru all
-        t = r.faces(">Y").workplane().circle(0.125).cutThruAll()
-        self.saveModel(t)
+
+        # thru all without explicit face selection
+        t = r.circle(0.5).cutThruAll()
         self.assertEqual(11, t.faces().size())
+
+        # side hole, thru all
+        t = t.faces(">Y").workplane().circle(0.125).cutThruAll()
+        self.saveModel(t)
+        self.assertEqual(13, t.faces().size())
 
     def testCutToFaceOffsetNOTIMPLEMENTEDYET(self):
         """


### PR DESCRIPTION
This PR will resolve #98 . 

### Before:
```python
import cadquery as cq
result = cq.Workplane("front").box(3.0, 4.0, 0.25).pushPoints ( [ ( 0,0.75 ),(0, -0.75) ]) \
    .polygon(6, 1.0).cutThruAll()
show_object(result)
```
![afbeelding](https://user-images.githubusercontent.com/13981538/53566768-75735200-3b5d-11e9-81f0-98df48c35099.png)

### After:
```python
import cadquery as cq
result = cq.Workplane("front").box(3.0, 4.0, 0.25).faces('>Z').pushPoints ( [ ( 0,0.75 ),(0, -0.75) ]) \
    .polygon(6, 1.0).cutThruAll()
show_object(result)
```
![afbeelding](https://user-images.githubusercontent.com/13981538/53566926-f3cff400-3b5d-11e9-9bed-a81ec952c15e.png)
