### PR TITLE
Fix ellipse documentation formatting

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2304,6 +2304,7 @@ class Workplane(object):
     ) -> "Workplane":
         """
         Make an ellipse for each item on the stack.
+
         :param x_radius: x radius of the ellipse (x-axis of plane the ellipse should lie in)
         :type x_radius: float > 0
         :param y_radius: y radius of the ellipse (y-axis of plane the ellipse should lie in)


### PR DESCRIPTION
An empty line is missing after ellipse short summary, causing the whole
text to be inserted to API Reference
(http://cadquery.readthedocs.io/en/latest/apireference.html)