### PR TITLE
Refactor selectors and add CenterNthSelector

### DIFF
--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -43,20 +43,19 @@ from typing import List, Union
 
 class Selector(object):
     """
-        Filters a list of objects
+    Filters a list of objects.
 
-        Filters must provide a single method that filters objects.
+    Filters must provide a single method that filters objects.
     """
 
     def filter(self, objectList):
         """
-            Filter the provided list
-            :param objectList: list to filter
-            :type objectList: list of FreeCAD primatives
-            :return: filtered list
+        Filter the provided list.
 
-            The default implementation returns the original list unfiltered
-
+        The default implementation returns the original list unfiltered.
+        :param objectList: list to filter
+        :type objectList: list of FreeCAD primatives
+        :return: filtered list
         """
         return objectList
 
@@ -156,8 +155,7 @@ class BoxSelector(Selector):
 
 class BaseDirSelector(Selector):
     """
-        A selector that handles selection on the basis of a single
-        direction vector
+    A selector that handles selection on the basis of a single direction vector.
     """
 
     def __init__(self, vector: Vector, tolerance: float = 0.0001):
@@ -170,9 +168,9 @@ class BaseDirSelector(Selector):
 
     def filter(self, objectList: List[Union[Face, Edge]]) -> List[Union[Face, Edge]]:
         """
-            There are lots of kinds of filters, but
-            for planes they are always based on the normal of the plane,
-            and for edges on the tangent vector along the edge
+        There are lots of kinds of filters, but for planes they are always
+        based on the normal of the plane, and for edges on the tangent vector
+        along the edge
         """
         r = []
         for o in objectList:
@@ -196,22 +194,21 @@ class BaseDirSelector(Selector):
 
 class ParallelDirSelector(BaseDirSelector):
     """
-        Selects objects parallel with the provided direction
+    Selects objects parallel with the provided direction.
 
-        Applicability:
-            Linear Edges
-            Planar Faces
+    Applicability:
+        Linear Edges
+        Planar Faces
 
-        Use the string syntax shortcut \|(X|Y|Z) if you want to select
-        based on a cardinal direction.
+    Use the string syntax shortcut \|(X|Y|Z) if you want to select based on a cardinal direction.
 
-        Example::
+    Example::
 
-            CQ(aCube).faces(ParallelDirSelector((0,0,1))
+        CQ(aCube).faces(ParallelDirSelector((0, 0, 1))
 
-        selects faces with a normals in the z direction, and is equivalent to::
+    selects faces with a normals in the z direction, and is equivalent to::
 
-            CQ(aCube).faces("|Z")
+        CQ(aCube).faces("|Z")
     """
 
     def test(self, vec: Vector) -> bool:
@@ -220,22 +217,21 @@ class ParallelDirSelector(BaseDirSelector):
 
 class DirectionSelector(BaseDirSelector):
     """
-        Selects objects aligned with the provided direction
+    Selects objects aligned with the provided direction.
 
-        Applicability:
-            Linear Edges
-            Planar Faces
+    Applicability:
+        Linear Edges
+        Planar Faces
 
-        Use the string syntax shortcut +/-(X|Y|Z) if you want to select
-        based on a cardinal direction.
+    Use the string syntax shortcut +/-(X|Y|Z) if you want to select based on a cardinal direction.
 
-        Example::
+    Example::
 
-            CQ(aCube).faces(DirectionSelector((0,0,1))
+        CQ(aCube).faces(DirectionSelector((0, 0, 1))
 
-        selects faces with a normals in the z direction, and is equivalent to::
+    selects faces with a normals in the z direction, and is equivalent to::
 
-            CQ(aCube).faces("+Z")
+        CQ(aCube).faces("+Z")
     """
 
     def test(self, vec: Vector) -> bool:
@@ -244,22 +240,22 @@ class DirectionSelector(BaseDirSelector):
 
 class PerpendicularDirSelector(BaseDirSelector):
     """
-        Selects objects perpendicular with the provided direction
+    Selects objects perpendicular with the provided direction.
 
-        Applicability:
-            Linear Edges
-            Planar Faces
+    Applicability:
+        Linear Edges
+        Planar Faces
 
-        Use the string syntax shortcut #(X|Y|Z) if you want to select
-        based on a cardinal direction.
+    Use the string syntax shortcut #(X|Y|Z) if you want to select based on a
+    cardinal direction.
 
-        Example::
+    Example::
 
-            CQ(aCube).faces(PerpendicularDirSelector((0,0,1))
+        CQ(aCube).faces(PerpendicularDirSelector((0, 0, 1))
 
-        selects faces with a normals perpendicular to the z direction, and is equivalent to::
+    selects faces with a normals perpendicular to the z direction, and is equivalent to::
 
-            CQ(aCube).faces("#Z")
+        CQ(aCube).faces("#Z")
     """
 
     def test(self, vec: Vector) -> bool:
@@ -270,22 +266,22 @@ class PerpendicularDirSelector(BaseDirSelector):
 
 class TypeSelector(Selector):
     """
-        Selects objects of the prescribed topological type.
+    Selects objects of the prescribed topological type.
 
-        Applicability:
-            Faces: Plane,Cylinder,Sphere
-            Edges: Line,Circle,Arc
+    Applicability:
+        Faces: Plane,Cylinder,Sphere
+        Edges: Line,Circle,Arc
 
-        You can use the shortcut selector %(PLANE|SPHERE|CONE) for faces,
-        and %(LINE|ARC|CIRCLE) for edges.
+    You can use the shortcut selector %(PLANE|SPHERE|CONE) for faces, and
+    %(LINE|ARC|CIRCLE) for edges.
 
-        For example this::
+    For example this::
 
-            CQ(aCube).faces ( TypeSelector("PLANE") )
+        CQ(aCube).faces ( TypeSelector("PLANE") )
 
-        will select 6 faces, and is equivalent to::
+    will select 6 faces, and is equivalent to::
 
-            CQ(aCube).faces( "%PLANE" )
+        CQ(aCube).faces( "%PLANE" )
 
     """
 
@@ -652,8 +648,8 @@ class _SimpleStringSyntaxSelector(Selector):
 
     def filter(self, objectList):
         """
-            selects minimum, maximum, positive or negative values relative to a direction
-            [+\|-\|<\|>\|] \<X\|Y\|Z>
+        selects minimum, maximum, positive or negative values relative to a direction
+        [+\|-\|<\|>\|] \<X\|Y\|Z>
         """
         return self.mySelector.filter(objectList)
 
@@ -759,7 +755,7 @@ class StringSyntaxSelector(Selector):
     Finally, it is also possible to use even more complex expressions with nesting
     and arbitrary number of terms, e.g.
 
-        (not >X[0] and #XY) or >XY[0] 
+        (not >X[0] and #XY) or >XY[0]
 
     Selectors are a complex topic: see :ref:`selector_reference` for more information
     """

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -312,7 +312,7 @@ class _NthSelector(Selector):
         """
         if len(objectlist) == 0:
             # nothing to filter
-            return []
+            raise ValueError("Can not return the Nth element of an empty list")
         clustered = self.cluster(objectlist)
         if not self.directionMax:
             clustered.reverse()
@@ -337,8 +337,6 @@ class _NthSelector(Selector):
         """
         Clusters the elements of objectlist if they are within tolerance.
         """
-        if len(objectlist) == 0:
-            return []
         key_and_obj = []
         for obj in objectlist:
             # Need to handle value errors, such as what occurs when you try to

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -574,7 +574,7 @@ def _makeGrammar():
         direction("only_dir")
         | (type_op("type_op") + cqtype("cq_type"))
         | (direction_op("dir_op") + direction("dir") + Optional(index))
-        | (center_nth_op("center_nth_op") + direction("dir") + index)
+        | (center_nth_op("center_nth_op") + direction("dir") + Optional(index))
         | (other_op("other_op") + direction("dir"))
         | named_view("named_view")
     )
@@ -653,7 +653,10 @@ class _SimpleStringSyntaxSelector(Selector):
             vec = self._getVector(pr)
             minmax = self.operatorMinMax[pr.center_nth_op]
 
-            return CenterNthSelector(vec, int("".join(pr.index.asList())), minmax)
+            if "index" in pr:
+                return CenterNthSelector(vec, int("".join(pr.index.asList())), minmax)
+            else:
+                return CenterNthSelector(vec, -1, minmax)
 
         elif "other_op" in pr:
             vec = self._getVector(pr)

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -53,7 +53,7 @@ class Selector(object):
 
         The default implementation returns the original list unfiltered.
         :param objectList: list to filter
-        :type objectList: list of FreeCAD primatives
+        :type objectList: list of OCCT primitives
         :return: filtered list
         """
         return objectList

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -174,12 +174,11 @@ class BaseDirSelector(Selector):
         r = []
         for o in objectList:
             # no really good way to avoid a switch here, edges and faces are simply different!
-            if isinstance(o, Face):
-                # a face is only parallel to a direction if it is a plane, and its normal is parallel to the dir
+            if isinstance(o, Face) and o.geomType() == "PLANE":
+                # a face is only parallel to a direction if it is a plane, and
+                # its normal is parallel to the dir
                 test_vector = o.normalAt(None)
-            elif isinstance(o, Edge) and (
-                o.geomType() == "LINE" or o.geomType() == "PLANE"
-            ):
+            elif isinstance(o, Edge) and o.geomType() == "LINE":
                 # an edge is parallel to a direction if its underlying geometry is plane or line
                 test_vector = o.tangentAt()
             else:

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -378,6 +378,7 @@ class RadiusNthSelector(_NthSelector):
         else:
             raise ValueError("Can not get a radius from this object")
 
+
 class CenterNthSelector(_NthSelector):
     """
     Sorts objects into a list with order determined by the distance of their center projected onto the specified direction.
@@ -387,11 +388,11 @@ class CenterNthSelector(_NthSelector):
     """
 
     def __init__(
-            self,
-            n: int,
-            vector: Vector,
-            directionMax: bool = True,
-            tolerance: float = 0.0001,
+        self,
+        n: int,
+        vector: Vector,
+        directionMax: bool = True,
+        tolerance: float = 0.0001,
     ):
         super().__init__(n, directionMax, tolerance)
         self.direction = vector
@@ -425,7 +426,9 @@ class DirectionMinMaxSelector(CenterNthSelector):
     def __init__(
         self, vector: Vector, directionMax: bool = True, tolerance: float = 0.0001
     ):
-        super().__init__(n=-1, vector=vector, directionMax=directionMax, tolerance=tolerance)
+        super().__init__(
+            n=-1, vector=vector, directionMax=directionMax, tolerance=tolerance
+        )
 
 
 # inherit from CenterNthSelector to get the CenterNthSelector.key method

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -386,8 +386,8 @@ class CenterNthSelector(_NthSelector):
 
     def __init__(
         self,
-        n: int,
         vector: Vector,
+        n: int,
         directionMax: bool = True,
         tolerance: float = 0.0001,
     ):
@@ -554,6 +554,9 @@ def _makeGrammar():
     # direction operator
     direction_op = oneOf([">", "<"])
 
+    # center Nth operator
+    center_nth_op = oneOf([">>", "<<"])
+
     # index definition
     ix_number = Group(Optional("-") + Word(nums))
     lsqbracket = Literal("[").suppress()
@@ -571,6 +574,7 @@ def _makeGrammar():
         direction("only_dir")
         | (type_op("type_op") + cqtype("cq_type"))
         | (direction_op("dir_op") + direction("dir") + Optional(index))
+        | (center_nth_op("center_nth_op") + direction("dir") + index)
         | (other_op("other_op") + direction("dir"))
         | named_view("named_view")
     )
@@ -608,7 +612,9 @@ class _SimpleStringSyntaxSelector(Selector):
 
         self.operatorMinMax = {
             ">": True,
+            ">>": True,
             "<": False,
+            "<<": False,
         }
 
         self.operator = {
@@ -642,6 +648,12 @@ class _SimpleStringSyntaxSelector(Selector):
                 )
             else:
                 return DirectionMinMaxSelector(vec, minmax)
+
+        elif "center_nth_op" in pr:
+            vec = self._getVector(pr)
+            minmax = self.operatorMinMax[pr.center_nth_op]
+
+            return CenterNthSelector(vec, int("".join(pr.index.asList())), minmax)
 
         elif "other_op" in pr:
             vec = self._getVector(pr)

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -19,7 +19,7 @@
 
 import math
 from .occ_impl.geom import Vector
-from .occ_impl.shapes import Shape, Edge, Face, Wire
+from .occ_impl.shapes import Shape, Edge, Face, Wire, geom_LUT_EDGE, geom_LUT_FACE
 from pyparsing import (
     Literal,
     Word,
@@ -544,7 +544,7 @@ def _makeGrammar():
 
     # CQ type definition
     cqtype = oneOf(
-        ["Plane", "Cylinder", "Sphere", "Cone", "Line", "Circle", "Arc"], caseless=True
+        set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()), caseless=True,
     )
     cqtype = cqtype.setParseAction(upcaseTokens)
 

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Master
+------
+### Breaking changes
+   * Fixed bug in ParallelDirSelector where non-planar faces could be selected. Note this will be breaking if you've used DirectionNthSelector and a non-planar face made it into your object list. In that case eg. ">X[2]" will have to become ">X[1]".
+
 2.0 (stable release)
 ------
 

--- a/doc/_static/tables.css
+++ b/doc/_static/tables.css
@@ -1,0 +1,6 @@
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+.wy-table-responsive {
+    overflow: visible;
+}

--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -178,6 +178,7 @@ as a basis for futher operations.
         PerpendicularDirSelector
         TypeSelector
         DirectionMinMaxSelector
+        CenterNthSelector
         BinarySelector
         AndSelector
         SumSelector

--- a/doc/classreference.rst
+++ b/doc/classreference.rst
@@ -60,10 +60,12 @@ Selector Classes
     BaseDirSelector
     ParallelDirSelector
     DirectionSelector
-    DirectionNthSelector
     PerpendicularDirSelector
     TypeSelector
+    RadiusNthSelector
+    CenterNthSelector
     DirectionMinMaxSelector
+    DirectionNthSelector
     BinarySelector
     AndSelector
     SumSelector

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,8 +26,10 @@ import cadquery
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
+
 def setup(app):
     app.add_css_file("tables.css")
+
 
 # -- General configuration -----------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,6 +26,9 @@ import cadquery
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
+def setup(app):
+    app.add_css_file("tables.css")
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -84,6 +84,8 @@ Selector    Selects                                    Selector Class
 <Y          Face farthest in the negative y dir        :py:class:`cadquery.DirectionMinMaxSelector`
 >Y[-2]      2nd farthest Face **normal** to the y dir  :py:class:`cadquery.DirectionNthSelector`
 <Y[0]       1st closest Face **normal** to the y dir   :py:class:`cadquery.DirectionNthSelector`
+>>Y[-2]     2nd farthest Face in the y dir             :py:class:`cadquery.CenterNthSelector`
+<<Y[0]      1st closest Face in the y dir              :py:class:`cadquery.CenterNthSelector`
 =========   =========================================  =======================================================
 
 
@@ -114,6 +116,8 @@ Selector  Selects                                               Selector Class
 <Y        Edges farthest in the negative y dir                  :py:class:`cadquery.DirectionMinMaxSelector`
 >Y[1]     2nd closest **parallel** edge in the positive y dir   :py:class:`cadquery.DirectionNthSelector`
 <Y[-2]    2nd farthest **parallel** edge in the negative y dir  :py:class:`cadquery.DirectionNthSelector`
+>>Y[-2]   2nd farthest edge in the y dir                        :py:class:`cadquery.CenterNthSelector`
+<<Y[0]    1st closest edge in the y dir                         :py:class:`cadquery.CenterNthSelector`
 ========  ====================================================  =============================================
 
 
@@ -129,6 +133,8 @@ Selector    Selects                                    Selector Class
 =========   =======================================    =======================================================
 >Y          Vertices farthest in the positive y dir    :py:class:`cadquery.DirectionMinMaxSelector`
 <Y          Vertices farthest in the negative y dir    :py:class:`cadquery.DirectionMinMaxSelector`
+>>Y[-2]     2nd farthest vertex in the y dir           :py:class:`cadquery.CenterNthSelector`
+<<Y[0]      1st closest vertex in the y dir            :py:class:`cadquery.CenterNthSelector`
 =========   =======================================    =======================================================
 
 User-defined Directions

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -7,53 +7,63 @@ String Selectors Reference
 CadQuery selector strings allow filtering various types of object lists. Most commonly, Edges, Faces, and Vertices are
 used, but all objects types can be filtered.
 
-String selectors are simply shortcuts for using the full object equivalents. If you pass one of the
-string patterns in, CadQuery will automatically use the associated selector object.
+Object lists are created by using the following methods, which each each collect a type of shape:
 
-    * :py:meth:`cadquery.Workplane.faces`
-    * :py:meth:`cadquery.Workplane.edges`
     * :py:meth:`cadquery.Workplane.vertices`
-    * :py:meth:`cadquery.Workplane.solids`
+    * :py:meth:`cadquery.Workplane.edges`
+    * :py:meth:`cadquery.Workplane.faces`
     * :py:meth:`cadquery.Workplane.shells`
+    * :py:meth:`cadquery.Workplane.solids`
+
+Each of these methods accepts either a Selector object or a string. String selectors are simply
+shortcuts for using the full object equivalents. If you pass one of the string patterns in,
+CadQuery will automatically use the associated selector object.
+
 
 .. note::
 
-    String selectors are shortcuts to concrete selector classes, which you can use or extend. See
-    :ref:`classreference` for more details
+    String selectors are simply shortcuts to concrete selector classes, which you can use or
+    extend. For a full description of how each selector class works, see :ref:`classreference`.
 
     If you find that the built-in selectors are not sufficient, you can easily plug in your own.
     See :ref:`extending` to see how.
 
 
 Combining Selectors
-==========================
+--------------------------
 
 Selectors can be combined logically, currently defined operators include **and**, **or**, **not** and **exc[ept]** (set difference).  For example:
 
 .. cadquery::
 
-    result = cq.Workplane("XY").box(2, 2, 2) \
-        .edges("|Z and >Y") \
+    result = (
+        cq.Workplane("XY")
+        .box(2, 2, 2)
+        .edges("|Z and >Y")
         .chamfer(0.2)
+    )
 
 Much more complex expressions are possible as well:
 
 .. cadquery::
 
-    result = cq.Workplane("XY").box(2, 2, 2) \
-        .faces(">Z") \
-        .shell(-0.2) \
-        .faces(">Z") \
-        .edges("not(<X or >X or <Y or >Y)") \
+    result = (
+        cq.Workplane("XY")
+        .box(2, 2, 2)
+        .faces(">Z")
+        .shell(-0.2)
+        .faces(">Z")
+        .edges("not(<X or >X or <Y or >Y)")
         .chamfer(0.1)
+    )
 
 .. _filteringfaces:
 
 Filtering Faces
 ----------------
 
-All types of filters work on faces.  In most cases, the selector refers to the direction of the **normal vector**
-of the face.
+All types of string selectors work on faces.  In most cases, the selector refers to the direction
+of the **normal vector** of the face.
 
 .. warning::
 
@@ -62,19 +72,19 @@ of the face.
 
 The axis used in the listing below are for illustration: any axis would work similarly in each case.
 
-=========   =======================================  =======================================================  ==========================
-Selector    Selects                                  Selector Class                                           # objects returned
-=========   =======================================  =======================================================  ==========================
-+Z          Faces with normal in +z direction        :py:class:`cadquery.DirectionSelector`                   0..many
-\|Z         Faces with normal parallel to z dir      :py:class:`cadquery.ParallelDirSelector`                 0..many
--X          Faces with normal in neg x direction     :py:class:`cadquery.DirectionSelector`                   0..many
-#Z          Faces with normal orthogonal to z dir    :py:class:`cadquery.PerpendicularDirSelector`            0..many
-%Plane      Faces of type plane                      :py:class:`cadquery.TypeSelector`                        0..many
->Y          Face farthest in the positive y dir      :py:class:`cadquery.DirectionMinMaxSelector`             0..many
-<Y          Face farthest in the negative y dir      :py:class:`cadquery.DirectionMinMaxSelector`             0..many
->Y[-2]      2nd farthest Face normal to the y dir    :py:class:`cadquery.DirectionNthSelector`                0..many
-<Y[0]       1st closest Face normal to the y dir     :py:class:`cadquery.DirectionNthSelector`                0..many
-=========   =======================================  =======================================================  ==========================
+=========   =========================================  =======================================================
+Selector    Selects                                    Selector Class
+=========   =========================================  =======================================================
++Z          Faces with normal in +z direction          :py:class:`cadquery.DirectionSelector`
+\|Z         Faces with normal parallel to z dir        :py:class:`cadquery.ParallelDirSelector`
+-X          Faces with normal in neg x direction       :py:class:`cadquery.DirectionSelector`
+#Z          Faces with normal orthogonal to z dir      :py:class:`cadquery.PerpendicularDirSelector`
+%Plane      Faces of type plane                        :py:class:`cadquery.TypeSelector`
+>Y          Face farthest in the positive y dir        :py:class:`cadquery.DirectionMinMaxSelector`
+<Y          Face farthest in the negative y dir        :py:class:`cadquery.DirectionMinMaxSelector`
+>Y[-2]      2nd farthest Face **normal** to the y dir  :py:class:`cadquery.DirectionNthSelector`
+<Y[0]       1st closest Face **normal** to the y dir   :py:class:`cadquery.DirectionNthSelector`
+=========   =========================================  =======================================================
 
 
 .. _filteringedges:
@@ -82,29 +92,29 @@ Selector    Selects                                  Selector Class             
 Filtering Edges
 ----------------
 
-Some filter types are not supported for edges.  The selector usually refers to the **direction** of the edge.
+Some filter types are not supported for edges. The selector usually refers to the **direction** of the edge.
 
 .. warning::
 
-    Non-linear edges are not selected for any selectors except type (%). Non-linear edges are never returned
-    when these filters are applied.
+    Non-linear edges are not selected for any string selectors except type (%). Non-linear edges
+    are never returned when these filters are applied.
 
 The axis used in the listing below are for illustration: any axis would work similarly in each case.
 
 
-=========   =======================================   =======================================================     ==========================
-Selector    Selects                                   Selector Class                                              # objects returned
-=========   =======================================   =======================================================     ==========================
-+Z          Edges aligned in the Z direction          :py:class:`cadquery.DirectionSelector`                      0..many
-\|Z         Edges parallel to z direction             :py:class:`cadquery.ParallelDirSelector`                    0..many
--X          Edges aligned in neg x direction          :py:class:`cadquery.DirectionSelector`                      0..many
-#Z          Edges perpendicular to z direction        :py:class:`cadquery.PerpendicularDirSelector`               0..many
-%Line       Edges of type line                        :py:class:`cadquery.TypeSelector`                           0..many
->Y          Edges farthest in the positive y dir      :py:class:`cadquery.DirectionMinMaxSelector`                0..many
-<Y          Edges farthest in the negative y dir      :py:class:`cadquery.DirectionMinMaxSelector`                0..many
->Y[1]       2nd closest edge in the positive y dir    :py:class:`cadquery.DirectionMinMaxSelector`                0..many
-<Y[-2]      2nd farthest edge in the negative y dir   :py:class:`cadquery.DirectionMinMaxSelector`                0..many
-=========   =======================================   =======================================================     ==========================
+========  ====================================================  =============================================
+Selector  Selects                                               Selector Class
+========  ====================================================  =============================================
++Z        Edges aligned in the Z direction                      :py:class:`cadquery.DirectionSelector`
+\|Z       Edges parallel to z direction                         :py:class:`cadquery.ParallelDirSelector`
+-X        Edges aligned in neg x direction                      :py:class:`cadquery.DirectionSelector`
+#Z        Edges perpendicular to z direction                    :py:class:`cadquery.PerpendicularDirSelector`
+%Line     Edges of type line                                    :py:class:`cadquery.TypeSelector`
+>Y        Edges farthest in the positive y dir                  :py:class:`cadquery.DirectionMinMaxSelector`
+<Y        Edges farthest in the negative y dir                  :py:class:`cadquery.DirectionMinMaxSelector`
+>Y[1]     2nd closest **parallel** edge in the positive y dir   :py:class:`cadquery.DirectionNthSelector`
+<Y[-2]    2nd farthest **parallel** edge in the negative y dir  :py:class:`cadquery.DirectionNthSelector`
+========  ====================================================  =============================================
 
 
 .. _filteringvertices:
@@ -112,14 +122,14 @@ Selector    Selects                                   Selector Class            
 Filtering Vertices
 -------------------
 
-Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter
+Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter.
 
-=========   =======================================    =======================================================     ==========================
-Selector    Selects                                    Selector Class                                              # objects returned
-=========   =======================================    =======================================================     ==========================
->Y          Vertices farthest in the positive y dir    :py:class:`cadquery.DirectionMinMaxSelector`                0..many
-<Y          Vertices farthest in the negative y dir    :py:class:`cadquery.DirectionMinMaxSelector`                0..many
-=========   =======================================    =======================================================     ==========================
+=========   =======================================    =======================================================
+Selector    Selects                                    Selector Class
+=========   =======================================    =======================================================
+>Y          Vertices farthest in the positive y dir    :py:class:`cadquery.DirectionMinMaxSelector`
+<Y          Vertices farthest in the negative y dir    :py:class:`cadquery.DirectionMinMaxSelector`
+=========   =======================================    =======================================================
 
 User-defined Directions
 -----------------------
@@ -128,7 +138,7 @@ It is possible to use user defined vectors as a basis for the selectors. For exa
 
 .. cadquery::
 
-    result = cq.Workplane("XY").box(10,10,10)
+    result = cq.Workplane("XY").box(10, 10, 10)
 
     # chamfer only one edge
-    result = result.edges('>(-1,1,0)').chamfer(1)
+    result = result.edges('>(-1, 1, 0)').chamfer(1)

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -94,12 +94,12 @@ Selector    Selects                                    Selector Class
 Filtering Edges
 ----------------
 
-Some filter types are not supported for edges. The selector usually refers to the **direction** of the edge.
+The selector usually refers to the **direction** of the edge.
 
 .. warning::
 
-    Non-linear edges are not selected for any string selectors except type (%). Non-linear edges
-    are never returned when these filters are applied.
+    Non-linear edges are not selected for any string selectors except type (%) and center (>>).
+    Non-linear edges are never returned when these filters are applied.
 
 The axis used in the listing below are for illustration: any axis would work similarly in each case.
 

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -7,7 +7,7 @@ String Selectors Reference
 CadQuery selector strings allow filtering various types of object lists. Most commonly, Edges, Faces, and Vertices are
 used, but all objects types can be filtered.
 
-Object lists are created by using the following methods, which each each collect a type of shape:
+Object lists are created by using the following methods, which each collect a type of shape:
 
     * :py:meth:`cadquery.Workplane.vertices`
     * :py:meth:`cadquery.Workplane.edges`

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -281,6 +281,24 @@ class TestCQSelectors(BaseTest):
         with self.assertRaises(IndexError):
             c.vertices(sel(Vector(0, 0, 1), 3))
 
+        # test string version
+        face1 = c.faces(">>X[-1]")
+        face2 = c.faces("<<(2,0,1)[0]")
+        face3 = c.faces("<<X[0]")
+
+        self.assertTrue(face1.val().isSame(face2.val()))
+        self.assertTrue(face1.val().isSame(face3.val()))
+
+        prism = Workplane().rect(2, 2).extrude(1, taper=30)
+
+        # CenterNth disregards orientation
+        edges1 = prism.edges(">>Z[-2]")
+        self.assertEqual(len(edges1.vals()), 4)
+
+        # DirectionNth does not
+        with self.assertRaises(ValueError):
+            prism.edges(">Z[-2]")
+
         # select a non-linear edge
         part = (
             Workplane()
@@ -789,6 +807,7 @@ class TestCQSelectors(BaseTest):
             "%Plane",
             ">XZ",
             "<Z[-2]",
+            "<<Z[2]",
             ">(1,4,55.)[20]",
             "|XY",
             "<YZ[0]",

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -203,7 +203,9 @@ class TestCQSelectors(BaseTest):
 
         left_face = c.faces(sel(0, Vector(1, 0, 0)))
         self.assertEqual(left_face.size(), 1)
-        self.assertTupleAlmostEquals((-0.5, 0, 0.5), left_face.val().Center().toTuple(), 3)
+        self.assertTupleAlmostEquals(
+            (-0.5, 0, 0.5), left_face.val().Center().toTuple(), 3
+        )
 
         middle_faces = c.faces(sel(1, Vector(1, 0, 0)))
         self.assertEqual(middle_faces.size(), 4)
@@ -212,7 +214,9 @@ class TestCQSelectors(BaseTest):
 
         right_face = c.faces(sel(2, Vector(1, 0, 0)))
         self.assertEqual(right_face.size(), 1)
-        self.assertTupleAlmostEquals((0.5, 0, 0.5), right_face.val().Center().toTuple(), 3)
+        self.assertTupleAlmostEquals(
+            (0.5, 0, 0.5), right_face.val().Center().toTuple(), 3
+        )
 
         with self.assertRaises(IndexError):
             c.faces(sel(3, Vector(1, 0, 0)))
@@ -242,13 +246,13 @@ class TestCQSelectors(BaseTest):
 
         # select a non-linear edge
         part = (
-             Workplane()
-             .rect(10, 10, centered=False)
-             .extrude(1)
-             .faces(">Z")
-             .workplane(centerOption="CenterOfMass")
-             .move(-3, 0)
-             .hole(2)
+            Workplane()
+            .rect(10, 10, centered=False)
+            .extrude(1)
+            .faces(">Z")
+            .workplane(centerOption="CenterOfMass")
+            .move(-3, 0)
+            .hole(2)
         )
         hole = part.faces(">Z").edges(sel(1, Vector(1, 0, 0)))
         # have we selected a single hole?
@@ -257,16 +261,22 @@ class TestCQSelectors(BaseTest):
 
         # select solids
         box0 = Workplane().box(1, 1, 1, centered=(True, True, True))
-        box1 = Workplane("XY", origin=(10, 10, 10)).box(1, 1, 1, centered=(True, True, True))
+        box1 = Workplane("XY", origin=(10, 10, 10)).box(
+            1, 1, 1, centered=(True, True, True)
+        )
         part = box0.add(box1)
         self.assertEqual(part.solids().size(), 2)
         for direction in [(0, 0, 1), (0, 1, 0), (1, 0, 0)]:
             box0_selected = part.solids(sel(0, Vector(direction)))
             self.assertEqual(1, box0_selected.size())
-            self.assertTupleAlmostEquals((0, 0, 0), box0_selected.val().Center().toTuple(), 3)
+            self.assertTupleAlmostEquals(
+                (0, 0, 0), box0_selected.val().Center().toTuple(), 3
+            )
             box1_selected = part.solids(sel(1, Vector(direction)))
             self.assertEqual(1, box0_selected.size())
-            self.assertTupleAlmostEquals((10, 10, 10), box1_selected.val().Center().toTuple(), 3)
+            self.assertTupleAlmostEquals(
+                (10, 10, 10), box1_selected.val().Center().toTuple(), 3
+            )
 
     def testMaxDistance(self):
         c = CQ(makeUnitCube())

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -162,7 +162,12 @@ class TestCQSelectors(BaseTest):
         self.assertNotEqual(c_curves.edges(), 0)
         self.assertEqual(c_curves.edges(loose_selector).size(), 0)
 
-        # leave faces until I figure out if it should only be PLANE or all faces
+        # this has a Face that is not a PLANE
+        face_dir = c_curves.faces().val().normalAt(None)
+        self.assertNotEqual(c_curves.faces(), 0)
+        self.assertEqual(
+            c_curves.faces(ParallelDirSelector(face_dir, tolerance=10)).size(), 0
+        )
 
         self.assertNotEqual(c.solids().size(), 0)
         self.assertEqual(c.solids(loose_selector).size(), 0)
@@ -290,6 +295,11 @@ class TestCQSelectors(BaseTest):
         # have we selected a single hole?
         self.assertEqual(1, hole.size())
         self.assertAlmostEqual(1, hole.val().radius())
+
+        # can we select a non-planar face?
+        hole_face = part.faces(sel(1, Vector(1, 0, 0)))
+        self.assertEqual(hole_face.size(), 1)
+        self.assertNotEqual(hole_face.val().geomType(), "PLANE")
 
         # select solids
         box0 = Workplane().box(1, 1, 1, centered=(True, True, True))

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -285,9 +285,11 @@ class TestCQSelectors(BaseTest):
         face1 = c.faces(">>X[-1]")
         face2 = c.faces("<<(2,0,1)[0]")
         face3 = c.faces("<<X[0]")
+        face4 = c.faces(">>X")
 
         self.assertTrue(face1.val().isSame(face2.val()))
         self.assertTrue(face1.val().isSame(face3.val()))
+        self.assertTrue(face1.val().isSame(face4.val()))
 
         prism = Workplane().rect(2, 2).extrude(1, taper=30)
 
@@ -808,6 +810,7 @@ class TestCQSelectors(BaseTest):
             ">XZ",
             "<Z[-2]",
             "<<Z[2]",
+            ">>(1,1,0)",
             ">(1,4,55.)[20]",
             "|XY",
             "<YZ[0]",

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -218,68 +218,68 @@ class TestCQSelectors(BaseTest):
         nothing = Workplane()
         self.assertEqual(nothing.solids().size(), 0)
         with self.assertRaises(ValueError):
-            nothing.solids(sel(0, Vector(0, 0, 1)))
+            nothing.solids(sel(Vector(0, 0, 1), 0))
 
         c = Workplane(makeUnitCube(centered=True))
 
-        bottom_face = c.faces(sel(0, Vector(0, 0, 1)))
+        bottom_face = c.faces(sel(Vector(0, 0, 1), 0))
         self.assertEqual(bottom_face.size(), 1)
         self.assertTupleAlmostEquals((0, 0, 0), bottom_face.val().Center().toTuple(), 3)
 
-        side_faces = c.faces(sel(1, Vector(0, 0, 1)))
+        side_faces = c.faces(sel(Vector(0, 0, 1), 1))
         self.assertEqual(side_faces.size(), 4)
         for f in side_faces.vals():
             self.assertAlmostEqual(0.5, f.Center().z)
 
-        top_face = c.faces(sel(2, Vector(0, 0, 1)))
+        top_face = c.faces(sel(Vector(0, 0, 1), 2))
         self.assertEqual(top_face.size(), 1)
         self.assertTupleAlmostEquals((0, 0, 1), top_face.val().Center().toTuple(), 3)
 
         with self.assertRaises(IndexError):
-            c.faces(sel(3, Vector(0, 0, 1)))
+            c.faces(sel(Vector(0, 0, 1), 3))
 
-        left_face = c.faces(sel(0, Vector(1, 0, 0)))
+        left_face = c.faces(sel(Vector(1, 0, 0), 0))
         self.assertEqual(left_face.size(), 1)
         self.assertTupleAlmostEquals(
             (-0.5, 0, 0.5), left_face.val().Center().toTuple(), 3
         )
 
-        middle_faces = c.faces(sel(1, Vector(1, 0, 0)))
+        middle_faces = c.faces(sel(Vector(1, 0, 0), 1))
         self.assertEqual(middle_faces.size(), 4)
         for f in middle_faces.vals():
             self.assertAlmostEqual(0, f.Center().x)
 
-        right_face = c.faces(sel(2, Vector(1, 0, 0)))
+        right_face = c.faces(sel(Vector(1, 0, 0), 2))
         self.assertEqual(right_face.size(), 1)
         self.assertTupleAlmostEquals(
             (0.5, 0, 0.5), right_face.val().Center().toTuple(), 3
         )
 
         with self.assertRaises(IndexError):
-            c.faces(sel(3, Vector(1, 0, 0)))
+            c.faces(sel(Vector(1, 0, 0), 3))
 
         # lower corner faces
-        self.assertEqual(c.faces(sel(0, Vector(1, 1, 1))).size(), 3)
+        self.assertEqual(c.faces(sel(Vector(1, 1, 1), 0)).size(), 3)
         # upper corner faces
-        self.assertEqual(c.faces(sel(1, Vector(1, 1, 1))).size(), 3)
+        self.assertEqual(c.faces(sel(Vector(1, 1, 1), 1)).size(), 3)
         with self.assertRaises(IndexError):
-            c.faces(sel(2, Vector(1, 1, 1)))
+            c.faces(sel(Vector(1, 1, 1), 2))
 
         for idx, z_val in zip([0, 1, 2], [0, 0.5, 1]):
-            edges = c.edges(sel(idx, Vector(0, 0, 1)))
+            edges = c.edges(sel(Vector(0, 0, 1), idx))
             self.assertEqual(edges.size(), 4)
             for e in edges.vals():
                 self.assertAlmostEqual(z_val, e.Center().z)
         with self.assertRaises(IndexError):
-            c.edges(sel(3, Vector(0, 0, 1)))
+            c.edges(sel(Vector(0, 0, 1), 3))
 
         for idx, z_val in zip([0, 1], [0, 1]):
-            vertices = c.vertices(sel(idx, Vector(0, 0, 1)))
+            vertices = c.vertices(sel(Vector(0, 0, 1), idx))
             self.assertEqual(vertices.size(), 4)
             for e in vertices.vals():
                 self.assertAlmostEqual(z_val, e.Z)
         with self.assertRaises(IndexError):
-            c.vertices(sel(3, Vector(0, 0, 1)))
+            c.vertices(sel(Vector(0, 0, 1), 3))
 
         # select a non-linear edge
         part = (
@@ -291,13 +291,13 @@ class TestCQSelectors(BaseTest):
             .move(-3, 0)
             .hole(2)
         )
-        hole = part.faces(">Z").edges(sel(1, Vector(1, 0, 0)))
+        hole = part.faces(">Z").edges(sel(Vector(1, 0, 0), 1))
         # have we selected a single hole?
         self.assertEqual(1, hole.size())
         self.assertAlmostEqual(1, hole.val().radius())
 
         # can we select a non-planar face?
-        hole_face = part.faces(sel(1, Vector(1, 0, 0)))
+        hole_face = part.faces(sel(Vector(1, 0, 0), 1))
         self.assertEqual(hole_face.size(), 1)
         self.assertNotEqual(hole_face.val().geomType(), "PLANE")
 
@@ -309,12 +309,12 @@ class TestCQSelectors(BaseTest):
         part = box0.add(box1)
         self.assertEqual(part.solids().size(), 2)
         for direction in [(0, 0, 1), (0, 1, 0), (1, 0, 0)]:
-            box0_selected = part.solids(sel(0, Vector(direction)))
+            box0_selected = part.solids(sel(Vector(direction), 0))
             self.assertEqual(1, box0_selected.size())
             self.assertTupleAlmostEquals(
                 (0, 0, 0), box0_selected.val().Center().toTuple(), 3
             )
-            box1_selected = part.solids(sel(1, Vector(direction)))
+            box1_selected = part.solids(sel(Vector(direction), 1))
             self.assertEqual(1, box0_selected.size())
             self.assertTupleAlmostEquals(
                 (10, 10, 10), box1_selected.val().Center().toTuple(), 3

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -100,6 +100,16 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(0, c.faces("%cone").size())
         self.assertEqual(0, c.faces("%SPHERE").size())
 
+    def testEdgeTypesFilter(self):
+        "Filters by edge type"
+        c = Workplane().ellipse(3, 4).circle(1).extrude(1)
+        self.assertEqual(2, c.edges("%Ellipse").size())
+        self.assertEqual(2, c.edges("%circle").size())
+        self.assertEqual(2, c.edges("%LINE").size())
+        self.assertEqual(0, c.edges("%Bspline").size())
+        self.assertEqual(0, c.edges("%Offset").size())
+        self.assertEqual(0, c.edges("%HYPERBOLA").size())
+
     def testPerpendicularDirFilter(self):
         c = CQ(makeUnitCube())
 

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -146,7 +146,7 @@ class TestCQSelectors(BaseTest):
         self.assertNotEqual(c.faces("+X").val().Center(), c.faces("-X").val().Center())
 
     def testParallelPlaneFaceFilter(self):
-        c = CQ(makeUnitCube())
+        c = CQ(makeUnitCube(centered=False))
 
         # faces parallel to Z axis
         # these two should produce the same behaviour:
@@ -161,6 +161,13 @@ class TestCQSelectors(BaseTest):
 
         # just for fun, vertices on faces parallel to z
         self.assertEqual(8, c.faces("|Z").vertices().size())
+
+        # check that the X & Y center of these faces is the same as the box (ie. we haven't selected the wrong face)
+        faces = c.faces(selectors.ParallelDirSelector(Vector((0, 0, 1)))).vals()
+        for f in faces:
+            c = f.Center()
+            self.assertAlmostEqual(c.x, 0.5)
+            self.assertAlmostEqual(c.y, 0.5)
 
     def testParallelEdgeFilter(self):
         c = CQ(makeUnitCube())


### PR DESCRIPTION
This PR will close #517 and add a CenterNthSelector to resolve #530. I touched a few other things as well, sorry for lumping them all in one PR but I've at least rebased all the commits into neat chunks.

---

Commit 6d2f3ba adds _NthSelector. It is an abstract class, it should only be inherited from, not instantiated.

Previously DirectionNthSelector lumped objects at a similar distance together by rounding that distance to a certain number of decimal places. This would mean that with a tolerance of 0.1, 0.249999999 and 0.250000001 would be put into seperate bins. So I've changed it to a simple clustering method. It's not perfect, but it's simple and I think it's an improvement over the previous one.

These two commits should not change or add any behaviour to CQ (except to remove that rounding issue). All our previous tests pass with these two new commits.

---

344651d added CenterNthSelector, to select the Nth object/objects along a direction. Similar to DirectionNthSelector, but without running them through ParallelDirSelector first.

Now DirectionMinMaxSelector can become a simple subclass of CenterNthSelector with the index set to -1.

---

Previously "Combining Selectors" appeared as a top level item on the side bar menu.
![screenshot2020-12-18-111717](https://user-images.githubusercontent.com/50230945/102577420-f5f6ae80-4147-11eb-9a2c-359a84b83337.png)

After a242473:
![screenshot2020-12-18-154652](https://user-images.githubusercontent.com/50230945/102577624-4b32c000-4148-11eb-8555-7b47d190f5dd.png)


---

While looking at the docs I noticed the tables were overflowing and it was hard to read. 

![screenshot2020-12-18-154812](https://user-images.githubusercontent.com/50230945/102577701-77e6d780-4148-11eb-8029-2986bb417d88.png)

4486381 adds some extra CSS from [here](https://github.com/readthedocs/sphinx_rtd_theme/issues/117) to change this behaviour, now tables (such as the Class Summary) line wrap. I've quickly checked all the pages in the HTML docs and I can't see any problems, I think it's only improved things. Now:

![screenshot2020-12-18-154905](https://user-images.githubusercontent.com/50230945/102577764-96e56980-4148-11eb-9f06-05417b03f9d9.png)

---

I've tried to add mypy type hints throughout all this, but I'm going to have to ask for help from the mypy gurus for one bit. I can't see why mypy errors on `RadiusNthSelector.filter`. I'm leaving this as a draft PR until I get the mypy errors sorted.