### PR TITLE
removed CQ.firstPoint from CQ.__init__

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1002,7 +1002,6 @@ class Workplane(CQ):
 
         self.obj = obj
         self.plane = tmpPlane
-        self.firstPoint = None
         # Changed so that workplane has the center as the first item on the stack
         self.objects = [self.plane.origin]
         self.parent = None


### PR DESCRIPTION
`CQ.__init__` creates an attribute called `firstPoint`. I can't find any references to the `CQ` attribute `firstPoint`, only the modelling context's `firstPoint`. I'm guessing it's just an artifact from before the modelling context was implemented and should be removed.