### PR TITLE
Change install instructions in readme to focus on master conda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,7 @@ conda create -n cadquery
 # Activate the new environment
 conda activate cadquery
 
-# Install the released version of CadQuery
-conda install -c conda-forge -c cadquery cadquery=2
-```
-
-Development version can be installed instead:
-```
+# CadQuery development is moving quickly, so it is best to install the latest version from GitHub master
 conda install -c conda-forge -c cadquery cadquery=master
 ```
 


### PR DESCRIPTION
Updates the installation instructions in the readme to avoid rushing a release. Will address #483 once merged.