### PR TITLE
Expose intersection joint type for shell

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1080,7 +1080,9 @@ class Workplane(object):
             ]
         )
 
-    def shell(self, thickness: float) -> "Workplane":
+    def shell(
+        self, thickness: float, kind: Literal["arc", "intersection"] = "arc"
+    ) -> "Workplane":
         """
         Remove the selected faces to create a shell of the specified thickness.
 
@@ -1088,6 +1090,7 @@ class Workplane(object):
 
         :param thickness: a positive float, representing the thickness of the desired shell.
             Negative values shell inwards, positive values shell outwards.
+        :param kind: kind of joints, intersetion or arc (default: arc).
         :raises: ValueError if the current stack contains objects that are not faces of a solid
              further up in the chain.
         :returns: a CQ object with the resulting shelled solid selected.
@@ -1120,7 +1123,7 @@ class Workplane(object):
 
         faces = [f for f in self.objects if isinstance(f, Face)]
 
-        s = solidRef.shell(faces, thickness)
+        s = solidRef.shell(faces, thickness, kind=kind)
         return self.newObject([s])
 
     def fillet(self, radius: float) -> "Workplane":

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1665,6 +1665,7 @@ class Mixin3D(object):
         faceList: Iterable[Face],
         thickness: float,
         tolerance: float = 0.0001,
+        kind: Literal["arc", "intersection"] = "arc",
     ) -> Any:
         """
             make a shelled solid of given  by removing the list of faces
@@ -1675,6 +1676,11 @@ class Mixin3D(object):
         :return: a shelled solid
         """
 
+        kind_dict = {
+            "arc": GeomAbs_JoinType.GeomAbs_Arc,
+            "intersection": GeomAbs_JoinType.GeomAbs_Intersection,
+        }
+
         occ_faces_list = TopTools_ListOfShape()
 
         if faceList:
@@ -1682,7 +1688,12 @@ class Mixin3D(object):
                 occ_faces_list.Append(f.wrapped)
 
             shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped, occ_faces_list, thickness, tolerance, Intersection=True
+                self.wrapped,
+                occ_faces_list,
+                thickness,
+                tolerance,
+                Intersection=True,
+                Join=kind_dict[kind],
             )
 
             shell_builder.Build()
@@ -1690,7 +1701,12 @@ class Mixin3D(object):
 
         else:  # if no faces provided a watertight solid will be constructed
             shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped, occ_faces_list, thickness, tolerance, Intersection=True
+                self.wrapped,
+                occ_faces_list,
+                thickness,
+                tolerance,
+                Intersection=True,
+                Join=kind_dict[kind],
             )
 
             shell_builder.Build()

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1828,9 +1828,21 @@ class TestCadQuery(BaseTest):
         """
             Create s simple box
         """
-        s = Workplane("XY").box(2, 2, 2).faces("+Z").shell(0.05)
-        self.saveModel(s)
-        self.assertEqual(23, s.faces().size())
+        s1 = Workplane("XY").box(2, 2, 2).faces("+Z").shell(0.05)
+        self.saveModel(s1)
+        self.assertEqual(23, s1.faces().size())
+
+        s2 = (
+            Workplane()
+            .ellipse(4, 2)
+            .extrude(4)
+            .faces(">Z")
+            .shell(+2, kind="intersection")
+        )
+        self.assertEqual(5, s2.faces().size())
+
+        s3 = Workplane().ellipse(4, 2).extrude(4).faces(">Z").shell(+2, kind="arc")
+        self.assertEqual(6, s3.faces().size())
 
     def testClosedShell(self):
         """


### PR DESCRIPTION
This PR will enable keeping sharp edges when shelling outwards

![image](https://user-images.githubusercontent.com/13981538/88366731-39f8a980-cd8a-11ea-9b21-033f61755fe3.png)

```python
res1= cq.Workplane().box(1,1,1).faces('>Z').shell(.4,kind='intersection')

res2= cq.Workplane(origin=(3,0,0)).box(1,1,1).faces('>Z').faces('>Z').shell(.4,kind='arc')
```