### PR TITLE
Fully closed shelling

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1118,8 +1118,6 @@ class Workplane(object):
         solidRef = self.findSolid()
 
         faces = [f for f in self.objects if isinstance(f, Face)]
-        if len(faces) < len(self.objects):
-            raise ValueError("Shelling requires that faces are selected")
 
         s = solidRef.shell(faces, thickness)
         return self.newObject([s])

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1816,6 +1816,18 @@ class TestCadQuery(BaseTest):
         self.saveModel(s)
         self.assertEqual(23, s.faces().size())
 
+    def testClosedShell(self):
+        """
+            Create a hollow box
+        """
+        s1 = Workplane("XY").box(2, 2, 2).shell(-0.1)
+        self.assertEqual(12, s1.faces().size())
+        self.assertTrue(s1.val().isValid())
+
+        s2 = Workplane("XY").box(2, 2, 2).shell(0.1)
+        self.assertEqual(32, s2.faces().size())
+        self.assertTrue(s2.val().isValid())
+
     def testOpenCornerShell(self):
         s = Workplane("XY").box(1, 1, 1)
         s1 = s.faces("+Z")


### PR DESCRIPTION
This will solve #393 . I was motivated by the discussion on our google group and it is rather small fix. Now one can create hollow models easily:
```python
b = cq.Wokrplane().box(1,1,1).shell(-0.1)
```
![obraz](https://user-images.githubusercontent.com/13981538/86946882-4dc9cc00-c14b-11ea-82bc-385a8c9684ce.png)
