### PR TITLE
Tagging objects in the chain

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -279,7 +279,7 @@ class CQ(object):
         """
         return self.objects[0]
 
-    def getTagged(self, name):
+    def _getTagged(self, name):
         """
         Search the parent chain for a an object with tag == name.
 
@@ -293,7 +293,7 @@ class CQ(object):
         if self.parent is None:
             raise ValueError("No CQ object named {} in chain".format(name))
         else:
-            return self.parent.getTagged(name)
+            return self.parent._getTagged(name)
 
     def toOCC(self):
         """
@@ -480,7 +480,7 @@ class CQ(object):
         :type name: string
         :returns: a CQ object with name's workplane
         """
-        tagged = self.getTagged(name)
+        tagged = self._getTagged(name)
         out = self.copyWorkplane(tagged)
         return out
 
@@ -590,7 +590,7 @@ class CQ(object):
             solids,shells, and other similar selector methods.  It is a useful extension point for
             plugin developers to make other selector methods.
         """
-        cq_obj = self.getTagged(tag) if tag else self
+        cq_obj = self._getTagged(tag) if tag else self
         # A single list of all faces from all objects on the stack
         toReturn = cq_obj._collectProperty(objType)
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -576,20 +576,25 @@ class CQ(object):
 
         return self._findType(Face, searchStack, searchParents)
 
-    def _selectObjects(self, objType, selector=None):
+    def _selectObjects(self, objType, selector=None, tag=None):
         """
             Filters objects of the selected type with the specified selector,and returns results
 
             :param objType: the type of object we are searching for
             :type objType: string: (Vertex|Edge|Wire|Solid|Shell|Compound|CompSolid)
+            :param tag: if set, search the tagged CQ object instead of self
+            :type tag: string
             :return: a CQ object with the selected objects on the stack.
 
             **Implementation Note**: This is the base implementation of the vertices,edges,faces,
             solids,shells, and other similar selector methods.  It is a useful extension point for
             plugin developers to make other selector methods.
         """
+        cq_obj = self
+        if tag:
+            cq_obj = self.getTagged(tag)
         # A single list of all faces from all objects on the stack
-        toReturn = self._collectProperty(objType)
+        toReturn = cq_obj._collectProperty(objType)
 
         if selector is not None:
             if isinstance(selector, str) or isinstance(selector, str):
@@ -600,7 +605,7 @@ class CQ(object):
 
         return self.newObject(toReturn)
 
-    def vertices(self, selector=None):
+    def vertices(self, selector=None, tag=None):
         """
         Select the vertices of objects on the stack, optionally filtering the selection. If there
         are multiple objects on the stack, the vertices of all objects are collected and a list of
@@ -608,6 +613,8 @@ class CQ(object):
 
         :param selector:
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains  the *distinct* vertices of *all* objects on the
            current stack, after being filtered by the selector, if provided
 
@@ -629,9 +636,9 @@ class CQ(object):
         :py:class:`StringSyntaxSelector`
 
         """
-        return self._selectObjects("Vertices", selector)
+        return self._selectObjects("Vertices", selector, tag)
 
-    def faces(self, selector=None):
+    def faces(self, selector=None, tag=None):
         """
         Select the faces of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the faces of all objects are collected and a list of all the
@@ -639,6 +646,8 @@ class CQ(object):
 
         :param selector: A selector
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains all of the *distinct* faces of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -661,9 +670,9 @@ class CQ(object):
 
         See more about selectors HERE
         """
-        return self._selectObjects("Faces", selector)
+        return self._selectObjects("Faces", selector, tag)
 
-    def edges(self, selector=None):
+    def edges(self, selector=None, tag=None):
         """
         Select the edges of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the edges of all objects are collected and a list of all the
@@ -671,6 +680,8 @@ class CQ(object):
 
         :param selector: A selector
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains all of the *distinct* edges of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -692,9 +703,9 @@ class CQ(object):
 
         See more about selectors HERE
         """
-        return self._selectObjects("Edges", selector)
+        return self._selectObjects("Edges", selector, tag)
 
-    def wires(self, selector=None):
+    def wires(self, selector=None, tag=None):
         """
         Select the wires of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the wires of all objects are collected and a list of all the
@@ -702,6 +713,8 @@ class CQ(object):
 
         :param selector: A selector
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains all of the *distinct* wires of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -715,9 +728,9 @@ class CQ(object):
 
         See more about selectors HERE
         """
-        return self._selectObjects("Wires", selector)
+        return self._selectObjects("Wires", selector, tag)
 
-    def solids(self, selector=None):
+    def solids(self, selector=None, tag=None):
         """
         Select the solids of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the solids of all objects are collected and a list of all the
@@ -725,6 +738,8 @@ class CQ(object):
 
         :param selector: A selector
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -741,9 +756,9 @@ class CQ(object):
 
         See more about selectors HERE
         """
-        return self._selectObjects("Solids", selector)
+        return self._selectObjects("Solids", selector, tag)
 
-    def shells(self, selector=None):
+    def shells(self, selector=None, tag=None):
         """
         Select the shells of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the shells of all objects are collected and a list of all the
@@ -751,6 +766,8 @@ class CQ(object):
 
         :param selector: A selector
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -761,9 +778,9 @@ class CQ(object):
 
         See more about selectors HERE
         """
-        return self._selectObjects("Shells", selector)
+        return self._selectObjects("Shells", selector, tag)
 
-    def compounds(self, selector=None):
+    def compounds(self, selector=None, tag=None):
         """
         Select compounds on the stack, optionally filtering the selection. If there are multiple
         objects on the stack, they are collected and a list of all the distinct compounds
@@ -771,6 +788,8 @@ class CQ(object):
 
         :param selector: A selector
         :type selector:  None, a Selector object, or a string selector expression.
+        :param tag: if set, search the tagged CQ object instead of self
+        :type tag: string
         :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -779,7 +798,7 @@ class CQ(object):
 
         See more about selectors HERE
         """
-        return self._selectObjects("Compounds", selector)
+        return self._selectObjects("Compounds", selector, tag)
 
     def toSvg(self, opts=None):
         """

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -590,9 +590,7 @@ class CQ(object):
             solids,shells, and other similar selector methods.  It is a useful extension point for
             plugin developers to make other selector methods.
         """
-        cq_obj = self
-        if tag:
-            cq_obj = self.getTagged(tag)
+        cq_obj = self.getTagged(tag) if tag else self
         # A single list of all faces from all objects on the stack
         toReturn = cq_obj._collectProperty(objType)
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -472,7 +472,7 @@ class CQ(object):
         out.ctx = self.ctx
         return out
 
-    def copyWorkplaneFromTagged(self, name):
+    def workplaneFromTagged(self, name):
         """
         Copies the workplane from a tagged parent.
 

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -633,9 +633,9 @@ Here we fillet all of the edges of a simple plate.
 Tagging objects
 ----------------
 
-The :py:meth:`CQ.tag` method can be used to tag a particular object in the chain with a string. At a later point in the chain, the method :py:meth:`CQ.getTagged` can be used to return the previously tagged object (note that CQ objects share the modelling context throughout a chain, so going back to a previously tagged object will not change what is in the modelling context eg. unextruded edges).
+The :py:meth:`CQ.tag` method can be used to tag a particular object in the chain with a string, so that it can be refered to later in the chain. 
 
-The method :py:meth:`CQ.getTagged` is awkward to use in chained calls (see :ref:`chaining`), the main utility of tags is when they are combined with other functions. The :py:meth:`CQ.workplaneFromTagged` method applies :py:meth:`CQ.copyWorkplane` to a tagged object. For example, when extruding two different solids from a surface, after the first solid is extruded it can become difficult to reselect the original surface with CadQuery's other selectors.
+The :py:meth:`CQ.workplaneFromTagged` method applies :py:meth:`CQ.copyWorkplane` to a tagged object. For example, when extruding two different solids from a surface, after the first solid is extruded it can become difficult to reselect the original surface with CadQuery's other selectors.
 
 .. cq_plot::
 
@@ -664,7 +664,7 @@ Tags can also be used with most selectors, including :py:meth:`CQ.vertices`, :py
               .faces("<X", tag="prism").workplane().circle(1).cutThruAll()
               .faces(">X", tag="prism").faces(">Y").workplane().circle(1).cutThruAll())
     show_object(result)
-            
+
 .. topic:: Api References
 
     .. hlist::

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -460,6 +460,32 @@ This example uses an offset workplane to make a compound object, which is perfec
         * :py:meth:`Workplane.box`
         * :py:meth:`Workplane`
 
+Copying Workplanes
+--------------------------
+
+An existing CQ object can copy a workplane from another CQ object.
+
+.. cq_plot::
+
+    result = (cq.Workplane("front").circle(1).extrude(10) # make a cylinder
+              # We want to make a second cylinder perpendicular to the first, 
+              # but we have no face to base the workplane off
+              .copyWorkplane(
+                  # create a temporary object with the required workplane
+                  cq.Workplane("right", origin=(-5, 0, 0))
+              ).circle(1).extrude(10))
+    show_object(result)
+
+.. topic:: API References
+
+    .. hlist:
+        :columns: 2
+
+        * :py:meth:`CQ.copyWorkplane` **!**
+        * :py:meth:`Workplane.circle`
+        * :py:meth:`Workplane.extrude`
+        * :py:meth:`Workplane`
+
 Rotated Workplanes
 --------------------------
 
@@ -602,6 +628,55 @@ Here we fillet all of the edges of a simple plate.
         * :py:meth:`Workplane.fillet` **!**
         * :py:meth:`Workplane.box`
         * :py:meth:`Workplane.edges`
+        * :py:meth:`Workplane`
+
+Tagging objects
+----------------
+
+The :py:meth:`CQ.tag` method can be used to tag a particular object in the chain with a string. At a later point in the chain, the method :py:meth:`CQ.getTagged` can be used to return the previously tagged object (note that CQ objects share the modelling context throughout a chain, so going back to a previously tagged object will not change what is in the modelling context eg. unextruded edges).
+
+The method :py:meth:`CQ.getTagged` is awkward to use in chained calls (see :ref:`chaining`), the main utility of tags is when they are combined with other functions. The :py:meth:`CQ.workplaneFromTagged` method applies :py:meth:`CQ.copyWorkplane` to a tagged object. For example, when extruding two different solids from a surface, after the first solid is extruded it can become difficult to reselect the original surface with CadQuery's other selectors.
+
+.. cq_plot::
+
+    result = (cq.Workplane("XY")
+              # create and tag the base workplane
+              .box(10, 10, 10).faces(">Z").workplane().tag("baseplane")
+              # extrude a cylinder
+              .center(-3, 0).circle(1).extrude(3)
+              # to reselect the base workplane, simply
+              .workplaneFromTagged("baseplane")
+              # extrude a second cylinder
+              .center(3, 0).circle(1).extrude(2))
+    show_object(result)
+
+
+Tags can also be used with most selectors, including :py:meth:`CQ.vertices`, :py:meth:`CQ.faces`, :py:meth:`CQ.edges`, :py:meth:`CQ.wires`, :py:meth:`CQ.shells`, :py:meth:`CQ.solids` and :py:meth:`CQ.compounds`.
+
+.. cq_plot::
+
+    result = (cq.Workplane("XY")
+              # create a triangular prism and tag it
+              .polygon(3, 5).extrude(4).tag("prism")
+              # create a sphere that obscures the prism
+              .sphere(10)
+              # create features based on the prism's faces
+              .faces("<X", tag="prism").workplane().circle(1).cutThruAll()
+              .faces(">X", tag="prism").faces(">Y").workplane().circle(1).cutThruAll())
+    show_object(result)
+            
+.. topic:: Api References
+
+    .. hlist::
+        :columns: 2
+
+        * :py:meth:`CQ.tag` **!**
+        * :py:meth:`CQ.getTagged` **!**
+        * :py:meth:`CQ.workplaneFromTagged` **!**
+        * :py:meth:`Workplane.extrude`
+        * :py:meth:`Workplane.cutThruAll`
+        * :py:meth:`Workplane.circle`
+        * :py:meth:`Workplane.faces`
         * :py:meth:`Workplane`
 
 A Parametric Bearing Pillow Block

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -111,6 +111,8 @@ backwards in the stack to get the face as well::
 You can browse stack access methods here: :ref:`stackMethods`.
 
 
+.. _chaining:
+
 Chaining
 ---------------------------
 

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -119,6 +119,11 @@ Chaining
 All CadQuery methods return another CadQuery object, so that you can chain the methods together fluently. Use
 the core CQ methods to get at the objects that were created.
 
+Each time a new CadQuery object is produced during these chained calls, it has a ``parent`` attribute that points
+to the CadQuery object that created it. Several CadQuery methods search this parent chain, for example when searching
+for the context solid. You can also give a CadQuery object a tag, and further down your chain of CadQuery calls you
+can refer back to this particular object using it's tag.
+
 
 The Context Solid
 ---------------------------

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2751,32 +2751,8 @@ class TestCadQuery(BaseTest):
                   .box(1, 1, 1, combine=False).tag("2 solids")
                   .union(Workplane("XY").box(6, 1, 1)))
         self.assertEqual(len(result.objects), 1)
-        result = result.getTagged("2 solids")
+        result = result._getTagged("2 solids")
         self.assertEqual(len(result.objects), 2)
-
-        # tags can be used to create geometry for construction
-        part = ( # create a base solid
-            Workplane("XY").box(1, 1, 1).tag("base")
-            # do some stuff "for construction"
-            .faces(">Y").workplane().box(1, 3, 1)
-            .faces(">Z").workplane().box(2, 1, 1)
-            .faces(">X").workplane()
-            # create an edge, which CadQuery adds to the modelling context
-            .circle(0.5)
-            # go back to base object, but modelling context is preserved
-            .getTagged("base")
-            .faces(">Z").workplane().circle(0.5)
-            # loft between the top of the base object and the wire at the end of the "for construction" code
-            .loft()
-        )
-        # assert face is made at the end of the construction geometry
-        self.assertTupleAlmostEquals(part.faces(">X").val().Center().toTuple(),
-                                     (1.0, 0.5, 1.5),
-                                     9)
-        # assert face points in the x-direction, like the construction geometry
-        self.assertTupleAlmostEquals(part.faces(">X").val().normalAt().toTuple(),
-                                     (1.0, 0, 0),
-                                     9)
 
     def testCopyWorkplane(self):
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2786,7 +2786,7 @@ class TestCadQuery(BaseTest):
                                      obj1.val().Center().toTuple(),
                                      9)
 
-    def testCopyWorkplaneFromTagged(self):
+    def testWorkplaneFromTagged(self):
 
         # create a flat, wide base. Extrude one object 4 units high, another
         # object ontop of it 6 units high. Go back to base plane. Extrude an
@@ -2794,7 +2794,7 @@ class TestCadQuery(BaseTest):
         result = (Workplane("XY").box(10, 10, 1, centered=(True, True, False))
                   .faces(">Z").workplane().tag("base").center(3, 0).rect(2, 2)
                   .extrude(4).faces(">Z").workplane().circle(1).extrude(6)
-                  .copyWorkplaneFromTagged("base").center(-3, 0).circle(1)
+                  .workplaneFromTagged("base").center(-3, 0).circle(1)
                   .extrude(11))
         self.assertTupleAlmostEquals(result.faces(">Z").val().Center().toTuple(),
                                      (-3, 0, 12),

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2746,10 +2746,13 @@ class TestCadQuery(BaseTest):
     def testTag(self):
 
         # test tagging
-        Workplane("XY").pushPoints([(-2, 0), (2, 0)]).box(1, 1, 1, combine=False)
-        result = (Workplane("XY").pushPoints([(-2, 0), (2, 0)])
-                  .box(1, 1, 1, combine=False).tag("2 solids")
-                  .union(Workplane("XY").box(6, 1, 1)))
+        result = (
+            Workplane("XY")
+            .pushPoints([(-2, 0), (2, 0)])
+            .box(1, 1, 1, combine=False)
+            .tag("2 solids")
+            .union(Workplane("XY") .box(6, 1, 1))
+        )
         self.assertEqual(len(result.objects), 1)
         result = result._getTagged("2 solids")
         self.assertEqual(len(result.objects), 2)
@@ -2758,23 +2761,34 @@ class TestCadQuery(BaseTest):
 
         obj0 = Workplane("XY").box(1, 1, 10).faces(">Z").workplane()
         obj1 = Workplane("XY").copyWorkplane(obj0).box(1, 1, 1)
-        self.assertTupleAlmostEquals((0, 0, 5),
-                                     obj1.val().Center().toTuple(),
-                                     9)
+        self.assertTupleAlmostEquals((0, 0, 5), obj1.val().Center().toTuple(), 9)
 
     def testWorkplaneFromTagged(self):
 
         # create a flat, wide base. Extrude one object 4 units high, another
         # object ontop of it 6 units high. Go back to base plane. Extrude an
         # object 11 units high. Assert that top face is 11 units high.
-        result = (Workplane("XY").box(10, 10, 1, centered=(True, True, False))
-                  .faces(">Z").workplane().tag("base").center(3, 0).rect(2, 2)
-                  .extrude(4).faces(">Z").workplane().circle(1).extrude(6)
-                  .workplaneFromTagged("base").center(-3, 0).circle(1)
-                  .extrude(11))
-        self.assertTupleAlmostEquals(result.faces(">Z").val().Center().toTuple(),
-                                     (-3, 0, 12),
-                                     9)
+        result = (
+            Workplane("XY")
+            .box(10, 10, 1, centered=(True, True, False))
+            .faces(">Z")
+            .workplane()
+            .tag("base")
+            .center(3, 0)
+            .rect(2, 2)
+            .extrude(4)
+            .faces(">Z")
+            .workplane()
+            .circle(1)
+            .extrude(6)
+            .workplaneFromTagged("base")
+            .center(-3, 0)
+            .circle(1)
+            .extrude(11)
+        )
+        self.assertTupleAlmostEquals(
+            result.faces(">Z").val().Center().toTuple(), (-3, 0, 12), 9
+        )
 
     def testTagSelectors(self):
 
@@ -2791,16 +2805,26 @@ class TestCadQuery(BaseTest):
         self.assertEqual(6, result0.wires(tag="box").size())
 
         # create two solids, tag them, join to one solid
-        result1 = (Workplane("XY").pushPoints([(1, 0), (-1, 0)]).box(1, 1, 1)
-                   .tag("boxes").sphere(1))
+        result1 = (
+            Workplane("XY")
+            .pushPoints([(1, 0), (-1, 0)])
+            .box(1, 1, 1)
+            .tag("boxes")
+            .sphere(1)
+        )
         self.assertEqual(1, result1.solids().size())
         self.assertEqual(2, result1.solids(tag="boxes").size())
         self.assertEqual(1, result1.shells().size())
         self.assertEqual(2, result1.shells(tag="boxes").size())
 
         # create 4 individual objects, tag it, then combine to one compound
-        result2 = (Workplane("XY").rect(4, 4).vertices()
-                   .box(1, 1, 1, combine=False).tag("4 objs"))
+        result2 = (
+            Workplane("XY")
+            .rect(4, 4)
+            .vertices()
+            .box(1, 1, 1, combine=False)
+            .tag("4 objs")
+        )
         result2 = result2.newObject([Compound.makeCompound(result2.objects)])
         self.assertEqual(1, result2.compounds().size())
         self.assertEqual(0, result2.compounds(tag="4 objs").size())

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2751,7 +2751,7 @@ class TestCadQuery(BaseTest):
             .pushPoints([(-2, 0), (2, 0)])
             .box(1, 1, 1, combine=False)
             .tag("2 solids")
-            .union(Workplane("XY") .box(6, 1, 1))
+            .union(Workplane("XY").box(6, 1, 1))
         )
         self.assertEqual(len(result.objects), 1)
         result = result._getTagged("2 solids")

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2799,3 +2799,32 @@ class TestCadQuery(BaseTest):
         self.assertTupleAlmostEquals(result.faces(">Z").val().Center().toTuple(),
                                      (-3, 0, 12),
                                      9)
+
+    def testTagSelectors(self):
+
+        result0 = Workplane("XY").box(1, 1, 1).tag("box").sphere(1)
+        # result is currently a sphere
+        self.assertEqual(1, result0.faces().size())
+        # a box has 8 vertices
+        self.assertEqual(8, result0.vertices(tag="box").size())
+        # 6 faces
+        self.assertEqual(6, result0.faces(tag="box").size())
+        # 12 edges
+        self.assertEqual(12, result0.edges(tag="box").size())
+        # 6 wires
+        self.assertEqual(6, result0.wires(tag="box").size())
+
+        # create two solids, tag them, join to one solid
+        result1 = (Workplane("XY").pushPoints([(1, 0), (-1, 0)]).box(1, 1, 1)
+                   .tag("boxes").sphere(1))
+        self.assertEqual(1, result1.solids().size())
+        self.assertEqual(2, result1.solids(tag="boxes").size())
+        self.assertEqual(1, result1.shells().size())
+        self.assertEqual(2, result1.shells(tag="boxes").size())
+
+        # create 4 individual objects, tag it, then combine to one compound
+        result2 = (Workplane("XY").rect(4, 4).vertices()
+                   .box(1, 1, 1, combine=False).tag("4 objs"))
+        result2 = result2.newObject([Compound.makeCompound(result2.objects)])
+        self.assertEqual(1, result2.compounds().size())
+        self.assertEqual(0, result2.compounds(tag="4 objs").size())

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -28,7 +28,7 @@ class TestCQSelectors(BaseTest):
         self.assertTupleAlmostEquals((0.0, 0.0, 0.0), s.plane.origin.toTuple(), 3)
 
         # move origin and confirm center moves
-        s.center(-2.0, -2.0)
+        s = s.center(-2.0, -2.0)
 
         # current point should be 0,0, but
 


### PR DESCRIPTION
In implementing this feature I've had to touch some pretty fundamental CQ code, so I'm going to write a detailed description of what I've been up to here, because I'd really like others to follow along, provide good feedback, and hopefully get this merged without treading on other's toes. 

### Tags

The main feature I'm implementing is the abilty to tag an object (method `CQ.tag`) within the chain, and reload that object at a later point (method `CQ.getTagged`). 

I've also created a method to create a workplane in the current CQ object by copying the workplane from another CQ object (method `CQ.copyWorkplane`). This is combined with tags in method `CQ.copyWorkplaneFromTagged`, allowing things like:
```python
result = (
    # create a base solid for others to be built upon
    cq.Workplane("XY")
    .box(10, 10, 1, centered=(True, True, False))
    .faces(">Z").workplane()
    .tag("base")
    # build ontop of base solid
    .center(3, 0).rect(2, 2).extrude(4)
    .faces(">Z").workplane().circle(1).extrude(6)
    # go back to the base workplane
    .copyWorkplaneFromTagged("base")
    # build a different solid ontop of the base solid
    .center(-3, 0).circle(1).extrude(11)
)
```
![tagExample](https://user-images.githubusercontent.com/50230945/71300554-c94d7100-23e5-11ea-8408-0a5589025ba5.png)

A good example of a use case is modelling a PCB. 

### Construction geometry using tags

CadQuery shares the modelling context between all objects in the chain. This has an interesting interaction with tags, in that you can easily:
1. set a tag,
2. create some solids and workplanes, or any other CAD operations,
3. create some edges (which are added to the modelling context's pending edges),
4. go back to the tagged object with `getTagged`,
5. the solids created in step 2 are gone, but your pending edges are still there and can be used in eg. a loft operation

This could be very useful when step 2 involves creating complicated geometry, and you can't be bothered doing the maths to figure out where the edges need to go in step 3. 

I wrote a test for this use case if you want to read some example code.

### Other changes

This process of returning to tagged objects is a bit of an edge case for the existing CadQuery code, so I had to make a couple of changes to handle some errors that popped up. 

*  `Workplane.newObject` previously referenced the parent's plane. This made `copyWorkplaneFromTagged` produce some very confusing results, where the plane of a tagged object could be modified by objects further down the chain. I changed `newObject` to copy the plane instead. I acknowledge this increases the memory requirements, but I think it's worth it and also `newObject` is now more in line with how the user would expect it to function.
*  `Workplane.center` previously changed the current object's plane before creating a new object with the current object's plane. I changed it such that the current object's plane is not modified. It's not as neat, but I think it's how users expect `center` to function.
*  `testWorkplaneCenter` in test_selectors previously relied upon the mutable plane. The style of that test didn't seem to follow CadQuery's chained calls, so I changed it. I don't understand why the original code was written in that style, so I'm bringing attention to it here in case I messed with something I shouldn't. I see that test was some of the earliest CQ2.0 code written, and perhaps that was why it didn't use chained calls?

### Todo

- [x] Add some examples for the docs
- [x] Further testing (I mean in regular use with CQ-editor, not just pytest)
- [x] See if I can think up of some other use cases for this. It's a pretty flexible method, the use cases are broad and I'm sure there are lots I'm missing. More use cases would let me write more tests and examples as well, which I would like to do.
- [x] Include feedback?

---

PS. I'm loving CadQuery. It's a light layer over OCC, so it's just so *flexible*. Extending it like this has been really enjoyable. None of that "smashing my head against the keyboard" as I struggle against heavy, opaque code I can't understand.