### PR TITLE
Update cutThruAll to remove unused positive argument (fixes #134)

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2507,15 +2507,14 @@ class Workplane(CQ):
 
         return self.newObject([s])
 
-    def cutThruAll(self, positive=False, clean=True, taper=0):
+    def cutThruAll(self, clean=True, taper=0):
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
+        Cuts through all material in both normal directions of workplane.
 
         Similar to extrude, except that a solid in the parent chain is required to remove material
         from. cutThruAll always removes material from a part.
 
-        :param boolean positive: True to cut in the positive direction, false to cut in the
-            negative direction
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
         :raises: ValueError if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected


### PR DESCRIPTION
Removed positive argument for cutThruAll and clarified doc string to indicate that cut is in both directions normal to the workplane. Previous doc string indicated that cut was only on one side of plane. Fixes issue #134.