### PR TITLE
Fix github-linguist statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Don't display text diffs for files that are not human readable
+# Git should not modify line endings in these test files
+tests/testdata/* -diff -text
+
+# Jupyter notebooks should be classified as documentation
+*.ipynb linguist-documentation -diff -text


### PR DESCRIPTION
CQ's current language statistics:
![screenshot2020-12-14-144611](https://user-images.githubusercontent.com/50230945/102169855-fe01e480-3ee2-11eb-90be-2ec0e0f908c1.png)

These changes will make it look like:
![screenshot2020-12-15-143743](https://user-images.githubusercontent.com/50230945/102169922-2689de80-3ee3-11eb-9e13-7017bba8504e.png)

[See my fork to see it in action](https://github.com/marcus7070/cadquery).

The problem was a single Jupyter Notebook, github-linguist naively counts every line of code in that 5MB file. Moving it to the examples directory means github-linguist now classes it as documentation (not core code) and ignores it.

I also added a `.gitattributes`, which tells git to treat `tests/testdata/*` and `*.ipynb` as un-diff-able and not to change the line endings on those files. Doesn't fix any issue in particular, just seems like good practise.