### PR TITLE
More consistent handling of BoundaryBox tolerance

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -764,7 +764,7 @@ class BoundBox(object):
     def add(
         self,
         obj: Union[Tuple[float, float, float], Vector, "BoundBox"],
-        tol: float = 1e-8,
+        tol: Optional[float] = None,
     ) -> "BoundBox":
         """Returns a modified (expanded) bounding box
 
@@ -776,6 +776,8 @@ class BoundBox(object):
 
         This bounding box is not changed.
         """
+
+        tol = TOL if tol is None else tol  # tol = TOL (by default)
 
         tmp = Bnd_Box()
         tmp.SetGap(tol)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -488,8 +488,8 @@ class Shape(object):
 
         return Shape.centerOfMass(self)
 
-    def CenterOfBoundBox(self, tolerance: float = 0.1) -> Vector:
-        return self.BoundingBox().center
+    def CenterOfBoundBox(self, tolerance: Optional[float] = None) -> Vector:
+        return self.BoundingBox(tolerance=tolerance).center
 
     @staticmethod
     def CombinedCenter(objects: Iterable["Shape"]) -> Vector:


### PR DESCRIPTION
I was working on some doc strings for another PR and noticed some inconsistencies in how the tolerances on bounding boxes were handled. This PR changes `BoundBox.add` tolerance to default to `TOL`, just like the `BoundBox._fromTopoDS` method. Also `Shape.centerOfBoundBox` previously had another different default tolerance that wasn't propagated anyway.