### PR TITLE
Implement locationAt

### DIFF
--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3559,3 +3559,33 @@ class TestCadQuery(BaseTest):
 
         w1 = Workplane().consolidateWires()
         self.assertEqual(w1.size(), 0)
+
+    def testLocationAt(self):
+
+        r = 1
+        e = Wire.makeHelix(r, r, r).Edges()[0]
+
+        locs_frenet = e.locations([0, 1], frame="frenet")
+
+        T1 = locs_frenet[0].wrapped.Transformation()
+        T2 = locs_frenet[1].wrapped.Transformation()
+
+        self.assertAlmostEqual(T1.TranslationPart().X(), r, 6)
+        self.assertAlmostEqual(T2.TranslationPart().X(), r, 6)
+        self.assertAlmostEqual(
+            T1.GetRotation().GetRotationAngle(), -T2.GetRotation().GetRotationAngle(), 6
+        )
+
+        ga = e._geomAdaptor()
+
+        locs_corrected = e.locations(
+            [ga.FirstParameter(), ga.LastParameter()],
+            mode="parameter",
+            frame="corrected",
+        )
+
+        T3 = locs_corrected[0].wrapped.Transformation()
+        T4 = locs_corrected[1].wrapped.Transformation()
+
+        self.assertAlmostEqual(T3.TranslationPart().X(), r, 6)
+        self.assertAlmostEqual(T4.TranslationPart().X(), r, 6)


### PR DESCRIPTION
This will resolve #389 . This is exposed only at shapes level, I don't think there is a elegant way to use expose this at the fluen api level.

Here is an example of what can be done with this functions. It can be very useful for modeling thread ends.
![obraz](https://user-images.githubusercontent.com/13981538/87451743-97f5f600-c600-11ea-8c22-c1296be72e6a.png)

```python
from cadquery import *

r = cq.Workplane().rect(3,1).extrude(0.1).faces('<Z').val()

s2 = Wire.makeHelix(7,20,5,angle=360).Edges()[0]
show_object(s2)
N = 20
locs = s2.Edges()[0].locations([0] + [i/N for i in range(1,N+1)])

show_object(Compound.makeCompound(r.located(l) for l in locs))
```


