### PR TITLE
Expose makeWire to parametricCurve

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1746,6 +1746,7 @@ class Workplane(object):
         N: int = 400,
         start: float = 0,
         stop: float = 1,
+        makeWire: bool = True,
     ) -> "Workplane":
         """
         Create a spline interpolated through the provided points.
@@ -1755,6 +1756,7 @@ class Workplane(object):
         :param N: number of points for discretization
         :param start: starting value of the parameter t
         :param stop: final value of the parameter t
+        :param makeWire: convert the resulting spline edge to a wire
         :return: a Workplane object with the current point unchanged
 
         """
@@ -1762,7 +1764,7 @@ class Workplane(object):
         diff = stop - start
         allPoints = [func(start + diff * t / N) for t in range(N + 1)]
 
-        return self.spline(allPoints, includeCurrent=False, makeWire=True)
+        return self.spline(allPoints, includeCurrent=False, makeWire=makeWire)
 
     def ellipseArc(
         self,


### PR DESCRIPTION
The use case - creating a complex wire made up of multiple parametricCurves or a combination of parametricCurves and other 2d operations. I think the only way currently would be to create each parametricCurve individually (creating separate spline wires) and then using Wire.combine() at the end, which seems messy.