### PR TITLE
Added option to center workplane on projected origin.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.linting.flake8Enabled": false,
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.pythonPath": "C:\\Users\\micha\\Anaconda3\\envs\\cq\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "python.linting.flake8Enabled": false,
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "python.pythonPath": "C:\\Users\\micha\\Anaconda3\\envs\\cq\\python.exe"
-}

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -262,7 +262,7 @@ class CQ(object):
         return self.objects[0].wrapped
 
     def workplane(self, offset=0.0, invert=False, centerOption='CenterOfMass',
-                  origin=(0, 0, 0)):
+                  origin=None):
         """
         Creates a new 2-D workplane, located relative to the first face on the stack.
 
@@ -273,7 +273,7 @@ class CQ(object):
         :type offset: float or None=0.0
         :type invert: boolean or None=False
         :type centerOption: string or None='CenterOfMass'
-        :type origin: tuple
+        :type origin: Vector or None
         :rtype: Workplane object ( which is a subclass of CQ )
 
         The first element on the stack must be a face, a set of
@@ -290,8 +290,9 @@ class CQ(object):
              on the face. The centerOption paramter sets how the center is defined.
              Options are 'CenterOfMass', 'CenterOfBoundBox', or 'ProjectedOrigin'.
              'CenterOfMass' and 'CenterOfBoundBox' are in relation to the selected
-             face/faces. 'ProjectedOrigin' uses the supplied origin, which defaults
-             to (0, 0, 0).
+             face/faces. 'ProjectedOrigin' uses the current planes origin by default
+             or can be specified as an arbitrary point using the optional origin
+             parameter.
            * The Z direction will be normal to the plane of the face,computed
              at the center point.
            * The X direction will be parallel to the x-y plane. If the workplane is  parallel to
@@ -343,6 +344,11 @@ class CQ(object):
         if centerOption not in {'CenterOfMass', 'ProjectedOrigin', 'CenterOfBoundBox'}:
             raise ValueError('Undefined centerOption value provided.')
 
+        if origin is None and centerOption == 'ProjectedOrigin': 
+            origin = self.plane.origin
+        elif isinstance(origin, tuple):
+            origin = Vector(origin)
+
         if len(self.objects) > 1:
             # are all objects 'PLANE'?
             if not all(o.geomType() in ('PLANE', 'CIRCLE') for o in self.objects):
@@ -385,7 +391,7 @@ class CQ(object):
 
         # update center to projected origin if desired
         if centerOption == 'ProjectedOrigin':
-            center = Vector(origin).projectToPlane(Plane(center, xDir, normal))
+            center = origin.projectToPlane(Plane(center, xDir, normal))
 
         # invert if requested
         if invert:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -344,11 +344,6 @@ class CQ(object):
         if centerOption not in {'CenterOfMass', 'ProjectedOrigin', 'CenterOfBoundBox'}:
             raise ValueError('Undefined centerOption value provided.')
 
-        if origin is None and centerOption == 'ProjectedOrigin': 
-            origin = self.plane.origin
-        elif isinstance(origin, tuple):
-            origin = Vector(origin)
-
         if len(self.objects) > 1:
             # are all objects 'PLANE'?
             if not all(o.geomType() in ('PLANE', 'CIRCLE') for o in self.objects):
@@ -391,6 +386,10 @@ class CQ(object):
 
         # update center to projected origin if desired
         if centerOption == 'ProjectedOrigin':
+            if origin is None:
+                origin = self.plane.origin
+            elif isinstance(origin, tuple):
+                origin = Vector(origin)
             center = origin.projectToPlane(Plane(center, xDir, normal))
 
         # invert if requested

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -376,9 +376,7 @@ class CQ(object):
 
         # update center to projected origin if desired
         if centerOption == 'ProjectedOrigin':
-            projected_center = Vector(0, 0, 0)
-            projected_center.projectToPlane(center, normal)
-            center = projected_center
+            center = Vector(0, 0, 0).projectToPlane(center, normal)
 
         # invert if requested
         if invert:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -334,23 +334,6 @@ class CQ(object):
                 xd = Vector(1, 0, 0)
             return xd
 
-        def _pointOnPlane(center, normal, point):
-            """
-            Returns the point on the plane defined by center and normal nearest to the input 
-            argument point.
-            """
-            a = normal.x; b = normal.y; c = normal.z
-            x0 = center.x; y0 = center.y; z0 = center.z
-            x1 = point.x; y1 = point.y; z1 = point.z
-
-            denom = a**2 + b**2 + c**2
-
-            nearest_x = (-a*b*y1 - a*c*z1 + a*(a*x0 + b*y0 + c*z0) + x1*(b**2 + c**2))/denom
-            nearest_y = (-a*b*x1 - b*c*z1 + b*(a*x0 + b*y0 + c*z0) + y1*(a**2 + c**2))/denom
-            nearest_z = (-a*c*x1 - b*c*y1 + c*(a*x0 + b*y0 + c*z0) + z1*(a**2 + b**2))/denom
-
-            return Vector(nearest_x, nearest_y, nearest_z)
-
         if len(self.objects) > 1:
             # are all objects 'PLANE'?
             if not all(o.geomType() in ('PLANE', 'CIRCLE') for o in self.objects):
@@ -393,7 +376,9 @@ class CQ(object):
 
         # update center to projected origin if desired
         if centerOption == 'ProjectedOrigin':
-            center = _pointOnPlane(center, normal, Vector(0, 0, 0))
+            projected_center = Vector(0, 0, 0)
+            projected_center.projectToPlane(center, normal)
+            center = projected_center
 
         # invert if requested
         if invert:

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -143,9 +143,26 @@ class Vector(object):
         raise NotImplementedError(
             "Have not needed this yet, but FreeCAD supports it!")
 
-    def projectToPlane(self):
-        raise NotImplementedError(
-            "Have not needed this yet, but FreeCAD supports it!")
+    def projectToPlane(self, *args):
+        """
+        Vector is projected onto the plane provided as input.
+
+        :param args: Plane object or base and normal vectors that define the plane
+
+        This method modifies the vector in place and returns the new vector.
+        """
+        if len(args) == 2:
+            base = args[0]
+            normal = args[1]
+        else:
+            base = args[0].origin
+            normal = args[1].zDir
+
+        result = self-normal*(((self-base).dot(normal))/normal.Length**2)
+
+        self.x = result.x
+        self.y = result.y
+        self.z = result.z
 
     def __neg__(self):
         return self * -1

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -154,15 +154,20 @@ class Vector(object):
         if len(args) == 2:
             base = args[0]
             normal = args[1]
-        else:
+        elif len(args) == 1:
             base = args[0].origin
-            normal = args[1].zDir
+            normal = args[0].zDir
+        else:
+            raise TypeError("Expected 1 or 2 arguments consisting of 1 Plane object \
+or a base Vector and a normal Vector object.")
 
         result = self-normal*(((self-base).dot(normal))/normal.Length**2)
 
         self.x = result.x
         self.y = result.y
         self.z = result.z
+
+        return self
 
     def __neg__(self):
         return self * -1

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -143,31 +143,18 @@ class Vector(object):
         raise NotImplementedError(
             "Have not needed this yet, but FreeCAD supports it!")
 
-    def projectToPlane(self, *args):
+    def projectToPlane(self, plane):
         """
         Vector is projected onto the plane provided as input.
 
-        :param args: Plane object or base and normal vectors that define the plane
+        :param args: Plane object
 
-        This method modifies the vector in place and returns the new vector.
+        Returns the projected vector.
         """
-        if len(args) == 2:
-            base = args[0]
-            normal = args[1]
-        elif len(args) == 1:
-            base = args[0].origin
-            normal = args[0].zDir
-        else:
-            raise TypeError("Expected 1 or 2 arguments consisting of 1 Plane object \
-or a base Vector and a normal Vector object.")
+        base = plane.origin
+        normal = plane.zDir
 
-        result = self-normal*(((self-base).dot(normal))/normal.Length**2)
-
-        self.x = result.x
-        self.y = result.y
-        self.z = result.z
-
-        return self
+        return self-normal*(((self-base).dot(normal))/normal.Length**2)
 
     def __neg__(self):
         return self * -1

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -161,23 +161,10 @@ class TestCadObjects(BaseTest):
         base = Vector(5, 7, 9)
         x_dir = Vector(1, 0, 0)
 
-        # test passing plane defined by base and normal
-        point = Vector(10, 11, 12).projectToPlane(base, normal)
-        self.assertTupleAlmostEquals(point.toTuple(), (59/7, 55/7, 51/7),
-                                     decimal_places)
-
-        point = Vector(10, 11, 12).projectToPlane(base, normal.normalized())
-        self.assertTupleAlmostEquals(point.toTuple(), (59/7, 55/7, 51/7),
-                                     decimal_places)
-
         # test passing Plane object
         point = Vector(10, 11, 12).projectToPlane(Plane(base, x_dir, normal))
         self.assertTupleAlmostEquals(point.toTuple(), (59/7, 55/7, 51/7),
                                      decimal_places)
-
-        # test wrong number of input arguments
-        with self.assertRaises(TypeError):
-            Vector(10,11.12).projectToPlane(1,1,1)
 
     def testMatrixCreationAndAccess(self):
         def matrix_vals(m):

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -151,6 +151,34 @@ class TestCadObjects(BaseTest):
         self.assertEqual(a, b)
         self.assertEqual(a, c)
 
+    def testVectorProject(self):
+        """
+        Test method to project vector to plane.
+        """
+        decimal_places = 9
+
+        normal = Vector(1, 2, 3)
+        base = Vector(5, 7, 9)
+        x_dir = Vector(1, 0, 0)
+
+        # test passing plane defined by base and normal
+        point = Vector(10, 11, 12).projectToPlane(base, normal)
+        self.assertTupleAlmostEquals(point.toTuple(), (59/7, 55/7, 51/7),
+                                     decimal_places)
+
+        point = Vector(10, 11, 12).projectToPlane(base, normal.normalized())
+        self.assertTupleAlmostEquals(point.toTuple(), (59/7, 55/7, 51/7),
+                                     decimal_places)
+
+        # test passing Plane object
+        point = Vector(10, 11, 12).projectToPlane(Plane(base, x_dir, normal))
+        self.assertTupleAlmostEquals(point.toTuple(), (59/7, 55/7, 51/7),
+                                     decimal_places)
+
+        # test wrong number of input arguments
+        with self.assertRaises(TypeError):
+            Vector(10,11.12).projectToPlane(1,1,1)
+
     def testMatrixCreationAndAccess(self):
         def matrix_vals(m):
             return [[m[r,c] for c in range(4)] for r in range(4)]

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1901,4 +1901,56 @@ class TestCadQuery(BaseTest):
         
         self.assertEqual(len(solid.Vertices()),4)
         self.assertEqual(len(solid.Faces()),4)
+
+    def testWorkplaneCenterOptions(self):
+        """
+        Test options for specifiying origin of workplane
+        """
+        decimal_places = 9
+
+        pts = [(90,0),(90,30),(30,30),(30,60),(0.0,60)]
+
+        r = Workplane("XY").polyline(pts).close().extrude(10.0)
+
+        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (0.0, 0.0, 10.0), decimal_places)
+
+        origin = r.faces(">Z").workplane(centerOption='CenterOfMass') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (37.5, 22.5, 10.0), decimal_places)
+
+        origin = r.faces(">Z").workplane(centerOption='CenterOfBoundBox') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (45.0, 30.0, 10.0), decimal_places)
+
+        r = Workplane("YZ").polyline(pts).close().extrude(10.0)
+
+        origin = r.faces(">X").workplane(centerOption='ProjectedOrigin') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (10.0, 0.0, 0.0), decimal_places)
+
+        origin = r.faces(">X").workplane(centerOption='CenterOfMass') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (10.0, 37.5, 22.5), decimal_places)
+
+        origin = r.faces(">X").workplane(centerOption='CenterOfBoundBox') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (10.0, 45.0, 30.0), decimal_places)
+
+        r = Workplane("XZ").polyline(pts).close().extrude(10.0)
+
+        origin = r.faces("<Y").workplane(centerOption='ProjectedOrigin') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (0.0, -10.0, 0.0), decimal_places)
+
+        origin = r.faces("<Y").workplane(centerOption='CenterOfMass') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (37.5, -10.0, 22.5), decimal_places)
+
+        origin = r.faces("<Y").workplane(centerOption='CenterOfBoundBox') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (45.0, -10.0, 30.0), decimal_places)
+
+
         

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1928,8 +1928,24 @@ class TestCadQuery(BaseTest):
                   .plane.origin.toTuple()
         self.assertTupleAlmostEquals(origin, (30.0, 10.0, 10.0), decimal_places)
 
+        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin',origin=Vector(30,10,20)) \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (30.0, 10.0, 10.0), decimal_places)
+
         with self.assertRaises(ValueError):
             origin = r.faces(">Z").workplane(centerOption='undefined')
+
+        # test case where plane origin is shifted with center call
+        r = r.faces(">Z").workplane(centerOption='ProjectedOrigin').center(30,0) \
+             .hole(90)
+
+        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (30.0, 0.0, 10.0), decimal_places)
+
+        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin', origin=(0,0,0)) \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (0.0, 0.0, 10.0), decimal_places)
 
         # make sure projection works in all directions
         r = Workplane("YZ").polyline(pts).close().extrude(10.0)

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1924,17 +1924,9 @@ class TestCadQuery(BaseTest):
                   .plane.origin.toTuple()
         self.assertTupleAlmostEquals(origin, (45.0, 30.0, 10.0), decimal_places)
 
-        # test case where plane origin is shifted with center call
-        r = r.faces(">Z").workplane(centerOption='ProjectedOrigin').center(30,0) \
-             .hole(90)
-
-        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin') \
+        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin',origin=(30,10,20)) \
                   .plane.origin.toTuple()
-        self.assertTupleAlmostEquals(origin, (30.0, 0.0, 10.0), decimal_places)
-
-        origin = r.faces(">Z").workplane(centerOption='ProjectedGlobalOrigin') \
-                  .plane.origin.toTuple()
-        self.assertTupleAlmostEquals(origin, (0.0, 0.0, 10.0), decimal_places)
+        self.assertTupleAlmostEquals(origin, (30.0, 10.0, 10.0), decimal_places)
 
         with self.assertRaises(ValueError):
             origin = r.faces(">Z").workplane(centerOption='undefined')

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1924,6 +1924,22 @@ class TestCadQuery(BaseTest):
                   .plane.origin.toTuple()
         self.assertTupleAlmostEquals(origin, (45.0, 30.0, 10.0), decimal_places)
 
+        # test case where plane origin is shifted with center call
+        r = r.faces(">Z").workplane(centerOption='ProjectedOrigin').center(30,0) \
+             .hole(90)
+
+        origin = r.faces(">Z").workplane(centerOption='ProjectedOrigin') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (30.0, 0.0, 10.0), decimal_places)
+
+        origin = r.faces(">Z").workplane(centerOption='ProjectedGlobalOrigin') \
+                  .plane.origin.toTuple()
+        self.assertTupleAlmostEquals(origin, (0.0, 0.0, 10.0), decimal_places)
+
+        with self.assertRaises(ValueError):
+            origin = r.faces(">Z").workplane(centerOption='undefined')
+
+        # make sure projection works in all directions
         r = Workplane("YZ").polyline(pts).close().extrude(10.0)
 
         origin = r.faces(">X").workplane(centerOption='ProjectedOrigin') \
@@ -1951,6 +1967,3 @@ class TestCadQuery(BaseTest):
         origin = r.faces("<Y").workplane(centerOption='CenterOfBoundBox') \
                   .plane.origin.toTuple()
         self.assertTupleAlmostEquals(origin, (45.0, -10.0, 30.0), decimal_places)
-
-
-        


### PR DESCRIPTION
Added 'ProjectedOrigin' option to centerOptions parameter of workplane method to place the center of the workplane at the position of the origin projected onto the plane. Also added test converge for all of the centerOption parameter choices.