### PR TITLE
loft with a single wire crashes #161

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1214,6 +1214,8 @@ class Solid(Shape, Mixin3D):
             wants to make an infinitely thin shell for a real FreeCADPart.
         """
         # the True flag requests building a solid instead of a shell.
+        if len(listOfWire) < 2:
+            raise ValueError("More than one wire is required")
         loft_builder = BRepOffsetAPI_ThruSections(True, ruled)
 
         for w in listOfWire:

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -261,11 +261,10 @@ class TestCadQuery(BaseTest):
 
     def testLoftWithOneWireRaisesValueError(self):
         s = Workplane("XY").circle(5)
-        try:
+        with self.assertRaises(ValueError) as cm:
             s.loft()
-            self.assertFail()
-        except ValueError as e:
-            self.assertEqual(str(e), "More than one wire is required")
+        err = cm.exception
+        self.assertEqual(str(err), "More than one wire is required")
 
 
     def testLoftCombine(self):

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -259,6 +259,15 @@ class TestCadQuery(BaseTest):
         # the resulting loft had a split on the side, not sure why really, i expected only 3 faces
         self.assertEqual(7, s.faces().size())
 
+    def testLoftWithOneWireRaisesValueError(self):
+        s = Workplane("XY").circle(5)
+        try:
+            s.loft()
+            self.assertFail()
+        except ValueError as e:
+            self.assertEqual(str(e), "More than one wire is required")
+
+
     def testLoftCombine(self):
         """
             test combining a lof with another feature


### PR DESCRIPTION
`Solid.Loft` crashes with segmentation fault, when called with one wire. Now the function checks, if there are at least 2 wires. Otherwise a `ValueError` is raised.
see issue #161 