### PR TITLE
StringSyntaxSelector: make -X different from +X

### DIFF
--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -526,13 +526,11 @@ class _SimpleStringSyntaxSelector(Selector):
         self.operatorMinMax = {
             '>': True,
             '<': False,
-            '+': True,
-            '-': False
         }
 
         self.operator = {
             '+': DirectionSelector,
-            '-': DirectionSelector,
+            '-': lambda v: DirectionSelector(-v),
             '#': PerpendicularDirSelector,
             '|': ParallelDirSelector}
 

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -122,6 +122,8 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(1, c.faces("+Y").size())
         self.assertEqual(1, c.faces("-Y").size())
         self.assertEqual(0, c.faces("XY").size())
+        self.assertEqual(c.faces("+X").val().Center(), c.faces("X").val().Center())
+        self.assertNotEqual(c.faces("+X").val().Center(), c.faces("-X").val().Center())
 
     def testParallelPlaneFaceFilter(self):
         c = CQ(makeUnitCube())


### PR DESCRIPTION
I was a bit surprised that `c.faces('-X')` returned the same result as `c.faces('+X')`.