### PR TITLE
Add sphinx v2.4 as run dependency

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - pyparsing 2.*
     - ezdxf
     - ipython 6.5.*
+    - sphinx 2.4.*
     - typing_extensions
     
 test:


### PR DESCRIPTION
With conda 4.8.3 on my Arch Linux system the default sphinx version is
3.1. I get the following error when running `./build-docs.sh`:

$ ./build-docs.sh
Running Sphinx v3.1.1

 Exception occurred:
   File "/opt/anaconda/envs/cqgui-master3/lib/python3.7/site-packages/cadquery/cq_directive.py", line 93, in setup
     app.add_directive("cq_plot", cq_directive, True, (0, 2, 0), **options)
 TypeError: add_directive() got an unexpected keyword argument 'height'
 The full traceback has been saved in /tmp/sphinx-err-euymmkgl.log, if you want to report the issue to the developers.
 Please also report this if it was a user error, so that a better error message can be provided next time.
 A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!

With sphinx 2.4 I was able to build the docs.

Fixes #398