### PR TITLE
Radius selector

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -190,7 +190,7 @@ from OCP.GeomFill import (
 )
 
 # for catching exceptions
-from OCP.Standard import Standard_NoSuchObject
+from OCP.Standard import Standard_NoSuchObject, Standard_Failure
 
 from math import pi, sqrt
 import warnings
@@ -1069,7 +1069,7 @@ class Mixin1D(object):
         geom = self._geomAdaptor()
         try:
             circ = geom.Circle()
-        except Standard_NoSuchObject as e:
+        except (Standard_NoSuchObject, Standard_Failure) as e:
             raise ValueError("Shape could not be reduced to a circle") from e
         return circ.Radius()
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -188,6 +188,10 @@ from OCP.GeomFill import (
     GeomFill_CorrectedFrenet,
     GeomFill_TrihedronLaw,
 )
+
+# for catching exceptions
+from OCP.Standard import Standard_NoSuchObject
+
 from math import pi, sqrt
 import warnings
 
@@ -1052,6 +1056,22 @@ class Mixin1D(object):
     def Length(self: Mixin1DProtocol) -> float:
 
         return GCPnts_AbscissaPoint.Length_s(self._geomAdaptor())
+
+    def radius(self: Mixin1DProtocol) -> float:
+        """
+        Calculate the radius.
+
+        Note that when applied to a Wire, the radius is simply the radius of the first edge.
+
+        :return: radius
+        :raises ValueError: if kernel can not reduce the shape to a circular edge
+        """
+        geom = self._geomAdaptor()
+        try:
+            circ = geom.Circle()
+        except Standard_NoSuchObject as e:
+            raise ValueError("Shape could not be reduced to a circle") from e
+        return circ.Radius()
 
     def IsClosed(self: Mixin1DProtocol) -> bool:
 

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -300,6 +300,51 @@ class TypeSelector(Selector):
         return r
 
 
+class RadiusNthSelector(Selector):
+    """
+    Select the object with the Nth radius.
+
+    Applicability:
+        All Edge and Wires.
+
+    Will ignore any shape that can not be represented as a circle or an arc of
+    a circle.
+    """
+
+    def __init__(self, n, directionMax=True, tolerance=0.0001):
+        self.N = n
+        self.directionMax = directionMax
+        self.TOLERANCE = tolerance
+
+    def filter(self, objectList):
+        # calculate how many digits of precision do we need
+        digits = -math.floor(math.log10(self.TOLERANCE))
+
+        # make a radius dict
+        # this is one to many mapping so I am using a default dict with list
+        objectDict = defaultdict(list)
+        for el in objectList:
+            try:
+                rad = el.radius()
+            except ValueError:
+                continue
+            objectDict[round(rad, digits)].append(el)
+
+        # choose the Nth unique rounded distance
+        sortedObjectList = sorted(
+            list(objectDict.keys()), reverse=not self.directionMax
+        )
+        try:
+            nth_distance = sortedObjectList[self.N]
+        except IndexError:
+            raise IndexError(
+                f"Attempted to access the {self.N}-th radius in a list {len(sortedObjectList)} long"
+            )
+
+        # map back to original objects and return
+        return objectDict[nth_distance]
+
+
 class DirectionMinMaxSelector(Selector):
     """
         Selects objects closest or farthest in the specified direction

--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -176,6 +176,7 @@ as a basis for futher operations.
         ParallelDirSelector
         DirectionSelector
         DirectionNthSelector
+        RadiusNthSelector
         PerpendicularDirSelector
         TypeSelector
         DirectionMinMaxSelector

--- a/doc/classreference.rst
+++ b/doc/classreference.rst
@@ -61,6 +61,7 @@ Selector Classes
     ParallelDirSelector
     DirectionSelector
     DirectionNthSelector
+    RadiusNthSelector
     PerpendicularDirSelector
     TypeSelector
     DirectionMinMaxSelector

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.6
   - ipython
-  - ocp
+  - ocp=7.4
   - pyparsing
   - sphinx=3.2.1
   - sphinx_rtd_theme

--- a/tests/test_cad_objects.py
+++ b/tests/test_cad_objects.py
@@ -418,6 +418,68 @@ class TestCadObjects(BaseTest):
             == loc3.wrapped.Transformation().TranslationPart().Z()
         )
 
+    def testEdgeWrapperRadius(self):
+
+        # get a radius from a simple circle
+        e0 = Edge.makeCircle(2.4)
+        self.assertAlmostEqual(e0.radius(), 2.4)
+
+        # radius of an arc
+        e1 = Edge.makeCircle(1.8, pnt=(5, 6, 7), dir=(1, 1, 1), angle1=20, angle2=30)
+        self.assertAlmostEqual(e1.radius(), 1.8)
+
+        # test value errors
+        e2 = Edge.makeEllipse(10, 20)
+        with self.assertRaises(ValueError):
+            e2.radius()
+
+        # radius from a wire
+        w0 = Wire.makeCircle(10, Vector(1, 2, 3), (-1, 0, 1))
+        self.assertAlmostEqual(w0.radius(), 10)
+
+        # radius from a wire with multiple edges
+        rad = 2.3
+        pnt = (7, 8, 9)
+        direction = (1, 0.5, 0.1)
+        w1 = Wire.assembleEdges(
+            [
+                Edge.makeCircle(rad, pnt, direction, 0, 10),
+                Edge.makeCircle(rad, pnt, direction, 10, 25),
+                Edge.makeCircle(rad, pnt, direction, 25, 230),
+            ]
+        )
+        self.assertAlmostEqual(w1.radius(), rad)
+
+        # test value error from wire
+        w2 = Wire.makePolygon([Vector(-1, 0, 0), Vector(0, 1, 0), Vector(1, -1, 0),])
+        with self.assertRaises(ValueError):
+            w2.radius()
+
+        # (I think) the radius of a wire is the radius of it's first edge.
+        # Since this is stated in the docstring better make sure.
+        no_rad = Wire.assembleEdges(
+            [
+                Edge.makeLine(Vector(0, 0, 0), Vector(0, 1, 0)),
+                Edge.makeCircle(1.0, angle1=90, angle2=270),
+            ]
+        )
+        with self.assertRaises(ValueError):
+            no_rad.radius()
+        yes_rad = Wire.assembleEdges(
+            [
+                Edge.makeCircle(1.0, angle1=90, angle2=270),
+                Edge.makeLine(Vector(0, -1, 0), Vector(0, 1, 0)),
+            ]
+        )
+        self.assertAlmostEqual(yes_rad.radius(), 1.0)
+        many_rad = Wire.assembleEdges(
+            [
+                Edge.makeCircle(1.0, angle1=0, angle2=180),
+                Edge.makeCircle(3.0, pnt=Vector(2, 0, 0), angle1=180, angle2=359),
+            ]
+        )
+        self.assertAlmostEqual(many_rad.radius(), 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Will close #501.

---

I've added an `Edge.radius` method to get the radius of a circular edge. 

The method uses `_geomAdaptor().Circle()`. When I used that code on a elipse, I got the kernel (7.4.0) to segfault. So I've restricted the method to just objects with `geomType() == "CIRCLE"` to be safe.

---

I've added a RadiusSelector in the style of DirectionNthSelector. 

I didn't add RadiusSelector to the string selector interface.

While I added it to the HTML docs, about half the selectors are not in the top level module and they don't show up due to #493.