### PR TITLE
Move to OCCT/OCP 7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
 - conda env create -f environment.yml
 - source ~/miniconda/bin/activate cadquery
 - conda install -c conda-forge -c defaults -c cadquery python=$PYTHON_VERSION mypy
-- pip install git+https://github.com/CadQuery/OCP-stubs.git
+- pip install git+https://github.com/CadQuery/OCP-stubs.git@7.5.1
 
 install:
 - python setup.py install

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -4,6 +4,7 @@ from typing_extensions import Protocol
 from OCP.TDocStd import TDocStd_Document
 from OCP.TCollection import TCollection_ExtendedString
 from OCP.XCAFDoc import XCAFDoc_DocumentTool, XCAFDoc_ColorType
+from OCP.XCAFApp import XCAFApp_Application
 from OCP.TDataStd import TDataStd_Name
 from OCP.TDF import TDF_Label
 from OCP.TopLoc import TopLoc_Location
@@ -104,7 +105,11 @@ def toCAF(
 ) -> Tuple[TDF_Label, TDocStd_Document]:
 
     # prepare a doc
+    app = XCAFApp_Application.GetApplication_s()
+
     doc = TDocStd_Document(TCollection_ExtendedString("XmlOcaf"))
+    app.InitDocument(doc)
+
     tool = XCAFDoc_DocumentTool.ShapeTool_s(doc.Main())
     tool.SetAutoNaming_s(False)
     ctool = XCAFDoc_DocumentTool.ColorTool_s(doc.Main())

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -148,12 +148,15 @@ from OCP.BRepCheck import BRepCheck_Analyzer
 
 from OCP.Font import (
     Font_FontMgr,
-    Font_BRepTextBuilder,
     Font_FA_Regular,
     Font_FA_Italic,
     Font_FA_Bold,
     Font_SystemFont,
 )
+
+from OCP.StdPrs import StdPrs_BRepFont, StdPrs_BRepTextBuilder as Font_BRepTextBuilder
+
+from OCP.NCollection import NCollection_Utf8String
 
 from OCP.BRepFeat import BRepFeat_MakeDPrism
 
@@ -2740,8 +2743,9 @@ class Compound(Shape, Mixin3D):
             font_t = mgr.FindFont(TCollection_AsciiString(font), font_kind)
 
         builder = Font_BRepTextBuilder()
+        font_i = StdPrs_BRepFont(NCollection_Utf8String(font_t.FontName().ToCString()), font_kind, size)
         text_flat = Shape(
-            builder.Perform(font_t.FontName().ToCString(), size, font_kind, text)
+            builder.Perform(font_i, NCollection_Utf8String(text))
         )
 
         bb = text_flat.BoundingBox()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2743,10 +2743,10 @@ class Compound(Shape, Mixin3D):
             font_t = mgr.FindFont(TCollection_AsciiString(font), font_kind)
 
         builder = Font_BRepTextBuilder()
-        font_i = StdPrs_BRepFont(NCollection_Utf8String(font_t.FontName().ToCString()), font_kind, size)
-        text_flat = Shape(
-            builder.Perform(font_i, NCollection_Utf8String(text))
+        font_i = StdPrs_BRepFont(
+            NCollection_Utf8String(font_t.FontName().ToCString()), font_kind, size
         )
+        text_flat = Shape(builder.Perform(font_i, NCollection_Utf8String(text)))
 
         bb = text_flat.BoundingBox()
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - setuptools
   run:
     - python {{ environ.get('PYTHON_VERSION') }}
-    - ocp 7.4
+    - ocp 7.5
     - pyparsing 2.*
     - ezdxf
     - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.6
   - ipython
-  - ocp=7.4
+  - ocp=7.5
   - pyparsing
   - sphinx=3.2.1
   - sphinx_rtd_theme

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3495,7 +3495,7 @@ class TestCadQuery(BaseTest):
         surface_points = [[-3.0, -3.0, -3.0], [3.0, 3.0, 3.0]]
         plate_1 = Workplane("XY").interpPlate(edge_wire, surface_points, thickness)
         self.assertTrue(plate_1.val().isValid())
-        self.assertAlmostEqual(plate_1.val().Volume(), 26.124970206, 3)
+        self.assertAlmostEqual(plate_1.val().Volume(), 26.124970206, 2)
 
         # Embossed star, need to change optional parameters to obtain nice looking result.
         r1 = 3.0
@@ -3627,7 +3627,7 @@ class TestCadQuery(BaseTest):
         surface_points = [[0, 0, 0]]
         plate_4 = Workplane("XY").interpPlate(edge_wire, surface_points, thickness)
         self.assertTrue(plate_4.val().isValid())
-        self.assertAlmostEqual(plate_4.val().Volume(), 7.760559490, 3)
+        self.assertAlmostEqual(plate_4.val().Volume(), 7.760559490, 2)
 
     def testTangentArcToPoint(self):
 


### PR DESCRIPTION
Will resolve #564

- [x] Compile OCP 7.5.1
- [x] Fix missing function on Windows
- [x] Generate stubs
- [x] Fix assy crash on CQ-editor (see https://github.com/CadQuery/CQ-editor/pull/238)