### PR TITLE
Expose SVG Export Options and Add Some Useful Extras

### DIFF
--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -48,6 +48,7 @@ def export(
     :param exportType: the exportFormat to use. If None will be inferred from the extension. Default: None.
     :param tolerance: the deflection tolerance, in model units. Default 0.1.
     :param angularTolerance: the angular tolerance, in radians. Default 0.1.
+    :param opt: additional options passed to the specific exporter. Default None.
     """
 
     shape: Shape

--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -37,12 +37,12 @@ def export(
     exportType: Optional[ExportLiterals] = None,
     tolerance: float = 0.1,
     angularTolerance: float = 0.1,
-    opt = None
+    opt=None,
 ):
 
     """
     Export Wokrplane or Shape to file. Multiple entities are converted to compound.
-    
+
     :param w:  Shape or Wokrplane to be exported.
     :param fname: output filename.
     :param exportType: the exportFormat to use. If None will be inferred from the extension. Default: None.
@@ -126,14 +126,14 @@ def exportShape(
     angularTolerance: float = 0.1,
 ):
     """
-        :param shape:  the shape to export. it can be a shape object, or a cadquery object. If a cadquery
-        object, the first value is exported
-        :param exportType: the exportFormat to use
-        :param fileLike: a file like object to which the content will be written.
-        The object should be already open and ready to write. The caller is responsible
-        for closing the object
-        :param tolerance: the linear tolerance, in model units. Default 0.1.
-        :param angularTolerance: the angular tolerance, in radians. Default 0.1.
+    :param shape:  the shape to export. it can be a shape object, or a cadquery object. If a cadquery
+    object, the first value is exported
+    :param exportType: the exportFormat to use
+    :param fileLike: a file like object to which the content will be written.
+    The object should be already open and ready to write. The caller is responsible
+    for closing the object
+    :param tolerance: the linear tolerance, in model units. Default 0.1.
+    :param angularTolerance: the angular tolerance, in radians. Default 0.1.
     """
 
     def tessellate(shape, angularTolerance):
@@ -189,8 +189,8 @@ def exportShape(
 @deprecate()
 def readAndDeleteFile(fileName):
     """
-        read data from file provided, and delete it when done
-        return the contents as a string
+    Read data from file provided, and delete it when done
+    return the contents as a string
     """
     res = ""
     with open(fileName, "r") as f:

--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -37,6 +37,7 @@ def export(
     exportType: Optional[ExportLiterals] = None,
     tolerance: float = 0.1,
     angularTolerance: float = 0.1,
+    opt = None
 ):
 
     """
@@ -81,7 +82,7 @@ def export(
 
     elif exportType == ExportTypes.SVG:
         with open(fname, "w") as f:
-            f.write(getSVG(shape))
+            f.write(getSVG(shape, opt))
 
     elif exportType == ExportTypes.AMF:
         tess = shape.tessellate(tolerance, angularTolerance)

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -263,16 +263,8 @@ def getSVG(shape, opts=None):
         {
             "unitScale": str(unitScale),
             "strokeWidth": str(strokeWidth),
-            "strokeColor": str(strokeColor[0])
-            + ","
-            + str(strokeColor[1])
-            + ","
-            + str(strokeColor[2]),
-            "hiddenColor": str(hiddenColor[0])
-            + ","
-            + str(hiddenColor[1])
-            + ","
-            + str(hiddenColor[2]),
+            "strokeColor": ",".join([str(x) for x in strokeColor]),
+            "hiddenColor": ",".join([str(x) for x in hiddenColor]),
             "hiddenContent": hiddenContent,
             "visibleContent": visibleContent,
             "xTranslate": str(xTranslate),

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -61,7 +61,7 @@ class UNITS:
 
 def guessUnitOfMeasure(shape):
     """
-        Guess the unit of measure of a shape.
+    Guess the unit of measure of a shape.
     """
     bb = BoundBox._fromTopoDS(shape.wrapped)
 
@@ -83,7 +83,7 @@ def guessUnitOfMeasure(shape):
 
 def makeSVGedge(e):
     """
-
+    Creates an SVG edge from a OCCT edge.
     """
 
     cs = StringIO.StringIO()
@@ -108,7 +108,7 @@ def makeSVGedge(e):
 
 def getPaths(visibleShapes, hiddenShapes):
     """
-
+    Collects the visible and hidden edges from the CadQuery object.
     """
 
     hiddenPaths = []
@@ -127,21 +127,22 @@ def getPaths(visibleShapes, hiddenShapes):
 
 def getSVG(shape, opts=None):
     """
-        Export a shape to SVG
+    Export a shape to SVG
     """
 
     # Available options and their defaults
-    d = {"width": 800,
-         "height": 240,
-         "marginLeft": 200,
-         "marginTop": 20,
-         "projectionDir": (-1.75, 1.1, 5),
-         "showAxes": True,
-         "strokeWidth": -1.0, # -1 = calculated based on unitScale
-         "strokeColor": (0, 0, 0), # RGB 0-255
-         "hiddenColor": (160, 160, 160), #RGB 0-255
-         "showHidden": True
-        }
+    d = {
+        "width": 800,
+        "height": 240,
+        "marginLeft": 200,
+        "marginTop": 20,
+        "projectionDir": (-1.75, 1.1, 5),
+        "showAxes": True,
+        "strokeWidth": -1.0,  # -1 = calculated based on unitScale
+        "strokeColor": (0, 0, 0),  # RGB 0-255
+        "hiddenColor": (160, 160, 160),  # RGB 0-255
+        "showHidden": True,
+    }
 
     if opts:
         d.update(opts)
@@ -237,11 +238,7 @@ def getSVG(shape, opts=None):
     # If the caller wants the axes indicator and is using the default direction, add in the indicator
     if showAxes and projectionDir == (-1.75, 1.1, 5):
         axesIndicator = AXES_TEMPLATE % (
-            {
-                "unitScale": str(unitScale),
-                "textboxY": str(height - 30),
-                "uom": str(uom)
-            }
+            {"unitScale": str(unitScale), "textboxY": str(height - 30), "uom": str(uom)}
         )
     else:
         axesIndicator = ""
@@ -250,8 +247,16 @@ def getSVG(shape, opts=None):
         {
             "unitScale": str(unitScale),
             "strokeWidth": str(strokeWidth),
-            "strokeColor": str(strokeColor[0]) + "," + str(strokeColor[1]) + "," + str(strokeColor[2]),
-            "hiddenColor": str(hiddenColor[0]) + "," + str(hiddenColor[1]) + "," +  str(hiddenColor[2]),
+            "strokeColor": str(strokeColor[0])
+            + ","
+            + str(strokeColor[1])
+            + ","
+            + str(strokeColor[2]),
+            "hiddenColor": str(hiddenColor[0])
+            + ","
+            + str(hiddenColor[1])
+            + ","
+            + str(hiddenColor[2]),
             "hiddenContent": hiddenContent,
             "visibleContent": visibleContent,
             "xTranslate": str(xTranslate),
@@ -260,18 +265,18 @@ def getSVG(shape, opts=None):
             "height": str(height),
             "textboxY": str(height - 30),
             "uom": str(uom),
-            "axesIndicator": axesIndicator
+            "axesIndicator": axesIndicator,
         }
     )
 
     return svg
 
 
-def exportSVG(shape, fileName: str, opts = None):
+def exportSVG(shape, fileName: str, opts=None):
     """
-        accept a cadquery shape, and export it to the provided file
-        TODO: should use file-like objects, not a fileName, and/or be able to return a string instead
-        export a view of a part to svg
+    Accept a cadquery shape, and export it to the provided file
+    TODO: should use file-like objects, not a fileName, and/or be able to return a string instead
+    export a view of a part to svg
     """
 
     svg = getSVG(shape.val(), opts)

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -127,7 +127,23 @@ def getPaths(visibleShapes, hiddenShapes):
 
 def getSVG(shape, opts=None):
     """
-    Export a shape to SVG
+    Export a shape to SVG text.
+
+    :param shape: A CadQuery shape object to convert to an SVG string.
+    :type Shape: Vertex, Edge, Wire, Face, Shell, Solid, or Compound.
+    :param opts: An options dictionary that influences the SVG that is output.
+    :type opts: Dictionary, keys are as follows:
+        width: Document width of the resulting image.
+        height: Document height of the resulting image.
+        marginLeft: Inset margin from the left side of the document.
+        marginTop: Inset margin from the top side of the document.
+        projectionDir: Direction the camera will view the shape from.
+        showAxes: Whether or not to show the axes indicator, which will only be
+                  visible when the projectionDir is also at the default.
+        strokeWidth: Width of the line that visible edges are drawn with.
+        strokeColor: Color of the line that visible edges are drawn with.
+        hiddenColor: Color of the line that hidden edges are drawn with.
+        showHidden: Whether or not to show hidden lines.
     """
 
     # Available options and their defaults

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -32,22 +32,23 @@ SVG_TEMPLATE = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 %(visibleContent)s
        </g>
     </g>
-    <g transform="translate(20,%(textboxY)s)" stroke="rgb(0,0,255)">
-        <line x1="30" y1="-30" x2="75" y2="-33" stroke-width="3" stroke="#000000" />
-         <text x="80" y="-30" style="stroke:#000000">X </text>
-
-        <line x1="30" y1="-30" x2="30" y2="-75" stroke-width="3" stroke="#000000" />
-         <text x="25" y="-85" style="stroke:#000000">Y </text>
-
-        <line x1="30" y1="-30" x2="58" y2="-15" stroke-width="3" stroke="#000000" />
-         <text x="65" y="-5" style="stroke:#000000">Z </text>
-        <!--
-            <line x1="0" y1="0" x2="%(unitScale)s" y2="0" stroke-width="3" />
-            <text x="0" y="20" style="stroke:#000000">1  %(uom)s </text>
-        -->
-    </g>
 </svg>
 """
+
+    # <g transform="translate(20,%(textboxY)s)" stroke="rgb(0,0,255)">
+    #     <line x1="30" y1="-30" x2="75" y2="-33" stroke-width="3" stroke="#000000" />
+    #      <text x="80" y="-30" style="stroke:#000000">X </text>
+
+    #     <line x1="30" y1="-30" x2="30" y2="-75" stroke-width="3" stroke="#000000" />
+    #      <text x="25" y="-85" style="stroke:#000000">Y </text>
+
+    #     <line x1="30" y1="-30" x2="58" y2="-15" stroke-width="3" stroke="#000000" />
+    #      <text x="65" y="-5" style="stroke:#000000">Z </text>
+    #     <!--
+    #         <line x1="0" y1="0" x2="%(unitScale)s" y2="0" stroke-width="3" />
+    #         <text x="0" y="20" style="stroke:#000000">1  %(uom)s </text>
+    #     -->
+    # </g>
 
 PATHTEMPLATE = '\t\t\t<path d="%s" />\n'
 
@@ -128,7 +129,7 @@ def getSVG(shape, opts=None):
         Export a shape to SVG
     """
 
-    d = {"width": 800, "height": 240, "marginLeft": 200, "marginTop": 20}
+    d = {"width": 800, "height": 240, "marginLeft": 200, "marginTop": 20, "projectionDir": (-1.75, 1.1, 5)}
 
     if opts:
         d.update(opts)
@@ -140,11 +141,12 @@ def getSVG(shape, opts=None):
     height = float(d["height"])
     marginLeft = float(d["marginLeft"])
     marginTop = float(d["marginTop"])
+    projectionDir = gp_Dir(*tuple(d["projectionDir"]))
 
     hlr = HLRBRep_Algo()
     hlr.Add(shape.wrapped)
 
-    projector = HLRAlgo_Projector(gp_Ax2(gp_Pnt(), DEFAULT_DIR))
+    projector = HLRAlgo_Projector(gp_Ax2(gp_Pnt(), projectionDir))
 
     hlr.Projector(projector)
     hlr.Update()
@@ -190,7 +192,7 @@ def getSVG(shape, opts=None):
     # get bounding box -- these are all in 2-d space
     bb = Compound.makeCompound(hidden + visible).BoundingBox()
 
-    # width pixels for x, height pixesl for y
+    # width pixels for x, height pixels for y
     unitScale = min(width / bb.xlen * 0.75, height / bb.ylen * 0.75)
 
     # compute amount to translate-- move the top left into view
@@ -199,7 +201,7 @@ def getSVG(shape, opts=None):
         (0 - bb.ymax) - marginTop / unitScale,
     )
 
-    # compute paths ( again -- had to strip out freecad crap )
+    # compute paths
     hiddenContent = ""
     for p in hiddenPaths:
         hiddenContent += PATHTEMPLATE % p
@@ -228,14 +230,14 @@ def getSVG(shape, opts=None):
     return svg
 
 
-def exportSVG(shape, fileName: str):
+def exportSVG(shape, fileName: str, opts = None):
     """
         accept a cadquery shape, and export it to the provided file
         TODO: should use file-like objects, not a fileName, and/or be able to return a string instead
         export a view of a part to svg
     """
 
-    svg = getSVG(shape.val())
+    svg = getSVG(shape.val(), opts)
     f = open(fileName, "w")
     f.write(svg)
     f.close()

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -44,12 +44,17 @@ class TestExporters(BaseTest):
 
         exporters.export(self._box(), "out.stl")
 
-    def testSTLOptions(self):
-        self._exportBox(exporters.ExportTypes.STL, ["facet normal"])
+    def testSVG(self):
+        self._exportBox(exporters.ExportTypes.SVG, ["<svg", "<g transform"])
+
+        exporters.export(self._box(), "out.svg")
+
+    def testSVGOptions(self):
+        self._exportBox(exporters.ExportTypes.SVG, ["<svg", "<g transform"])
 
         exporters.export(
             self._box(),
-            "out.stl",
+            "out.svg",
             opt={
                 "width": 100,
                 "height": 100,
@@ -63,11 +68,6 @@ class TestExporters(BaseTest):
                 "showHidden": True,
             },
         )
-
-    def testSVG(self):
-        self._exportBox(exporters.ExportTypes.SVG, ["<svg", "<g transform"])
-
-        exporters.export(self._box(), "out.svg")
 
     def testAMF(self):
         self._exportBox(exporters.ExportTypes.AMF, ["<amf units", "</object>"])

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -55,7 +55,7 @@ class TestExporters(BaseTest):
                 "height": 100,
                 "marginLeft": 10,
                 "marginTop": 10,
-                "showAxes": True,
+                "showAxes": False,
                 "projectionDir": (0, 0, 1),
                 "strokeWidth": 0.25,
                 "strokeColor": (255, 0, 0),

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -44,6 +44,26 @@ class TestExporters(BaseTest):
 
         exporters.export(self._box(), "out.stl")
 
+    def testSTLOptions(self):
+        self._exportBox(exporters.ExportTypes.STL, ["facet normal"])
+
+        exporters.export(
+            self._box(),
+            "out.stl",
+            opt={
+                "width": 100,
+                "height": 100,
+                "marginLeft": 10,
+                "marginTop": 10,
+                "showAxes": True,
+                "projectionDir": (0, 0, 1),
+                "strokeWidth": 0.25,
+                "strokeColor": (255, 0, 0),
+                "hiddenColor": (0, 0, 255),
+                "showHidden": True,
+            },
+        )
+
     def testSVG(self):
         self._exportBox(exporters.ExportTypes.SVG, ["<svg", "<g transform"])
 


### PR DESCRIPTION
I'm still working on this, but wanted to get it out in the open to get feedback.

Exposed the `getSVG()` 'opt' parameter so that things like height, width and margins could be controlled. Also added a projection direction opt to control the projection view of the shape. The following code currently works with this fork/branch:
```python
import cadquery as cq
from cadquery import exporters

result = cq.Workplane("XY").circle(1.0)

exporters.export(result,
                 "/home/jwright/Downloads/out.svg",
                 opt={"width": 100,
                      "height": 100,
                      "marginLeft": 10,
                      "marginTop": 10,
                      "projectionDir": (0, 0, 1)})
```
There's been some discussion around SVGs and HLR lately, so feedback is welcome. I'll share on Discord to get feedback as well.

Tagging @adam-urbanczyk and @marcus7070 