### PR TITLE
Apply 2 as version.

### DIFF
--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     'TypeSelector', 'DirectionMinMaxSelector', 'StringSyntaxSelector', 'Selector', 'plugins'
 ]
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"

--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     'TypeSelector', 'DirectionMinMaxSelector', 'StringSyntaxSelector', 'Selector', 'plugins'
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.0dev"


### PR DESCRIPTION
I want to distinguish https://github.com/CadQuery/cadquery and https://github.com/dcowden/cadquery but version of them are 1.*.
I distinguish them with referencing included module like this but is has possibility to work wrong.
```py
import cadquery
import sys

if 'FreeCAD' in sys.modules:
  print('It's https://github.com/dcowden/cadquery')

if 'OCC' in sys.modules:
  print('It's https://github.com/CadQuery/cadquery')
```
How about to use 2.* as version of this repository?
If the idea is accepted, I can distinguish them like this.
```py
import cadquery

if cadquery.__version__.startswith('1.'):
  print('It's https://github.com/dcowden/cadquery')

if cadquery.__version__.startswith('2.'):
  print('It's https://github.com/CadQuery/cadquery')
```

Thank you.