### PR TITLE
Fixed Wedge Primtive

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2862,6 +2862,64 @@ class Workplane(CQ):
         else:
             return self.union(spheres, clean=clean)
 
+    def wedge(self, dx, dy, dz, xmin, zmin, xmax, zmax, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1),
+              centered=(True, True, True), combine=True, clean=True):
+        """
+        :param dx: Distance along the X axis
+        :param dy: Distance along the Y axis
+        :param dz: Distance along the Z axis
+        :param xmin: The minimum X location
+        :param zmin:The minimum Z location
+        :param xmax:The maximum X location
+        :param zmax: The maximum Z location
+        :param pnt: A vector for the origin of the direction for the wedge
+        :param dir: The direction vector for the major axis of the wedge
+        :param combine: Whether the results should be combined with other solids on the stack
+            (and each other)
+        :param clean: true to attempt to have the kernel clean up the geometry, false otherwise
+        :return: A wedge object for each point on the stack
+
+        One wedge is created for each item on the current stack. If no items are on the stack, one
+        wedge using the current workplane center is created.
+
+        If combine is true, the result will be a single object on the stack:
+            If a solid was found in the chain, the result is that solid with all wedges produced
+            fused onto it otherwise, the result is the combination of all the produced wedges
+
+        If combine is false, the result will be a list of the wedges produced
+        """
+
+        # Convert the point tuple to a vector, if needed
+        if isinstance(pnt, tuple):
+            pnt = Vector(pnt)
+
+        # Convert the direction tuple to a vector, if needed
+        if isinstance(dir, tuple):
+            dir = Vector(dir)
+
+        def _makewedge(pnt):
+            (xp, yp, zp) = pnt.toTuple()
+
+            if not centered[0]:
+                xp += dx / 2.
+
+            if not centered[1]:
+                yp += dy / 2.
+
+            if not centered[2]:
+                zp += dx / 2.
+
+            return Solid.makeWedge(dx, dy, dz, xmin, zmin, xmax, zmax, Vector(xp, yp, zp), dir)
+
+        # We want a wedge for each point on the workplane
+        wedges = self.eachpoint(_makewedge)
+
+        # If we don't need to combine everything, just return the created wedges
+        if not combine:
+            return wedges
+        else:
+            return self.union(wedges, clean=clean)
+
     def clean(self):
         """
         Cleans the current solid by removing unwanted edges from the

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2872,8 +2872,8 @@ class Workplane(CQ):
         :param zmin:The minimum Z location
         :param xmax:The maximum X location
         :param zmax: The maximum Z location
-        :param pnt: A vector for the origin of the direction for the wedge
-        :param dir: The direction vector for the major axis of the wedge
+        :param pnt: A vector (or tuple) for the origin of the direction for the wedge
+        :param dir: The direction vector (or tuple) for the major axis of the wedge
         :param combine: Whether the results should be combined with other solids on the stack
             (and each other)
         :param clean: true to attempt to have the kernel clean up the geometry, false otherwise

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1226,23 +1226,22 @@ class Solid(Shape, Mixin3D):
         return cls(loft_builder.Shape())
 
     @classmethod
-    def makeWedge(cls, xmin, ymin, zmin, z2min, x2min, xmax, ymax, zmax, z2max, x2max, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1)):
+    def makeWedge(cls, dx, dy, dz, xmin, zmin, xmax, zmax, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1)):
         """
         Make a wedge located in pnt
         By default pnt=Vector(0,0,0) and dir=Vector(0,0,1)
         """
-        return cls(BRepPrimAPI_MakeWedge(gp_Ax2(pnt.toPnt(),
-                                                dir.toDir()),
-                                         xmin,
-                                         ymin,
-                                         zmin,
-                                         z2min,
-                                         x2min,
-                                         xmax,
-                                         ymax,
-                                         zmax,
-                                         z2max,
-                                         x2max).Solid())
+
+        return cls(BRepPrimAPI_MakeWedge(
+                    gp_Ax2(pnt.toPnt(),
+                    dir.toDir()),
+                    dx,
+                    dy,
+                    dz,
+                    xmin,
+                    zmin,
+                    xmax,
+                    zmax).Solid())
 
     @classmethod
     def makeSphere(cls, radius, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1), angleDegrees1=0, angleDegrees2=90, angleDegrees3=360):

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1365,7 +1365,7 @@ class TestCadQuery(BaseTest):
 
     def testSphereDefaults(self):
         s = Workplane("XY").sphere(10)
-        # self.saveModel(s) # Until FreeCAD fixes their sphere operation
+        self.saveModel(s) # Until FreeCAD fixes their sphere operation
         self.assertEqual(1, s.solids().size())
         self.assertEqual(1, s.faces().size())
 
@@ -1389,6 +1389,36 @@ class TestCadQuery(BaseTest):
         # self.saveModel(s) # Until FreeCAD fixes their sphere operation
         self.assertEqual(1, s.solids().size())
         self.assertEqual(4, s.faces().size())
+
+    def testWedgeDefaults(self):
+        s = Workplane("XY").wedge(10, 10, 10, 5, 5, 5, 5)
+        self.saveModel(s)
+        self.assertEqual(1, s.solids().size())
+        self.assertEqual(5, s.faces().size())
+        self.assertEqual(5, s.vertices().size())
+
+    def testWedgeCentering(self):
+        s = Workplane("XY").wedge(10, 10, 10, 5, 5, 5, 5, centered=(False, False, False))
+        # self.saveModel(s)
+        self.assertEqual(1, s.solids().size())
+        self.assertEqual(5, s.faces().size())
+        self.assertEqual(5, s.vertices().size())
+
+    def testWedgePointList(self):
+        s = Workplane("XY").rect(
+            4.0, 4.0, forConstruction=True).vertices().wedge(10, 10, 10, 5, 5, 5, 5, combine=False)
+        #self.saveModel(s)
+        self.assertEqual(4, s.solids().size())
+        self.assertEqual(20, s.faces().size())
+        self.assertEqual(20, s.vertices().size())
+
+    def testWedgeCombined(self):
+        s = Workplane("XY").rect(
+            4.0, 4.0, forConstruction=True).vertices().wedge(10, 10, 10, 5, 5, 5, 5, combine=True)
+        # self.saveModel(s)
+        self.assertEqual(1, s.solids().size())
+        self.assertEqual(12, s.faces().size())
+        self.assertEqual(16, s.vertices().size())
 
     def testQuickStartXY(self):
         s = Workplane(Plane.XY()).box(2, 4, 0.5).faces(">Z").workplane().rect(1.5, 3.5, forConstruction=True)\


### PR DESCRIPTION
Fixed the way the OCC wedge primitive function is called per #160 and made CQ's wedge primitive act like the others (such as sphere). It's now possible to push points onto the stack and then have a wedge put at each point.