### PR TITLE
Fixed bug where tolerance parameter of BoundingBox had no effect

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -827,7 +827,7 @@ class BoundBox(object):
             raise NotImplementedError
             # brepbndlib_AddOptimal(shape, bbox) #this is 'exact' but expensive - not yet wrapped by PythonOCC
         else:
-            mesh = BRepMesh_IncrementalMesh(shape, TOL, True)
+            mesh = BRepMesh_IncrementalMesh(shape, tol, True)
             mesh.Perform()
             # this is adds +margin but is faster
             brepbndlib_Add(shape, bbox, True)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -315,8 +315,8 @@ class Shape(object):
     def isValid(self):
         return BRepCheck_Analyzer(self.wrapped).IsValid()
 
-    def BoundingBox(self, tolerance=0.1):  # need to implement that in GEOM
-        return BoundBox._fromTopoDS(self.wrapped)
+    def BoundingBox(self, tolerance=None):  # need to implement that in GEOM
+        return BoundBox._fromTopoDS(self.wrapped, tol=tolerance)
 
     def mirror(self, mirrorPlane="XY", basePointVector=(0, 0, 0)):
 
@@ -353,7 +353,7 @@ class Shape(object):
         return Shape.centerOfMass(self)
 
     def CenterOfBoundBox(self, tolerance=0.1):
-        return self.BoundingBox(self.wrapped).center
+        return self.BoundingBox().center
 
     @staticmethod
     def CombinedCenter(objects):

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -836,6 +836,15 @@ class TestCadQuery(BaseTest):
         self.assertAlmostEqual(7.5, bb_center.y, 3)
         self.assertAlmostEqual(50.0, bb_center.z, 3)
 
+        # The following will raise with the default tolerance of TOL 1e-2
+        bb = result.val().BoundingBox(tolerance=1e-3)
+        self.assertAlmostEqual(0.0, bb.xmin, 2)
+        self.assertAlmostEqual(28, bb.xmax, 2)
+        self.assertAlmostEqual(0.0, bb.ymin, 2)
+        self.assertAlmostEqual(15.0, bb.ymax, 2)
+        self.assertAlmostEqual(0.0, bb.zmin, 2)
+        self.assertAlmostEqual(100.0, bb.zmax, 2)
+
     def testCutThroughAll(self):
         """
             Tests a model that uses more than one workplane


### PR DESCRIPTION
The tolerance parameter of the BoundingBox method of shape had no effect. Fixed this by passing the tolerance to the _fromTopoDS call. Changed the tolerance default value from 0.1 to None so that the global TOL is used by default.  This allows the user to set the global TOL value as outlined in #74.  The CenterofBoundbox method incorrectly passed a shape to the BoundingBox method, which is the position for the tolerance paramter. This has been fixed.  The _fromTopoDS method hard coded the global variable TOL in it's call to BRepMesh_IncrementalMesh. This has been updated to use the user supplied tolerance if one has been provided. Added test coverage for the tolerance parameter of the BoundingBox method.