### PR TITLE
Create a child workplane on a vertex

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -543,8 +543,10 @@ class Workplane(object):
                         if isinstance(obj, Shape)
                         else obj.Center()
                     )
-                if self.parent is not None and isinstance(self.parent.val(), Face):
-                    normal = self.parent.val().normalAt(center)
+
+                val = self.parent.val() if self.parent else None
+                if isinstance(val, Face):
+                    normal = val.normalAt(center)
                     xDir = _computeXdir(normal)
                 else:
                     normal = self.plane.zDir

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -543,7 +543,7 @@ class Workplane(object):
                         if isinstance(obj, Shape)
                         else obj.Center()
                     )
-                if isinstance(self.parent.val(), Face):
+                if self.parent is not None and isinstance(self.parent.val(), Face):
                     normal = self.parent.val().normalAt(center)
                     xDir = _computeXdir(normal)
                 else:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -543,8 +543,12 @@ class Workplane(object):
                         if isinstance(obj, Shape)
                         else obj.Center()
                     )
-                normal = self.plane.zDir
-                xDir = self.plane.xDir
+                if isinstance(self.parent, Face):
+                    normal = self.parent.plane.zDir
+                    xDir = self.parent.plane.xDir
+                else:
+                    normal = self.plane.zDir
+                    xDir = self.plane.xDir
             else:
                 raise ValueError("Needs a face or a vertex or point on a work plane")
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -543,9 +543,9 @@ class Workplane(object):
                         if isinstance(obj, Shape)
                         else obj.Center()
                     )
-                if isinstance(self.parent, Face):
-                    normal = self.parent.plane.zDir
-                    xDir = self.parent.plane.xDir
+                if isinstance(self.parent.val(), Face):
+                    normal = self.parent.val().normalAt(center)
+                    xDir = _computeXdir(normal)
                 else:
                     normal = self.plane.zDir
                     xDir = self.plane.xDir

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3117,7 +3117,7 @@ class TestCadQuery(BaseTest):
     def testWorkplaneOrientationOnVertex(self):
 
         # create a 10 unit sized cube on the XY plane
-        parent = Workplane("XY").rect(10.0,10.0).extrude(10)
+        parent = Workplane("XY").rect(10.0, 10.0).extrude(10)
 
         # assert that the direction tuples reflect accordingly
         assert parent.plane.xDir.toTuple() == approx((1.0, 0.0, 0.0))

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3114,6 +3114,22 @@ class TestCadQuery(BaseTest):
             result.faces(">Z").val().Center().toTuple(), (-3, 0, 12), 9
         )
 
+    def testWorkplaneOrientationOnVertex(self):
+
+        # create a 10 unit sized cube on the XY plane
+        parent = Workplane("XY").rect(10.0,10.0).extrude(10)
+
+        # assert that the direction tuples reflect accordingly
+        assert parent.plane.xDir.toTuple() == approx((1.0, 0.0, 0.0))
+        assert parent.plane.zDir.toTuple() == approx((0.0, 0.0, 1.0))
+
+        # select the <XZ vertex on the <Y face and create a new workplane.
+        child = parent.faces("<Y").vertices("<XZ").workplane()
+
+        # assert that the direction tuples reflect the new workplane on the <Y face
+        assert child.plane.xDir.toTuple() == approx((1.0, 0.0, -0.0))
+        assert child.plane.zDir.toTuple() == approx((0.0, -1.0, -0.0))
+
     def testTagSelectors(self):
 
         result0 = Workplane("XY").box(1, 1, 1).tag("box").sphere(1)


### PR DESCRIPTION
This PR should resolve #24 and #149 (I think).

This is also my first time coding anything in the CAD domain, so I'm open to criticism on the solution since I'm not very familiar with the domain. I have an intermediate level of knowledge of CAD as a hobby user, not as a programmer.

I'm also new to CadQuery, so the only potential issue I see is this only looks at the immediate parent workplane for a Face to use. I'm not sure if it should instead do some kind of recursive search through the entire stack for a Face (assuming there's a long stack of related workplanes)