### PR TITLE
Ellipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 .idea/*
 cadquery.egg-info
 target/*
+.vscode

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1585,13 +1585,12 @@ class Workplane(CQ):
 
 
         # Start building the ellipse with the current point as center
-        # to support strating as the result of center(x,y) or moveTo(x,y) do not use local coordinates
         center = self._findFromPoint(useLocalCoords=False)
-        e = Edge.makeEllipse(x_radius, y_radius, center, Vector(0, 0, 1), angle1, angle2, sense==1)
-
+        e = Edge.makeEllipse(x_radius, y_radius, center, self.plane.zDir, self.plane.xDir, angle1, angle2, sense==1)
+        
         # Rotate if necessary
         if rotation_angle != 0.0:
-            e = e.rotate(center, center.add(Vector(0,0,1)), rotation_angle)
+            e = e.rotate(center, center.add(self.plane.zDir), rotation_angle)
 
         # Move the start point of the ellipse onto the last current point
         if startAtCurrent:
@@ -2076,7 +2075,7 @@ class Workplane(CQ):
         :type forConstruction: true if the wires are for reference, false if they are creating
             part geometry
         :return: a new CQ object with the created wires on the stack
-        
+
         *NOTE* Due to a bug in opencascade (https://tracker.dev.opencascade.org/view.php?id=31290)
         the center of mass (equals center for next shape) is shifted. To create concentric ellipses
         use Workplane("XY")
@@ -2084,7 +2083,7 @@ class Workplane(CQ):
             .center(0, 0).ellipse(50, 5)
         """
         def makeEllipseWire(obj):
-            elip = Wire.makeEllipse(x_radius, y_radius, obj, Vector(0, 0, 1), rotation_angle=rotation_angle)
+            elip = Wire.makeEllipse(x_radius, y_radius, obj, Vector(0, 0, 1), Vector(1, 0, 0), rotation_angle=rotation_angle)
             elip.forConstruction = forConstruction
             return elip
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1567,8 +1567,18 @@ class Workplane(CQ):
 
         return self.spline(allPoints, includeCurrent=False, makeWire=True)
 
-    def ellipseArc(self, x_radius, y_radius, angle1=360, angle2=360, rotation_angle=0.0, sense=1,
-                forConstruction=False, startAtCurrent=True, makeWire=False):
+    def ellipseArc(
+        self,
+        x_radius,
+        y_radius,
+        angle1=360,
+        angle2=360,
+        rotation_angle=0.0,
+        sense=1,
+        forConstruction=False,
+        startAtCurrent=True,
+        makeWire=False,
+    ):
         """Draw an elliptical arc with x and y radiuses either with start point at current point or
         or current point being the center of the arc
 
@@ -1583,11 +1593,19 @@ class Workplane(CQ):
         :param makeWire: convert the resulting arc edge to a wire
         """
 
-
         # Start building the ellipse with the current point as center
         center = self._findFromPoint(useLocalCoords=False)
-        e = Edge.makeEllipse(x_radius, y_radius, center, self.plane.zDir, self.plane.xDir, angle1, angle2, sense==1)
-        
+        e = Edge.makeEllipse(
+            x_radius,
+            y_radius,
+            center,
+            self.plane.zDir,
+            self.plane.xDir,
+            angle1,
+            angle2,
+            sense == 1,
+        )
+
         # Rotate if necessary
         if rotation_angle != 0.0:
             e = e.rotate(center, center.add(self.plane.zDir), rotation_angle)
@@ -2082,8 +2100,16 @@ class Workplane(CQ):
             .center(10, 20).ellipse(100,10)
             .center(0, 0).ellipse(50, 5)
         """
+
         def makeEllipseWire(obj):
-            elip = Wire.makeEllipse(x_radius, y_radius, obj, Vector(0, 0, 1), Vector(1, 0, 0), rotation_angle=rotation_angle)
+            elip = Wire.makeEllipse(
+                x_radius,
+                y_radius,
+                obj,
+                Vector(0, 0, 1),
+                Vector(1, 0, 0),
+                rotation_angle=rotation_angle,
+            )
             elip.forConstruction = forConstruction
             return elip
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2020,6 +2020,41 @@ class Workplane(CQ):
 
         return self.eachpoint(makeCircleWire, useLocalCoordinates=True)
 
+    # ellipse from current point
+    def ellipse(self, x_radius, y_radius, angle1=360, angle2=360, rotation_angle=0.0,
+                closed=False, forConstruction=False):
+        """
+        Make an ellipse for each item on the stack.
+        :param x_radius: x radius of the ellipse (x-axis of plane the ellipse should lie in)
+        :type x_radius: float > 0
+        :param y_radius: y radius of the ellipse (y-axis of plane the ellipse should lie in)
+        :type y_radius: float > 0
+        :param forConstruction: should the new wires be reference geometry only?
+        :type forConstruction: true if the wires are for reference, false if they are creating
+            part geometry
+        :param rotation_angle: angle to rotate the ellipse (0 = no rotation = default)
+        :type rotation_angle: float
+        :param angle1: start angle of arc
+        :type angle1: float
+        :param angle2: end angle of arc
+        :type angle2: float
+        :param rotation_angle: angle to rotate the created ellipse / arc
+        :type rotation_angle: float
+        :return: a new CQ object with the created wires on the stack
+        
+        *NOTE* Due to a bug in opencascade (https://tracker.dev.opencascade.org/view.php?id=31290)
+        the center of mass (equals center for next shape) is shifted. To create concentric ellipses
+        use Workplane("XY")
+            .center(10, 20).ellipse(100,10)
+            .center(0, 0).ellipse(50, 5)
+        """
+        def makeEllipseWire(obj):
+            elip = Wire.makeEllipse(x_radius, y_radius, obj, Vector(0, 0, 1), angle1, angle2, rotation_angle, closed)
+            elip.forConstruction = forConstruction
+            return elip
+
+        return self.eachpoint(makeEllipseWire, useLocalCoordinates=True)
+
     def polygon(self, nSides, diameter, forConstruction=False):
         """
         Creates a polygon inscribed in a circle of the specified diameter for each point on

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1567,6 +1567,48 @@ class Workplane(CQ):
 
         return self.spline(allPoints, includeCurrent=False, makeWire=True)
 
+    def ellipseArc(self, x_radius, y_radius, angle1=360, angle2=360, rotation_angle=0.0, sense=1,
+                forConstruction=False, startAtCurrent=True, makeWire=False):
+        """Draw an elliptical arc with x and y radiuses either with start point at current point or
+        or current point being the center of the arc
+
+        :param x_radius: x radius of the ellipse (along the x-axis of plane the ellipse should lie in)
+        :param y_radius: y radius of the ellipse (along the y-axis of plane the ellipse should lie in)
+        :param angle1: start angle of arc
+        :param angle2: end angle of arc (angle2 == angle1 return closed ellipse = default)
+        :param rotation_angle: angle to rotate the created ellipse / arc
+        :param sense: clockwise (-1) or counter clockwise (1)
+        :param startAtCurrent: True: start point of arc is moved to current point; False: center of
+            arc is on current point
+        :param makeWire: convert the resulting arc edge to a wire
+        """
+
+
+        # Start building the ellipse with the current point as center
+        # to support strating as the result of center(x,y) or moveTo(x,y) do not use local coordinates
+        center = self._findFromPoint(useLocalCoords=False)
+        e = Edge.makeEllipse(x_radius, y_radius, center, Vector(0, 0, 1), angle1, angle2, sense==1)
+
+        # Rotate if necessary
+        if rotation_angle != 0.0:
+            e = e.rotate(center, center.add(Vector(0,0,1)), rotation_angle)
+
+        # Move the start point of the ellipse onto the last current point
+        if startAtCurrent:
+            startPoint = e.startPoint()
+            e = e.translate(center.sub(startPoint))
+
+        if makeWire:
+            rv = Wire.assembleEdges([e])
+            if not forConstruction:
+                self._addPendingWire(rv)
+        else:
+            rv = e
+            if not forConstruction:
+                self._addPendingEdge(e)
+
+        return self.newObject([rv])
+
     def threePointArc(self, point1, point2, forConstruction=False):
         """
         Draw an arc from the current point, through point1, and ending at point2
@@ -2021,25 +2063,18 @@ class Workplane(CQ):
         return self.eachpoint(makeCircleWire, useLocalCoordinates=True)
 
     # ellipse from current point
-    def ellipse(self, x_radius, y_radius, angle1=360, angle2=360, rotation_angle=0.0,
-                closed=False, forConstruction=False):
+    def ellipse(self, x_radius, y_radius, rotation_angle=0.0, forConstruction=False):
         """
         Make an ellipse for each item on the stack.
         :param x_radius: x radius of the ellipse (x-axis of plane the ellipse should lie in)
         :type x_radius: float > 0
         :param y_radius: y radius of the ellipse (y-axis of plane the ellipse should lie in)
         :type y_radius: float > 0
+        :param rotation_angle: angle to rotate the ellipse (0 = no rotation = default)
+        :type rotation_angle: float
         :param forConstruction: should the new wires be reference geometry only?
         :type forConstruction: true if the wires are for reference, false if they are creating
             part geometry
-        :param rotation_angle: angle to rotate the ellipse (0 = no rotation = default)
-        :type rotation_angle: float
-        :param angle1: start angle of arc
-        :type angle1: float
-        :param angle2: end angle of arc
-        :type angle2: float
-        :param rotation_angle: angle to rotate the created ellipse / arc
-        :type rotation_angle: float
         :return: a new CQ object with the created wires on the stack
         
         *NOTE* Due to a bug in opencascade (https://tracker.dev.opencascade.org/view.php?id=31290)
@@ -2049,7 +2084,7 @@ class Workplane(CQ):
             .center(0, 0).ellipse(50, 5)
         """
         def makeEllipseWire(obj):
-            elip = Wire.makeEllipse(x_radius, y_radius, obj, Vector(0, 0, 1), angle1, angle2, rotation_angle, closed)
+            elip = Wire.makeEllipse(x_radius, y_radius, obj, Vector(0, 0, 1), rotation_angle=rotation_angle)
             elip.forConstruction = forConstruction
             return elip
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -77,7 +77,7 @@ from OCC.Core.TopoDS import (
 
 from OCC.Core.TopoDS import TopoDS_Compound, TopoDS_Builder
 
-from OCC.Core.GC import GC_MakeArcOfCircle, GC_MakeArcOfEllipse   # geometry construction
+from OCC.Core.GC import GC_MakeArcOfCircle, GC_MakeArcOfEllipse  # geometry construction
 from OCC.Core.GCE2d import GCE2d_MakeSegment
 from OCC.Core.GeomAPI import GeomAPI_Interpolate, GeomAPI_ProjectPointOnSurf
 
@@ -745,8 +745,17 @@ class Edge(Shape, Mixin1D):
             return cls(BRepBuilderAPI_MakeEdge(circle_geom).Edge())
 
     @classmethod
-    def makeEllipse(cls, x_radius, y_radius, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1), xdir=Vector(1, 0, 0),
-                    angle1=360.0, angle2=360.0, sense=1):
+    def makeEllipse(
+        cls,
+        x_radius,
+        y_radius,
+        pnt=Vector(0, 0, 0),
+        dir=Vector(0, 0, 1),
+        xdir=Vector(1, 0, 0),
+        angle1=360.0,
+        angle2=360.0,
+        sense=1,
+    ):
         """
         Interpolate a spline through the provided points.
         :param cls:
@@ -770,7 +779,9 @@ class Edge(Shape, Mixin1D):
         if y_radius > x_radius:
             # swap x and y radius and rotate by 90° afterwards to create an ellipse with x_radius < y_radius
             correction_angle = 90.0 * DEG2RAD
-            ellipse_gp = gp_Elips(ax2, y_radius, x_radius).Rotated(ax1, correction_angle)
+            ellipse_gp = gp_Elips(ax2, y_radius, x_radius).Rotated(
+                ax1, correction_angle
+            )
         else:
             correction_angle = 0.0
             ellipse_gp = gp_Elips(ax2, x_radius, y_radius)
@@ -779,17 +790,18 @@ class Edge(Shape, Mixin1D):
             ellipse = cls(BRepBuilderAPI_MakeEdge(ellipse_gp).Edge())
         else:  # arc case
             # take correction_angle into account
-            ellipse_geom = GC_MakeArcOfEllipse(ellipse_gp,
-                                               angle1 * DEG2RAD - correction_angle,
-                                               angle2 * DEG2RAD - correction_angle,
-                                               sense==1).Value()
+            ellipse_geom = GC_MakeArcOfEllipse(
+                ellipse_gp,
+                angle1 * DEG2RAD - correction_angle,
+                angle2 * DEG2RAD - correction_angle,
+                sense == 1,
+            ).Value()
             ellipse = cls(BRepBuilderAPI_MakeEdge(ellipse_geom).Edge())
 
         return ellipse
 
     @classmethod
-    def makeSpline(cls, listOfVector, tangents=None, periodic=False,
-                   tol = 1e-6):
+    def makeSpline(cls, listOfVector, tangents=None, periodic=False, tol=1e-6):
         """
         Interpolate a spline through the provided points.
         :param cls:
@@ -907,8 +919,18 @@ class Wire(Shape, Mixin1D):
         return w
 
     @classmethod
-    def makeEllipse(cls, x_radius, y_radius, center, normal, xDir, angle1=360.0, angle2=360.0,
-                    rotation_angle=0.0, closed=True):
+    def makeEllipse(
+        cls,
+        x_radius,
+        y_radius,
+        center,
+        normal,
+        xDir,
+        angle1=360.0,
+        angle2=360.0,
+        rotation_angle=0.0,
+        closed=True,
+    ):
         """
             Makes an Ellipse centered at the provided point, having normal in the provided direction
             :param x_radius: floating point major radius of the ellipse (x-axis), must be > 0
@@ -921,7 +943,9 @@ class Wire(Shape, Mixin1D):
             :return:
         """
 
-        ellipse_edge = Edge.makeEllipse(x_radius, y_radius, center, normal, xDir, angle1, angle2)
+        ellipse_edge = Edge.makeEllipse(
+            x_radius, y_radius, center, normal, xDir, angle1, angle2
+        )
 
         if angle1 != angle2 and closed:
             line = Edge.makeLine(ellipse_edge.endPoint(), ellipse_edge.startPoint())

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -132,7 +132,7 @@ from OCC.Core.BRepFeat import BRepFeat_MakeDPrism
 
 from OCC.Core.BRepClass3d import BRepClass3d_SolidClassifier
 
-from math import pi, sqrt, tan, atan2
+from math import pi, sqrt
 from functools import reduce
 import warnings
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -940,7 +940,7 @@ class Wire(Shape, Mixin1D):
             :param angle1: start angle of arc
             :param angle2: end angle of arc
             :param rotation_angle: angle to rotate the created ellipse / arc
-            :return:
+            :return: Wire
         """
 
         ellipse_edge = Edge.makeEllipse(

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -750,7 +750,7 @@ class Edge(Shape, Mixin1D):
 
     @classmethod
     def makeEllipse(cls, x_radius, y_radius, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1),
-                    angle1=360.0, angle2=360.0):
+                    angle1=360.0, angle2=360.0, sense=1):
         """
         Interpolate a spline through the provided points.
         :param cls:
@@ -760,6 +760,7 @@ class Edge(Shape, Mixin1D):
         :param dir: vector representing the direction of the plane the ellipse should lie in
         :param angle1: start angle of arc
         :param angle2: end angle of arc (angle2 == angle1 return closed ellipse = default)
+        :param sense: clockwise (-1) or counter clockwise (1)
         :return: an Edge
         """
 
@@ -784,7 +785,7 @@ class Edge(Shape, Mixin1D):
             ellipse_geom = GC_MakeArcOfEllipse(ellipse_gp,
                                                angle1 * DEG2RAD - correction_angle,
                                                angle2 * DEG2RAD - correction_angle,
-                                               True).Value()
+                                               sense==1).Value()
             ellipse = cls(BRepBuilderAPI_MakeEdge(ellipse_geom).Edge())
 
         return ellipse

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -757,7 +757,7 @@ class Edge(Shape, Mixin1D):
         sense=1,
     ):
         """
-        Interpolate a spline through the provided points.
+        Makes an Ellipse centered at the provided point, having normal in the provided direction
         :param cls:
         :param x_radius: x radius of the ellipse (along the x-axis of plane the ellipse should lie in)
         :param y_radius: y radius of the ellipse (along the y-axis of plane the ellipse should lie in)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3,7 +3,6 @@ from .geom import Vector, BoundBox, Plane
 import OCC.Core.TopAbs as ta  # Tolopolgy type enum
 import OCC.Core.GeomAbs as ga  # Geometry type enum
 
-<<<<<<< HEAD
 from OCC.Core.gp import (
     gp_Vec,
     gp_Pnt,
@@ -12,16 +11,13 @@ from OCC.Core.gp import (
     gp_Ax3,
     gp_Dir,
     gp_Circ,
+    gp_Elips,
     gp_Trsf,
     gp_Pln,
     gp_GTrsf,
     gp_Pnt2d,
     gp_Dir2d,
 )
-=======
-from OCC.Core.gp import (gp_Vec, gp_Pnt, gp_Ax1, gp_Ax2, gp_Ax3, gp_Dir, gp_Circ, gp_Elips,
-                         gp_Trsf, gp_Pln, gp_GTrsf, gp_Pnt2d, gp_Dir2d)
->>>>>>> added ellipse
 
 # collection of pints (used for spline construction)
 from OCC.Core.TColgp import TColgp_HArray1OfPnt
@@ -749,7 +745,7 @@ class Edge(Shape, Mixin1D):
             return cls(BRepBuilderAPI_MakeEdge(circle_geom).Edge())
 
     @classmethod
-    def makeEllipse(cls, x_radius, y_radius, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1),
+    def makeEllipse(cls, x_radius, y_radius, pnt=Vector(0, 0, 0), dir=Vector(0, 0, 1), xdir=Vector(1, 0, 0),
                     angle1=360.0, angle2=360.0, sense=1):
         """
         Interpolate a spline through the provided points.
@@ -766,9 +762,10 @@ class Edge(Shape, Mixin1D):
 
         pnt = Vector(pnt).toPnt()
         dir = Vector(dir).toDir()
+        xdir = Vector(xdir).toDir()
 
         ax1 = gp_Ax1(pnt, dir)
-        ax2 = gp_Ax2(pnt, dir)
+        ax2 = gp_Ax2(pnt, dir, xdir)
 
         if y_radius > x_radius:
             # swap x and y radius and rotate by 90° afterwards to create an ellipse with x_radius < y_radius
@@ -910,7 +907,7 @@ class Wire(Shape, Mixin1D):
         return w
 
     @classmethod
-    def makeEllipse(cls, x_radius, y_radius, center, normal, angle1=360.0, angle2=360.0,
+    def makeEllipse(cls, x_radius, y_radius, center, normal, xDir, angle1=360.0, angle2=360.0,
                     rotation_angle=0.0, closed=True):
         """
             Makes an Ellipse centered at the provided point, having normal in the provided direction
@@ -924,7 +921,7 @@ class Wire(Shape, Mixin1D):
             :return:
         """
 
-        ellipse_edge = Edge.makeEllipse(x_radius, y_radius, center, normal, angle1, angle2)
+        ellipse_edge = Edge.makeEllipse(x_radius, y_radius, center, normal, xDir, angle1, angle2)
 
         if angle1 != angle2 and closed:
             line = Edge.makeLine(ellipse_edge.endPoint(), ellipse_edge.startPoint())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 from cadquery import *
-from OCC.gp import gp_Vec
+from OCC.Core.gp import gp_Vec
 import unittest
 import sys
 import os

--- a/tests/test_cad_objects.py
+++ b/tests/test_cad_objects.py
@@ -16,6 +16,7 @@ from cadquery import *
 
 DEG2RAD = 2 * math.pi / 360
 
+
 class TestCadObjects(BaseTest):
     def _make_circle(self):
 
@@ -24,7 +25,7 @@ class TestCadObjects(BaseTest):
 
     def _make_ellipse(self):
 
-        ellipse = gp_Elips(gp_Ax2(gp_Pnt(1, 2, 3), gp_DZ()), 4., 2.)
+        ellipse = gp_Elips(gp_Ax2(gp_Pnt(1, 2, 3), gp_DZ()), 4.0, 2.0)
         return Shape.cast(BRepBuilderAPI_MakeEdge(ellipse).Edge())
 
     def testVectorConstructors(self):
@@ -79,7 +80,9 @@ class TestCadObjects(BaseTest):
     def testEdgeWrapperEllipseCenter(self):
         e = self._make_ellipse()
         w = Wire.assembleEdges([e])
-        self.assertTupleAlmostEquals((1.0, 2.0, 3.0), Face.makeFromWires(w).Center().toTuple(), 3)
+        self.assertTupleAlmostEquals(
+            (1.0, 2.0, 3.0), Face.makeFromWires(w).Center().toTuple(), 3
+        )
 
     def testEdgeWrapperMakeCircle(self):
         halfCircleEdge = Edge.makeCircle(
@@ -99,10 +102,24 @@ class TestCadObjects(BaseTest):
         x_radius, y_radius = 20, 10
         angle1, angle2 = -75.0, 90.0
         arcEllipseEdge = Edge.makeEllipse(
-            x_radius=x_radius, y_radius=y_radius, pnt=(0, 0, 0), dir=(0, 0, 1), angle1=angle1, angle2=angle2)
+            x_radius=x_radius,
+            y_radius=y_radius,
+            pnt=(0, 0, 0),
+            dir=(0, 0, 1),
+            angle1=angle1,
+            angle2=angle2,
+        )
 
-        start = (x_radius * math.cos(angle1 * DEG2RAD), y_radius * math.sin(angle1 * DEG2RAD), 0.0)
-        end = (x_radius * math.cos(angle2 * DEG2RAD), y_radius * math.sin(angle2 * DEG2RAD), 0.0)
+        start = (
+            x_radius * math.cos(angle1 * DEG2RAD),
+            y_radius * math.sin(angle1 * DEG2RAD),
+            0.0,
+        )
+        end = (
+            x_radius * math.cos(angle2 * DEG2RAD),
+            y_radius * math.sin(angle2 * DEG2RAD),
+            0.0,
+        )
         self.assertTupleAlmostEquals(start, arcEllipseEdge.startPoint().toTuple(), 3)
         self.assertTupleAlmostEquals(end, arcEllipseEdge.endPoint().toTuple(), 3)
 
@@ -111,10 +128,24 @@ class TestCadObjects(BaseTest):
         x_radius, y_radius = 10, 20
         angle1, angle2 = 0.0, 45.0
         arcEllipseEdge = Edge.makeEllipse(
-            x_radius=x_radius, y_radius=y_radius, pnt=(0, 0, 0), dir=(0, 0, 1), angle1=angle1, angle2=angle2)
+            x_radius=x_radius,
+            y_radius=y_radius,
+            pnt=(0, 0, 0),
+            dir=(0, 0, 1),
+            angle1=angle1,
+            angle2=angle2,
+        )
 
-        start = (x_radius * math.cos(angle1 * DEG2RAD), y_radius * math.sin(angle1 * DEG2RAD), 0.0)
-        end = (x_radius * math.cos(angle2 * DEG2RAD), y_radius * math.sin(angle2 * DEG2RAD), 0.0)
+        start = (
+            x_radius * math.cos(angle1 * DEG2RAD),
+            y_radius * math.sin(angle1 * DEG2RAD),
+            0.0,
+        )
+        end = (
+            x_radius * math.cos(angle2 * DEG2RAD),
+            y_radius * math.sin(angle2 * DEG2RAD),
+            0.0,
+        )
         self.assertTupleAlmostEquals(start, arcEllipseEdge.startPoint().toTuple(), 3)
         self.assertTupleAlmostEquals(end, arcEllipseEdge.endPoint().toTuple(), 3)
 
@@ -123,10 +154,24 @@ class TestCadObjects(BaseTest):
         x_radius, y_radius = 20, 20
         angle1, angle2 = 15.0, 60.0
         arcEllipseEdge = Edge.makeEllipse(
-            x_radius=x_radius, y_radius=y_radius, pnt=(0, 0, 0), dir=(0, 0, 1), angle1=angle1, angle2=angle2)
+            x_radius=x_radius,
+            y_radius=y_radius,
+            pnt=(0, 0, 0),
+            dir=(0, 0, 1),
+            angle1=angle1,
+            angle2=angle2,
+        )
 
-        start = (x_radius * math.cos(angle1 * DEG2RAD), y_radius * math.sin(angle1 * DEG2RAD), 0.0)
-        end = (x_radius * math.cos(angle2 * DEG2RAD), y_radius * math.sin(angle2 * DEG2RAD), 0.0)
+        start = (
+            x_radius * math.cos(angle1 * DEG2RAD),
+            y_radius * math.sin(angle1 * DEG2RAD),
+            0.0,
+        )
+        end = (
+            x_radius * math.cos(angle2 * DEG2RAD),
+            y_radius * math.sin(angle2 * DEG2RAD),
+            0.0,
+        )
         self.assertTupleAlmostEquals(start, arcEllipseEdge.startPoint().toTuple(), 3)
         self.assertTupleAlmostEquals(end, arcEllipseEdge.endPoint().toTuple(), 3)
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -738,12 +738,12 @@ class TestCadQuery(BaseTest):
         self.assertTupleAlmostEquals(ep1.toTuple(), ep2.toTuple(), 3)
 
     def testMakeEllipse(self):
-        el = cq.Wire.makeEllipse(
+        el = Wire.makeEllipse(
             1,
             2,
-            cq.Vector(0, 0, 0),
-            cq.Vector(0, 0, 1),
-            cq.Vector(1, 0, 0),
+            Vector(0, 0, 0),
+            Vector(0, 0, 1),
+            Vector(1, 0, 0),
             0,
             90,
             45,

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -737,6 +737,22 @@ class TestCadQuery(BaseTest):
         self.assertTupleAlmostEquals(sp1.toTuple(), sp2.toTuple(), 3)
         self.assertTupleAlmostEquals(ep1.toTuple(), ep2.toTuple(), 3)
 
+    def testMakeEllipse(self):
+        el = cq.Wire.makeEllipse(
+            1,
+            2,
+            cq.Vector(0, 0, 0),
+            cq.Vector(0, 0, 1),
+            cq.Vector(1, 0, 0),
+            0,
+            90,
+            45,
+            True,
+        )
+
+        self.assertTrue(el.isClosed())
+        self.assertTrue(el.isValid())
+
     def testSweep(self):
         """
         Tests the operation of sweeping a wire(s) along a path

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -739,18 +739,10 @@ class TestCadQuery(BaseTest):
 
     def testMakeEllipse(self):
         el = Wire.makeEllipse(
-            1,
-            2,
-            Vector(0, 0, 0),
-            Vector(0, 0, 1),
-            Vector(1, 0, 0),
-            0,
-            90,
-            45,
-            True,
+            1, 2, Vector(0, 0, 0), Vector(0, 0, 1), Vector(1, 0, 0), 0, 90, 45, True,
         )
 
-        self.assertTrue(el.isClosed())
+        self.assertTrue(el.IsClosed())
         self.assertTrue(el.isValid())
 
     def testSweep(self):

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -544,7 +544,7 @@ class TestCadQuery(BaseTest):
         # test include current
         path1 = Workplane("XZ").spline(pts[1:], includeCurrent=True).val()
         self.assertAlmostEqual(path.Length(), path1.Length())
-        
+
         # test tangents and offset plane
         pts = [(0, 0), (-1, 1), (-2, 0), (-1, 0)]
         tangents = [(0, 1), (1, 0)]

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -644,11 +644,11 @@ class TestCadQuery(BaseTest):
                 angle2=a2,
                 rotation_angle=ra,
                 sense=-1,
-                makeWire=True
+                makeWire=True,
             )
         )
 
-        self.assertEqual(len(ellipseArc4.ctx.pendingWires),1)
+        self.assertEqual(len(ellipseArc4.ctx.pendingWires), 1)
 
         start = ellipseArc4.vertices().objects[0]
         end = ellipseArc4.vertices().objects[1]

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -497,7 +497,6 @@ class TestCadQuery(BaseTest):
         self.assertAlmostEqual(path.Length(), path1.Length())
 
     def testRotatedEllipse(self):
-
         def rotatePoint(x, y, alpha):
             # rotation matrix
             a = alpha * DEG2RAD
@@ -517,52 +516,108 @@ class TestCadQuery(BaseTest):
         ex_rot, ey_rot = rotatePoint(*ellipsePoints(r1, r2, a2), ra)
 
         # startAtCurrent=False, sense = 1
-        ellipseArc1 = Workplane("XY").moveTo(*p0).ellipseArc(
-            r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra)
+        ellipseArc1 = (
+            Workplane("XY")
+            .moveTo(*p0)
+            .ellipseArc(
+                r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra
+            )
+        )
         start = ellipseArc1.vertices().objects[0]
         end = ellipseArc1.vertices().objects[1]
 
-        self.assertTupleAlmostEquals((start.X, start.Y), (p0[0] + sx_rot, p0[1] + sy_rot), 3)
-        self.assertTupleAlmostEquals((end.X, end.Y), (p0[0] + ex_rot, p0[1] + ey_rot), 3)
+        self.assertTupleAlmostEquals(
+            (start.X, start.Y), (p0[0] + sx_rot, p0[1] + sy_rot), 3
+        )
+        self.assertTupleAlmostEquals(
+            (end.X, end.Y), (p0[0] + ex_rot, p0[1] + ey_rot), 3
+        )
 
         # startAtCurrent=True, sense = 1
-        ellipseArc2 = Workplane("XY").moveTo(*p0).ellipseArc(
-            r1, r2, startAtCurrent=True, angle1=a1, angle2=a2, rotation_angle=ra)
+        ellipseArc2 = (
+            Workplane("XY")
+            .moveTo(*p0)
+            .ellipseArc(
+                r1, r2, startAtCurrent=True, angle1=a1, angle2=a2, rotation_angle=ra
+            )
+        )
         start = ellipseArc2.vertices().objects[0]
         end = ellipseArc2.vertices().objects[1]
 
-        self.assertTupleAlmostEquals((start.X, start.Y), (p0[0] + sx_rot - sx_rot, p0[1] + sy_rot - sy_rot), 3)
-        self.assertTupleAlmostEquals((end.X, end.Y), (p0[0] + ex_rot - sx_rot, p0[1] + ey_rot - sy_rot), 3)
+        self.assertTupleAlmostEquals(
+            (start.X, start.Y), (p0[0] + sx_rot - sx_rot, p0[1] + sy_rot - sy_rot), 3
+        )
+        self.assertTupleAlmostEquals(
+            (end.X, end.Y), (p0[0] + ex_rot - sx_rot, p0[1] + ey_rot - sy_rot), 3
+        )
 
         # startAtCurrent=False, sense = -1
-        ellipseArc3 = Workplane("XY").moveTo(*p0).ellipseArc(
-            r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra, sense=-1)
+        ellipseArc3 = (
+            Workplane("XY")
+            .moveTo(*p0)
+            .ellipseArc(
+                r1,
+                r2,
+                startAtCurrent=False,
+                angle1=a1,
+                angle2=a2,
+                rotation_angle=ra,
+                sense=-1,
+            )
+        )
         start = ellipseArc3.vertices().objects[0]
         end = ellipseArc3.vertices().objects[1]
 
         # swap start and end points for coparison due to different sense
-        self.assertTupleAlmostEquals((start.X, start.Y), (p0[0] + ex_rot, p0[1] + ey_rot), 3)
-        self.assertTupleAlmostEquals((end.X, end.Y), (p0[0] + sx_rot, p0[1] + sy_rot), 3)
+        self.assertTupleAlmostEquals(
+            (start.X, start.Y), (p0[0] + ex_rot, p0[1] + ey_rot), 3
+        )
+        self.assertTupleAlmostEquals(
+            (end.X, end.Y), (p0[0] + sx_rot, p0[1] + sy_rot), 3
+        )
 
         # startAtCurrent=True, sense = -1
-        ellipseArc4 = Workplane("XY").moveTo(*p0).ellipseArc(
-            r1, r2, startAtCurrent=True, angle1=a1, angle2=a2, rotation_angle=ra, sense=-1)
+        ellipseArc4 = (
+            Workplane("XY")
+            .moveTo(*p0)
+            .ellipseArc(
+                r1,
+                r2,
+                startAtCurrent=True,
+                angle1=a1,
+                angle2=a2,
+                rotation_angle=ra,
+                sense=-1,
+            )
+        )
         start = ellipseArc4.vertices().objects[0]
         end = ellipseArc4.vertices().objects[1]
 
         # swap start and end points for coparison due to different sense
-        self.assertTupleAlmostEquals((start.X, start.Y), (p0[0] + ex_rot - ex_rot, p0[1] + ey_rot - ey_rot), 3)
-        self.assertTupleAlmostEquals((end.X, end.Y), (p0[0] + sx_rot - ex_rot, p0[1] + sy_rot - ey_rot), 3)
+        self.assertTupleAlmostEquals(
+            (start.X, start.Y), (p0[0] + ex_rot - ex_rot, p0[1] + ey_rot - ey_rot), 3
+        )
+        self.assertTupleAlmostEquals(
+            (end.X, end.Y), (p0[0] + sx_rot - ex_rot, p0[1] + sy_rot - ey_rot), 3
+        )
 
     def testEllipseArcsClockwise(self):
-        ellipseArc = Workplane("XY").moveTo(10,15).ellipseArc(5, 4, -10, 190, 45, sense=-1, startAtCurrent=False)
+        ellipseArc = (
+            Workplane("XY")
+            .moveTo(10, 15)
+            .ellipseArc(5, 4, -10, 190, 45, sense=-1, startAtCurrent=False)
+        )
         sp = ellipseArc.val().startPoint()
         ep = ellipseArc.val().endPoint()
-        self.assertTupleAlmostEquals((sp.x, sp.y), ( 7.009330014275797, 11.027027582524015), 3)
-        self.assertTupleAlmostEquals((ep.x, ep.y), (13.972972417475985, 17.990669985724203), 3)
+        self.assertTupleAlmostEquals(
+            (sp.x, sp.y), (7.009330014275797, 11.027027582524015), 3
+        )
+        self.assertTupleAlmostEquals(
+            (ep.x, ep.y), (13.972972417475985, 17.990669985724203), 3
+        )
 
-        ellipseArc = (ellipseArc
-            .ellipseArc(5, 4, -10, 190, 315, sense=-1)
+        ellipseArc = (
+            ellipseArc.ellipseArc(5, 4, -10, 190, 315, sense=-1)
             .ellipseArc(5, 4, -10, 190, 225, sense=-1)
             .ellipseArc(5, 4, -10, 190, 135, sense=-1)
         )
@@ -570,14 +625,22 @@ class TestCadQuery(BaseTest):
         self.assertTupleAlmostEquals((sp.x, sp.y), (ep.x, ep.y), 3)
 
     def testEllipseArcsCounterClockwise(self):
-        ellipseArc = Workplane("XY").moveTo(10,15).ellipseArc(5, 4, -10, 190, 45, startAtCurrent=False)
+        ellipseArc = (
+            Workplane("XY")
+            .moveTo(10, 15)
+            .ellipseArc(5, 4, -10, 190, 45, startAtCurrent=False)
+        )
         sp = ellipseArc.val().startPoint()
         ep = ellipseArc.val().endPoint()
-        self.assertTupleAlmostEquals((sp.x, sp.y), (13.972972417475985, 17.990669985724203), 3)
-        self.assertTupleAlmostEquals((ep.x, ep.y), ( 7.009330014275797, 11.027027582524015), 3)
+        self.assertTupleAlmostEquals(
+            (sp.x, sp.y), (13.972972417475985, 17.990669985724203), 3
+        )
+        self.assertTupleAlmostEquals(
+            (ep.x, ep.y), (7.009330014275797, 11.027027582524015), 3
+        )
 
-        ellipseArc = (ellipseArc
-            .ellipseArc(5, 4, -10, 190, 135)
+        ellipseArc = (
+            ellipseArc.ellipseArc(5, 4, -10, 190, 135)
             .ellipseArc(5, 4, -10, 190, 225)
             .ellipseArc(5, 4, -10, 190, 315)
         )
@@ -591,13 +654,23 @@ class TestCadQuery(BaseTest):
         r1, r2 = 20, 10
         ra = 25
 
-        ellipseArc1 = Workplane("XY").moveTo(*p0).ellipseArc(
-            r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra)
+        ellipseArc1 = (
+            Workplane("XY")
+            .moveTo(*p0)
+            .ellipseArc(
+                r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra
+            )
+        )
         sp1 = ellipseArc1.val().startPoint()
         ep1 = ellipseArc1.val().endPoint()
 
-        ellipseArc2 = Workplane("XY").moveTo(*p0).ellipseArc(
-            r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra)
+        ellipseArc2 = (
+            Workplane("XY")
+            .moveTo(*p0)
+            .ellipseArc(
+                r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra
+            )
+        )
         sp2 = ellipseArc2.val().startPoint()
         ep2 = ellipseArc2.val().endPoint()
 
@@ -862,9 +935,9 @@ class TestCadQuery(BaseTest):
         self.assertEqual(14, s.faces().size())
 
     def testConcentricEllipses(self):
-        concentricEllipses  = (Workplane("XY")
-                                 .center(10, 20).ellipse(100,10)
-                                 .center(0, 0).ellipse(50, 5))
+        concentricEllipses = (
+            Workplane("XY").center(10, 20).ellipse(100, 10).center(0, 0).ellipse(50, 5)
+        )
         v = concentricEllipses.vertices().objects[0]
         self.assertTupleAlmostEquals((v.X, v.Y), (10 + 50, 20), 3)
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -644,8 +644,12 @@ class TestCadQuery(BaseTest):
                 angle2=a2,
                 rotation_angle=ra,
                 sense=-1,
+                makeWire=True
             )
         )
+
+        self.assertEqual(len(ellipseArc4.ctx.pendingWires),1)
+
         start = ellipseArc4.vertices().objects[0]
         end = ellipseArc4.vertices().objects[1]
 


### PR DESCRIPTION
I have implemented ellipses following the implementation of circles, however, having some more flexibility. Compared to circle the following parameters are avaiable:

- `x_radius`, `y_radius`: While OCC needs `major_radius > minor_radius`, the implementation allows for arbitrary `x` and `y` radiuses. If `x_radius < y_radius`, the implementation swaps both and rotates the resulting ellipse by `+90°`. This was done to simplify building arbitrary ellipses in cadquery
- `angle1` (default=`360`), angle2 (default=`360`): allow to return an arc between `angle1`and `angle2`. This actually just makes `GC_MakeArcOfEllipse`available
- `closed` (default=`False`): If an arc, return a closed wire if `True`
- `rotation_angle` (default=`0.0`): rotate the resulting ellipse or arc around its center if `rotation_angle != 0.0`

