### PR TITLE
Use Intersection = True in shell

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1682,7 +1682,7 @@ class Mixin3D(object):
                 occ_faces_list.Append(f.wrapped)
 
             shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped, occ_faces_list, thickness, tolerance
+                self.wrapped, occ_faces_list, thickness, tolerance, Intersection = True
             )
 
             shell_builder.Build()
@@ -1690,7 +1690,7 @@ class Mixin3D(object):
 
         else:  # if no faces provided a watertight solid will be constructed
             shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped, occ_faces_list, thickness, tolerance
+                self.wrapped, occ_faces_list, thickness, tolerance, Intersection = True
             )
 
             shell_builder.Build()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1682,7 +1682,7 @@ class Mixin3D(object):
                 occ_faces_list.Append(f.wrapped)
 
             shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped, occ_faces_list, thickness, tolerance, Intersection = True
+                self.wrapped, occ_faces_list, thickness, tolerance, Intersection=True
             )
 
             shell_builder.Build()
@@ -1690,7 +1690,7 @@ class Mixin3D(object):
 
         else:  # if no faces provided a watertight solid will be constructed
             shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped, occ_faces_list, thickness, tolerance, Intersection = True
+                self.wrapped, occ_faces_list, thickness, tolerance, Intersection=True
             )
 
             shell_builder.Build()

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1844,6 +1844,11 @@ class TestCadQuery(BaseTest):
         self.assertEqual(32, s2.faces().size())
         self.assertTrue(s2.val().isValid())
 
+        pts = [(1.0, 0.0), (0.3, 0.2), (0.0, 0.0), (0.3, -0.1), (1.0, -0.03)]
+
+        s3 = Workplane().polyline(pts).close().extrude(1).shell(-0.05)
+        self.assertTrue(s3.val().isValid())
+
     def testOpenCornerShell(self):
         s = Workplane("XY").box(1, 1, 1)
         s1 = s.faces("+Z")


### PR DESCRIPTION
Related to google groups discussion. After this modification shelling takes into account intersection between non-adjacent faces:

![image](https://user-images.githubusercontent.com/13981538/88321365-54e20400-cd1f-11ea-82ea-48983bb0f537.png)
