### PR TITLE
Updated the installation to reference OCP and pointed to the master installation option

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,17 +4,23 @@ Installing CadQuery
 ===================================
 
 CadQuery 2.0 is based on
-`PythonOCC <http://www.pythonocc.org/>`_,
+`OCP <https://github.com/CadQuery/OCP>`_,
 which is a set of Python bindings for the open-source `OpenCascade <http://www.opencascade.com/>`_ modelling kernel.
 
 Anaconda or Miniconda (Python 3.x editions), Python 3.x
 ----------------------------------------------
-CadQuery requires PythonOCC and Python version 3.x
+CadQuery requires OCP and Python version 3.x
 
 Command Line Installation
 ------------------------------------------
 
-Once you have Anaconda or Miniconda installed, activate the environment you want to use and type::
+CadQuery development moves very quickly, so you will need to choose whether you want the latest features or an older, probably more stable, version of CadQuery.
+
+To get the latest features (recommended), once you have Anaconda or Miniconda installed, activate the environment you want to use and type::
+
+        conda install -c cadquery -c conda-forge cadquery=master
+
+If you want an older, more stable version of CadQuery, once you have Anaconda or Miniconda installed, activate the environment you want to use and type::
 
         conda install -c conda-forge -c cadquery cadquery=2
 
@@ -35,6 +41,8 @@ Adding a Nicer GUI via CQ-editor
 If you prefer to have a GUI available, your best option is to use
 `CQ-editor <https://github.com/CadQuery/CQ-editor>`_.
 
-CQ-editor relies on Anaconda/Miniconda as well, and the README explains how to set up an environment that will run CQ-editor.
+CQ-editor relies on Anaconda/Miniconda as well, and the README explains how to set up an environment that will run CQ-editor. However, if you are running the master branch (latest features) of CadQuery, you will want to install CQ-editor into your activated Anaconda environment with the following::
+
+        conda install -c cadquery -c conda-forge cq-editor=master
 
 


### PR DESCRIPTION
I kept repeating the same installation method to help people get the latest features, so I updated the docs. There were a couple of outdated references to PythonOCC that I removed as well.