### PR TITLE
Add more examples for the shell method

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -566,8 +566,12 @@ Multiple faces can be removed using more complex selectors.
 
 .. cq_plot::
 
-   s = cq.Workplane("front").box(2, 2, 2)
-   result = s.faces("+Z or -X or +X").shell(0.1)
+   result = (
+        cq.Workplane("front")
+        .box(2, 2, 2)
+        .faces("+Z or -X or +X")
+        .shell(0.1)
+   )
    show_object(result)
 
 .. topic:: Api References

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -555,21 +555,19 @@ and the original object will be the 'hollowed out' portion.
     result = cq.Workplane("front").box(2, 2, 2).shell(0.1)
     show_object(result)
 
-Use faces to select a single face to be removed from the resulting hollow shape.
+Use face selectors to select a face to be removed from the resulting hollow shape.
 
 .. cq_plot::
 
     result = cq.Workplane("front").box(2, 2, 2).faces("+Z").shell(0.1)
     show_object(result)
 
-To remove multiple faces create a solid, select the first face using s.faces()
-and then use the :py:meth:`Workplane.add()` method to add each
-additional face.
+Multiple faces can be removed using more complex selectors.
 
 .. cq_plot::
 
    s = cq.Workplane("front").box(2, 2, 2)
-   result = s.faces("+Z").add(s.faces("-X")).add(s.faces("+X")).shell(0.1)
+   result = s.faces("+Z or -X or +X").shell(0.1)
    show_object(result)
 
 .. topic:: Api References

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -576,7 +576,7 @@ Multiple faces can be removed using more complex selectors.
         :columns: 2
 
         * :py:meth:`Workplane.shell` **!**
-        * :py:meth:`Workplane.add` **!**
+        * :ref:`selector_reference`
         * :py:meth:`Workplane.box`
         * :py:meth:`Workplane.faces`
         * :py:meth:`Workplane`

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -537,14 +537,40 @@ In the example below, a rectangle is drawn, and its vertices are used to locate 
 Shelling To Create Thin features
 --------------------------------
 
-Shelling converts a solid object into a shell of uniform thickness.  To shell an object, one or more faces
-are removed, and then the inside of the solid is 'hollowed out' to make the shell.
+Shelling converts a solid object into a shell of uniform thickness.
 
+To shell an object and 'hollow out' the inside pass a negative thickness parameter
+to the :py:meth:`Workplane.shell()` method of a shape.
 
 .. cq_plot::
 
-    result = cq.Workplane("front").box(2, 2, 2).faces("+Z").shell(0.05)
+    result = cq.Workplane("front").box(2, 2, 2).shell(-0.1)
     show_object(result)
+
+A positive thickness parameter wraps an object with filleted outside edges
+and the original object will be the 'hollowed out' portion.
+
+.. cq_plot::
+
+    result = cq.Workplane("front").box(2, 2, 2).shell(0.1)
+    show_object(result)
+
+Use faces to select a single face to be removed from the resulting hollow shape.
+
+.. cq_plot::
+
+    result = cq.Workplane("front").box(2, 2, 2).faces("+Z").shell(0.1)
+    show_object(result)
+
+To remove multiple faces create a solid, select the first face using s.faces()
+and then use the :py:meth:`Workplane.add()` method to add each
+additional face.
+
+.. cq_plot::
+
+   s = cq.Workplane("front").box(2, 2, 2)
+   result = s.faces("+Z").add(s.faces("-X")).add(s.faces("+X")).shell(0.1)
+   show_object(result)
 
 .. topic:: Api References
 
@@ -552,6 +578,7 @@ are removed, and then the inside of the solid is 'hollowed out' to make the shel
         :columns: 2
 
         * :py:meth:`Workplane.shell` **!**
+        * :py:meth:`Workplane.add` **!**
         * :py:meth:`Workplane.box`
         * :py:meth:`Workplane.faces`
         * :py:meth:`Workplane`


### PR DESCRIPTION
Here is an attempt to add more examples for shell now that it support fully closed shelling #394.

I wasn't able to execute `build-docs.sh`, hopefully I can do that on my Arch Linux system, please let me know what other steps I need perform.

```
(cqgui-master4) wink@3900x:~/prgs/CadQuery/forks/cadquery (Add-more-examples-for-the-shell-method)
$ ./build-docs.sh 
Running Sphinx v3.1.2

Exception occurred:
  File "/opt/anaconda/envs/cqgui-master4/lib/python3.7/site-packages/cadquery/cq_directive.py", line 93, in setup
    app.add_directive("cq_plot", cq_directive, True, (0, 2, 0), **options)
TypeError: add_directive() got an unexpected keyword argument 'height'
The full traceback has been saved in /tmp/sphinx-err-zfwn2w3a.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```