### PR TITLE
Making largestDimension work as expected

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2279,13 +2279,51 @@ class Workplane(CQ):
         how long or wide a feature must be to make sure to cut through all of the material
         :return: A value representing the largest dimension of the first solid on the stack
         """
+        xmin = ymin = zmin = 999999
+        xmax = ymax = zmax = -999999
+
+        # Get all the solids contained within this CQ object
+        solids = self.solids().vals()
+
+        # Protect against this being called on something like a blank workplane
+        if len(solids) == 0: return -1
+
+        # Find the combined outer bounds of all the solids
+        for solid in solids:
+            # Mins
+            if solid.BoundingBox().xmin < xmin:
+                xmin = solid.BoundingBox().xmin
+            if solid.BoundingBox().ymin < ymin:
+                ymin = solid.BoundingBox().ymin
+            if solid.BoundingBox().zmin < zmin:
+                zmin = solid.BoundingBox().zmin
+
+            # Maxes
+            if solid.BoundingBox().xmax > xmax:
+                xmax = solid.BoundingBox().xmax
+            if solid.BoundingBox().ymax > ymax:
+                ymax = solid.BoundingBox().ymax
+            if solid.BoundingBox().zmax > zmax:
+                zmax = solid.BoundingBox().zmax
+
+        xLength = (xmax - xmin)
+        yLength = (ymax - ymin)
+        zLength = (zmax - zmin)
+
+        centroid = Vector(xLength, yLength, zLength)
+
+        # Calculate the sphere size of the outer bounds of all solids
+        sphereSize = centroid.Length
+
+        return sphereSize
+
         # TODO: this implementation is naive and returns the dims of the first solid... most of
         # TODO: the time this works. but a stronger implementation would be to search all solids.
-        s = self.findSolid()
-        if s:
-            return s.BoundingBox().DiagonalLength * 5.0
-        else:
-            return -1
+        # s = self.findSolid()
+        # if s:
+        #     return s.BoundingBox().DiagonalLength * 5.0
+        # else:
+        #     return -1
 
     def cutEach(self, fcn, useLocalCoords=False, clean=True):
         """

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2283,7 +2283,8 @@ class Workplane(CQ):
         compound = self.findSolid()
 
         # Protect against this being called on something like a blank workplane
-        if not compound: return -1
+        if not compound:
+            return -1
 
         # Get the extents of the bounding box of the solids
         xmin = compound.BoundingBox().xmin
@@ -2294,9 +2295,9 @@ class Workplane(CQ):
         zmax = compound.BoundingBox().zmax
 
         # Find the length of each axis
-        xLength = (xmax - xmin)
-        yLength = (ymax - ymin)
-        zLength = (zmax - zmin)
+        xLength = xmax - xmin
+        yLength = ymax - ymin
+        zLength = zmax - zmin
 
         # Calculate the sphere size of the outer bounds of all solids from the lengths along each axis
         centroid = Vector(xLength, yLength, zLength)

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2279,51 +2279,30 @@ class Workplane(CQ):
         how long or wide a feature must be to make sure to cut through all of the material
         :return: A value representing the largest dimension of the first solid on the stack
         """
-        xmin = ymin = zmin = 999999
-        xmax = ymax = zmax = -999999
-
         # Get all the solids contained within this CQ object
-        solids = self.solids().vals()
+        compound = self.findSolid()
 
         # Protect against this being called on something like a blank workplane
-        if len(solids) == 0: return -1
+        if not compound: return -1
 
-        # Find the combined outer bounds of all the solids
-        for solid in solids:
-            # Mins
-            if solid.BoundingBox().xmin < xmin:
-                xmin = solid.BoundingBox().xmin
-            if solid.BoundingBox().ymin < ymin:
-                ymin = solid.BoundingBox().ymin
-            if solid.BoundingBox().zmin < zmin:
-                zmin = solid.BoundingBox().zmin
+        # Get the extents of the bounding box of the solids
+        xmin = compound.BoundingBox().xmin
+        ymin = compound.BoundingBox().ymin
+        zmin = compound.BoundingBox().zmin
+        xmax = compound.BoundingBox().xmax
+        ymax = compound.BoundingBox().ymax
+        zmax = compound.BoundingBox().zmax
 
-            # Maxes
-            if solid.BoundingBox().xmax > xmax:
-                xmax = solid.BoundingBox().xmax
-            if solid.BoundingBox().ymax > ymax:
-                ymax = solid.BoundingBox().ymax
-            if solid.BoundingBox().zmax > zmax:
-                zmax = solid.BoundingBox().zmax
-
+        # Find the length of each axis
         xLength = (xmax - xmin)
         yLength = (ymax - ymin)
         zLength = (zmax - zmin)
 
+        # Calculate the sphere size of the outer bounds of all solids from the lengths along each axis
         centroid = Vector(xLength, yLength, zLength)
-
-        # Calculate the sphere size of the outer bounds of all solids
         sphereSize = centroid.Length
 
         return sphereSize
-
-        # TODO: this implementation is naive and returns the dims of the first solid... most of
-        # TODO: the time this works. but a stronger implementation would be to search all solids.
-        # s = self.findSolid()
-        # if s:
-        #     return s.BoundingBox().DiagonalLength * 5.0
-        # else:
-        #     return -1
 
     def cutEach(self, fcn, useLocalCoords=False, clean=True):
         """

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2286,24 +2286,7 @@ class Workplane(CQ):
         if not compound:
             return -1
 
-        # Get the extents of the bounding box of the solids
-        xmin = compound.BoundingBox().xmin
-        ymin = compound.BoundingBox().ymin
-        zmin = compound.BoundingBox().zmin
-        xmax = compound.BoundingBox().xmax
-        ymax = compound.BoundingBox().ymax
-        zmax = compound.BoundingBox().zmax
-
-        # Find the length of each axis
-        xLength = xmax - xmin
-        yLength = ymax - ymin
-        zLength = zmax - zmin
-
-        # Calculate the sphere size of the outer bounds of all solids from the lengths along each axis
-        centroid = Vector(xLength, yLength, zLength)
-        sphereSize = centroid.Length
-
-        return sphereSize
+        return compound.BoundingBox().DiagonalLength
 
     def cutEach(self, fcn, useLocalCoords=False, clean=True):
         """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -254,7 +254,7 @@ class Shape(object):
 
     @classmethod
     def cast(cls, obj, forConstruction=False):
-        "Returns the right type of wrapper, given a FreeCAD object"
+        "Returns the right type of wrapper, given a OCCT object"
 
         tr = None
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1503,7 +1503,12 @@ class TestCadQuery(BaseTest):
         r = Workplane("XY").box(1, 1, 1)
         dim = r.largestDimension()
 
-        self.assertAlmostEqual(8.7, dim, 1)
+        self.assertAlmostEqual(1.76, dim, 1)
+
+        r = Workplane("XY").rect(1, 1).extrude(1)
+        dim = r.largestDimension()
+
+        self.assertAlmostEqual(1.76, dim, 1)
 
         r = Workplane("XY")
         dim = r.largestDimension()

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1733,7 +1733,6 @@ class TestCadQuery(BaseTest):
 
         # Tests the case where the depth of the cboreHole is not specified
         c2 = CQ(makeCube(3.0))
-        pnts = [(-1.0, -1.0), (0.0, 0.0), (1.0, 1.0)]
         c2 = c2.faces(">Z").workplane().pushPoints(pnts).cboreHole(0.1, 0.25, 0.25)
         self.assertEqual(15, c2.faces().size())
 


### PR DESCRIPTION
**WIP - do not merge.**

Intended to address #266 but I've run into a couple of issues.

1. Several tests fail now because `largestDimension` is used for automatically determining hole depth. I don't think the original method was doing this correctly, and I need to get this sorted out before this PR is viable.
Ex: https://github.com/CadQuery/cadquery/blob/6ecb0fc96f2379fbfd8de7f5b935dd880be99047/cadquery/cq.py#L2347

I think that's a reason that only the bounding box of the first solid was checked. You wouldn't want the hole depth to be based on all the solids in a compound (or would you?). In any case, I suspect the original implementation was kind of a hack to get hole depth to work properly. I need to think about this a bit to figure out how to refactor the code for hole depth.

2. I'm not getting the enclosing sphere diameter that I expected. For a unit cube (1x1x1), I would expect the diagonal (which is the diameter of the enclosing sphere?) to be sqrt(1^2 + 1^2) or 1.414, but my method using the Vector length yields about 1.76. I'm probably missing something simple in vector length vs diagonal/hypotenuse using two sides of the square.

Thoughts and guidance welcome.

@adam-urbanczyk @greyltc