### PR TITLE
Increase HASH_CODE_MAX

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -114,7 +114,7 @@ from functools import reduce
 
 TOLERANCE = 1e-6
 DEG2RAD = 2 * pi / 360.
-HASH_CODE_MAX = 2147483647  # MAX_INT, required by OCC.Core.HashCode
+HASH_CODE_MAX = 2147483647  # max 32bit signed int, required by OCC.Core.HashCode
 
 shape_LUT = \
     {ta.TopAbs_VERTEX: 'Vertex',

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -114,7 +114,7 @@ from functools import reduce
 
 TOLERANCE = 1e-6
 DEG2RAD = 2 * pi / 360.
-HASH_CODE_MAX = int(1e+6)  # required by OCC.Core.HashCode
+HASH_CODE_MAX = 2147483647  # MAX_INT, required by OCC.Core.HashCode
 
 shape_LUT = \
     {ta.TopAbs_VERTEX: 'Vertex',


### PR DESCRIPTION
Increase HASH_CODE_MAX to 2147483647 (C MAX_INT) to prevent hash collisions that result in occasional faces missing from face selector calls. Addresses issue #139.