### PR TITLE
Fixed parametricCurve() to use correct stop value

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1700,7 +1700,8 @@ class Workplane(object):
 
         """
 
-        allPoints = [func(start + stop * t / N) for t in range(N + 1)]
+        diff = stop - start
+        allPoints = [func(start + diff * t / N) for t in range(N + 1)]
 
         return self.spline(allPoints, includeCurrent=False, makeWire=True)
 


### PR DESCRIPTION
parametricCurve() takes a start and stop value as inputs:
```
:param start: starting value of the parameter t
:param stop: final value of the parameter t
```
The final value in the current implementation is actually `start + stop`. This PR fixes it to end at the specified stop value
