### PR TITLE
Remove the combine arg for bool ops and get rid of side-effects

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2378,13 +2378,11 @@ class Workplane(CQ):
 
         return self.newObject([s])
 
-    def union(self, toUnion=None, combine=True, clean=True):
+    def union(self, toUnion=None, clean=True):
         """
         Unions all of the items on the stack of toUnion with the current solid.
         If there is no current solid, the items in toUnion are unioned together.
-        if combine=True, the result and the original are updated to point to the new object
-        if combine=False, the result will be on the stack, but the original is unmodified
-
+        
         :param toUnion:
         :type toUnion: a solid object, or a CQ object having a solid,
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
@@ -2409,9 +2407,8 @@ class Workplane(CQ):
         # now combine with existing solid, if there is one
         # look for parents to cut from
         solidRef = self.findSolid(searchStack=True, searchParents=True)
-        if combine and solidRef is not None:
+        if solidRef is not None:
             r = solidRef.fuse(newS)
-            solidRef.wrapped = newS.wrapped
         else:
             r = newS
 
@@ -2420,13 +2417,10 @@ class Workplane(CQ):
 
         return self.newObject([r])
 
-    def cut(self, toCut, combine=True, clean=True):
+    def cut(self, toCut, clean=True):
         """
         Cuts the provided solid from the current solid, IE, perform a solid subtraction
-
-        if combine=True, the result and the original are updated to point to the new object
-        if combine=False, the result will be on the stack, but the original is unmodified
-
+        
         :param toCut: object to cut
         :type toCut: a solid object, or a CQ object having a solid,
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
@@ -2451,19 +2445,13 @@ class Workplane(CQ):
 
         if clean:
             newS = newS.clean()
-
-        if combine:
-            solidRef.wrapped = newS.wrapped
-
+        
         return self.newObject([newS])
 
-    def intersect(self, toIntersect, combine=True, clean=True):
+    def intersect(self, toIntersect, clean=True):
         """
         Intersects the provided solid from the current solid.
-
-        if combine=True, the result and the original are updated to point to the new object
-        if combine=False, the result will be on the stack, but the original is unmodified
-
+        
         :param toIntersect: object to intersect
         :type toIntersect: a solid object, or a CQ object having a solid,
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
@@ -2488,10 +2476,7 @@ class Workplane(CQ):
         newS = solidRef.intersect(solidToIntersect)
 
         if clean: newS = newS.clean()
-
-        if combine:
-            solidRef.wrapped = newS.wrapped
-
+        
         return self.newObject([newS])
 
     def cutBlind(self, distanceToCut, clean=True, taper=None):

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -147,10 +147,8 @@ class CQ(object):
             # Put the one we are keeping on the stack, and also update the
             # context solidto the one we kept.
             if keepTop:
-                solid.wrapped = top.wrapped
                 return self.newObject([top])
             else:
-                solid.wrapped = bottom.wrapped
                 return self.newObject([bottom])
 
     def combineSolids(self, otherCQToCombine=None):
@@ -2568,7 +2566,6 @@ class Workplane(CQ):
             parentSolid = self.findSolid(searchStack=False, searchParents=True)
             if parentSolid is not None:
                 r = parentSolid.fuse(r)
-                parentSolid.wrapped = r.wrapped
 
         return self.newObject([r])
 

--- a/examples/Ex003_Pillow_Block_With_Counterbored_Holes.py
+++ b/examples/Ex003_Pillow_Block_With_Counterbored_Holes.py
@@ -3,6 +3,7 @@ import cadquery as cq
 # These can be modified rather than hardcoding values for each dimension.
 length = 80.0                               # Length of the block
 width = 60.0                                # Width of the block
+height = 100.0                              # Height of the block
 thickness = 10.0                         # Thickness of the block
 center_hole_dia = 22.0             # Diameter of center hole in block
 cbore_hole_diameter = 2.4     # Bolt shank/threads clearance hole diameter

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1227,9 +1227,9 @@ class TestCadQuery(BaseTest):
         self.assertEqual(7, c.faces().size())
 
         # now cut it in half sideways
-        c.faces(">Y").workplane(-0.5).split(keepTop=True)
-        self.saveModel(c)
-        self.assertEqual(8, c.faces().size())
+        result = c.faces(">Y").workplane(-0.5).split(keepTop=True)
+        self.saveModel(result)
+        self.assertEqual(8, result.faces().size())
 
     def testSplitKeepingBoth(self):
         """

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -771,9 +771,9 @@ class TestCadQuery(BaseTest):
         currentS = s.rect(2.0, 2.0).extrude(0.5)
         toCut = s.rect(1.0, 1.0).extrude(0.5)
 
-        currentS.cut(toCut.val())
+        resS = currentS.cut(toCut.val())
 
-        self.assertEqual(10, currentS.faces().size())
+        self.assertEqual(10, resS.faces().size())
 
     def testIntersect(self):
         """
@@ -783,15 +783,15 @@ class TestCadQuery(BaseTest):
         currentS = s.rect(2.0, 2.0).extrude(0.5)
         toIntersect = s.rect(1.0, 1.0).extrude(1)
 
-        currentS.intersect(toIntersect.val())
+        resS = currentS.intersect(toIntersect.val())
 
-        self.assertEqual(6, currentS.faces().size())
-        self.assertAlmostEqual(currentS.val().Volume(),0.5)
+        self.assertEqual(6, resS.faces().size())
+        self.assertAlmostEqual(resS.val().Volume(),0.5)
 
-        currentS.intersect(toIntersect)
+        resS = currentS.intersect(toIntersect)
 
-        self.assertEqual(6, currentS.faces().size())
-        self.assertAlmostEqual(currentS.val().Volume(),0.5)
+        self.assertEqual(6, resS.faces().size())
+        self.assertAlmostEqual(resS.val().Volume(),0.5)
 
     def testBoundingBox(self):
         """
@@ -1414,10 +1414,9 @@ class TestCadQuery(BaseTest):
         currentS = s.rect(2.0, 2.0).extrude(0.5)
         toUnion = s.rect(1.0, 1.0).extrude(1.0)
 
-        currentS.union(toUnion.val(), combine=False)
-
-        # TODO: When unioning and combining is figured out, uncomment the following assert
-        # self.assertEqual(10,currentS.faces().size())
+        resS = currentS.union(toUnion)
+        
+        self.assertEqual(11,resS.faces().size())
 
     def testCombine(self):
         s = Workplane(Plane.XY())


### PR DESCRIPTION
This PR will resolve #133 

I removed the combine keyword argument from union, intersect and cut. This means that those functions never have side-effects, new cq stack object is always created.