### PR TITLE
Adding docker publish action

### DIFF
--- a/.github/workflows/dockerhub-publish-dev.yml
+++ b/.github/workflows/dockerhub-publish-dev.yml
@@ -2,7 +2,7 @@ name: dockerhub-publish
 
 on:
   push:
-    branches: develop
+    branches: master
 
 jobs:
   main:
@@ -26,7 +26,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: cadquery/cadquery:dev
+          tags: cadquery/cadquery
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish-dev.yml
+++ b/.github/workflows/dockerhub-publish-dev.yml
@@ -1,0 +1,32 @@
+name: dockerhub-publish
+
+on:
+  push:
+    branches: develop
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: cadquery/cadquery:dev
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM continuumio/miniconda3
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN useradd -ms /bin/bash cq
+
+WORKDIR /home/cq/
+
+USER root
+
+RUN apt-get install -y libgl1-mesa-glx
+
+RUN conda install -c cadquery -c conda-forge cadquery=master
+
+USER cq


### PR DESCRIPTION
Just a thought but I'm wondering if the dockerfile that @jmwright made could be automatically build and published on dockerhub each time a push to master branch is made.

There is a Github action for automating such a task https://github.com/docker/build-push-action

This PR would need to be accompanied with some new github repository secrets that grant access to the dockerhub account
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN

If another Dockerfile (perhaps with jupyter notebook) gets added then another git action can build that one as well

Co-authored-by: @jmwright 