### PR TITLE
Fix dxf arc export for some partial circles

### DIFF
--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -14,8 +14,7 @@ CURVE_TOLERANCE = 1e-9
 def _dxf_line(e, msp, plane):
 
     msp.add_line(
-        e.startPoint().toTuple(),
-        e.endPoint().toTuple(),
+        e.startPoint().toTuple(), e.endPoint().toTuple(),
     )
 
 

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -33,17 +33,18 @@ def _dxf_circle(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
 
     phi = c_dy.AngleWithRef(dy, c_dz)
 
-    if c_dz.XYZ().Z() > 0:
+    is_ccw = c_dz.XYZ().Z() > 0
+    if is_ccw:
         a1 = RAD2DEG * (geom.FirstParameter() - phi)
         a2 = RAD2DEG * (geom.LastParameter() - phi)
     else:
-        a1 = -RAD2DEG * (geom.LastParameter() + phi)
-        a2 = -RAD2DEG * (geom.FirstParameter() + phi)
+        a1 = -RAD2DEG * (geom.FirstParameter() - phi) + 180
+        a2 = -RAD2DEG * (geom.LastParameter() - phi) + 180
 
     if e.IsClosed():
         msp.add_circle((c.X(), c.Y(), c.Z()), r)
     else:
-        msp.add_arc((c.X(), c.Y(), c.Z()), r, a1, a2)
+        msp.add_arc((c.X(), c.Y(), c.Z()), r, a1, a2, is_ccw)
 
 
 def _dxf_ellipse(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
@@ -68,7 +69,7 @@ def _dxf_ellipse(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
 
 
 def _dxf_spline(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
-
+    
     adaptor = e._geomAdaptor()
     curve = GeomConvert.CurveToBSplineCurve_s(adaptor.Curve().Curve())
 

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -14,7 +14,8 @@ CURVE_TOLERANCE = 1e-9
 def _dxf_line(e, msp, plane):
 
     msp.add_line(
-        e.startPoint().toTuple(), e.endPoint().toTuple(),
+        e.startPoint().toTuple(),
+        e.endPoint().toTuple(),
     )
 
 
@@ -33,18 +34,17 @@ def _dxf_circle(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
 
     phi = c_dy.AngleWithRef(dy, c_dz)
 
-    is_ccw = c_dz.XYZ().Z() > 0
-    if is_ccw:
+    if c_dz.XYZ().Z() > 0:
         a1 = RAD2DEG * (geom.FirstParameter() - phi)
         a2 = RAD2DEG * (geom.LastParameter() - phi)
     else:
-        a1 = -RAD2DEG * (geom.FirstParameter() - phi) + 180
-        a2 = -RAD2DEG * (geom.LastParameter() - phi) + 180
+        a1 = -RAD2DEG * (geom.LastParameter() - phi) + 180
+        a2 = -RAD2DEG * (geom.FirstParameter() - phi) + 180
 
     if e.IsClosed():
         msp.add_circle((c.X(), c.Y(), c.Z()), r)
     else:
-        msp.add_arc((c.X(), c.Y(), c.Z()), r, a1, a2, is_ccw)
+        msp.add_arc((c.X(), c.Y(), c.Z()), r, a1, a2)
 
 
 def _dxf_ellipse(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
@@ -69,7 +69,7 @@ def _dxf_ellipse(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
 
 
 def _dxf_spline(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
-    
+
     adaptor = e._geomAdaptor()
     curve = GeomConvert.CurveToBSplineCurve_s(adaptor.Curve().Curve())
 
@@ -102,10 +102,10 @@ DXF_CONVERTERS = {
 def exportDXF(w: Workplane, fname: str):
     """
     Export Workplane content to DXF. Works with 2D sections.
-        
+
     :param w: Workplane to be exported.
     :param fname: output filename.
-        
+
     """
 
     plane = w.plane

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -14,9 +14,9 @@ from tests import BaseTest
 class TestExporters(BaseTest):
     def _exportBox(self, eType, stringsToFind, tolerance=0.1, angularTolerance=0.1):
         """
-            Exports a test object, and then looks for
-            all of the supplied strings to be in the result
-            returns the result in case the case wants to do more checks also
+        Exports a test object, and then looks for
+        all of the supplied strings to be in the result
+        returns the result in case the case wants to do more checks also
         """
         p = Workplane("XY").box(1, 2, 3)
 
@@ -115,6 +115,17 @@ class TestExporters(BaseTest):
 
         self.assertAlmostEqual(s3.val().Area(), s3_i.val().Area(), 6)
         self.assertAlmostEqual(s3.edges().size(), s3_i.edges().size())
+
+        cyl = Workplane("XY").circle(22).extrude(10, both=True).translate((-50, 0, 0))
+
+        s4 = Workplane("XY").box(80, 60, 5).cut(cyl).section()
+
+        exporters.dxf.exportDXF(s4, "res4.dxf")
+
+        s4_i = importers.importDXF("res4.dxf")
+
+        self.assertAlmostEqual(s4.val().Area(), s4_i.val().Area(), 6)
+        self.assertAlmostEqual(s4.edges().size(), s4_i.edges().size())
 
     def testTypeHandling(self):
 


### PR DESCRIPTION
Hey folks!

I'm not sure if this is the 'right' fix, but some partial circles (specifically, the ones with c_dz.XYZ().Z() < 0) were exporting flipped for me.

The changes are pretty minor, and fixed all the broken arcs on my data.  Basically, rotate the arc 180 degrees.  I also flipped the start/end and used the is_counterclockwise flag for those arcs.

Broken:
<img width="684" alt="Screen Shot 2020-09-24 at 11 41 26 PM" src="https://user-images.githubusercontent.com/696471/94234966-97f75980-febf-11ea-85b0-0f53729598b7.png">

Fixed:
<img width="743" alt="Screen Shot 2020-09-24 at 11 41 57 PM" src="https://user-images.githubusercontent.com/696471/94235118-e7d62080-febf-11ea-903e-7ebbf69762fa.png">

