### PR TITLE
findSolid errors

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -236,8 +236,8 @@ class Workplane(object):
 
         :param boolean keepTop: True to keep the top, False or None to discard it
         :param boolean keepBottom: True to keep the bottom, False or None to discard it
-        :raises: ValueError if keepTop and keepBottom are both false.
-        :raises: ValueError if there is not a solid in the current stack or the parent chain
+        :raises ValueError: if keepTop and keepBottom are both false.
+        :raises ValueError: if there is no solid in the current stack or parent chain
         :returns: CQ object with the desired objects on the stack.
 
         The most common operation splits a solid and keeps one half. This sample creates
@@ -1118,7 +1118,7 @@ class Workplane(object):
         :param thickness: a positive float, representing the thickness of the desired shell.
             Negative values shell inwards, positive values shell outwards.
         :param kind: kind of joints, intersetion or arc (default: arc).
-        :raises: ValueError if the current stack contains objects that are not faces of a solid
+        :raises ValueError: if the current stack contains objects that are not faces of a solid
              further up in the chain.
         :returns: a CQ object with the resulting shelled solid selected.
 
@@ -1162,15 +1162,14 @@ class Workplane(object):
 
         :param radius: the radius of the fillet, must be > zero
         :type radius: positive float
-        :raises: ValueError if at least one edge is not selected
-        :raises: ValueError if the solid containing the edge is not in the chain
+        :raises ValueError: if at least one edge is not selected
+        :raises ValueError: if the solid containing the edge is not in the chain
         :returns: cq object with the resulting solid selected.
 
         This example will create a unit cube, with the top edges filleted::
 
             s = Workplane().box(1,1,1).faces("+Z").edges().fillet(0.1)
         """
-        # TODO: we will need much better edge selectors for this to work
         # TODO: ensure that edges selected actually belong to the solid in the chain, otherwise,
         # TODO: we segfault
 
@@ -1199,8 +1198,8 @@ class Workplane(object):
         :param length2: optional parameter for asymmetrical chamfer
         :type length: positive float
         :type length2: positive float
-        :raises: ValueError if at least one edge is not selected
-        :raises: ValueError if the solid containing the edge is not in the chain
+        :raises ValueError: if at least one edge is not selected
+        :raises ValueError: if the solid containing the edge is not in the chain
         :returns: cq object with the resulting solid selected.
 
         This example will create a unit cube, with the top edges chamfered::
@@ -2515,8 +2514,11 @@ class Workplane(object):
     def largestDimension(self) -> float:
         """
         Finds the largest dimension in the stack.
+
         Used internally to create thru features, this is how you can compute
         how long or wide a feature must be to make sure to cut through all of the material
+
+        :raises ValueError: if no solids or compounds are found
         :return: A value representing the largest dimension of the first solid on the stack
         """
         # Get all the solids contained within this CQ object
@@ -2536,8 +2538,8 @@ class Workplane(object):
         :param fcn: a function suitable for use in the eachpoint method: ie, that accepts a vector
         :param useLocalCoords: same as for :py:meth:`eachpoint`
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :raises ValueError: if no solids or compounds are found in the stack or parent chain
         :return: a CQ object that contains the resulting solid
-        :raises: an error if there is not a context solid to cut from
         """
         ctxSolid = self.findSolid()
 
@@ -3058,7 +3060,7 @@ class Workplane(object):
         :param toCut: object to cut
         :type toCut: a solid object, or a CQ object having a solid,
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :raises: ValueError if there is no solid to subtract from in the chain
+        :raises ValueError: if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected
         """
 
@@ -3103,7 +3105,7 @@ class Workplane(object):
         :param toIntersect: object to intersect
         :type toIntersect: a solid object, or a CQ object having a solid,
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :raises: ValueError if there is no solid to intersect with in the chain
+        :raises ValueError: if there is no solid to intersect with in the chain
         :return: a CQ object with the resulting object selected
         """
 
@@ -3153,7 +3155,7 @@ class Workplane(object):
             <0 means in the negative direction
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
         :param float taper: angle for optional tapered extrusion
-        :raises: ValueError if there is no solid to subtract from in the chain
+        :raises ValueError: if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected
 
         see :py:meth:`cutThruAll` to cut material from the entire part
@@ -3183,7 +3185,7 @@ class Workplane(object):
         from. cutThruAll always removes material from a part.
 
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :raises: ValueError if there is no solid to subtract from in the chain
+        :raises ValueError: if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected
 
         see :py:meth:`cutBlind` to cut material to a limited depth
@@ -3761,6 +3763,7 @@ class Workplane(object):
         Slices current solid at the given height.
 
         :param float height: height to slice at (default: 0)
+        :raises ValueError: if no solids or compounds are found
         :return: a CQ object with the resulting face(s).
         """
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -703,9 +703,7 @@ class Workplane(object):
 
         return found
 
-    def findFace(
-        self, searchStack: bool = True, searchParents: bool = True
-    ) -> Optional[Face]:
+    def findFace(self, searchStack: bool = True, searchParents: bool = True) -> Face:
         """
         Finds the first face object in the chain, searching from the current node
         backwards through parents until one is found.
@@ -715,7 +713,13 @@ class Workplane(object):
         :returns: A face or None if no face is found.
         """
 
-        return self._findType(Face, searchStack, searchParents)
+        found = self._findType(Face, searchStack, searchParents)
+
+        if found is None:
+            message = "on the stack or " if searchStack else ""
+            raise ValueError("Cannot find a face {}in the parent chain".format(message))
+
+        return found
 
     def _selectObjects(
         self,

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -293,10 +293,11 @@ class Workplane(object):
         combined and returned on the stack of the new object.
         """
         # loop through current stack objects, and combine them
-        toCombine = self.solids().vals()
+        toCombine = cast(List[Solid], self.solids().vals())
 
         if otherCQToCombine:
-            for obj in otherCQToCombine.solids().vals():
+            otherSolids = cast(List[Solid], otherCQToCombine.solids().vals())
+            for obj in otherSolids:
                 toCombine.append(obj)
 
         if len(toCombine) < 1:
@@ -672,7 +673,7 @@ class Workplane(object):
 
     def findSolid(
         self, searchStack: bool = True, searchParents: bool = True
-    ) -> Union[Solid, Compound]:
+    ) -> Optional[Union[Solid, Compound]]:
         """
         Finds the first solid object in the chain, searching from the current node
         backwards through parents until one is found.
@@ -2994,7 +2995,7 @@ class Workplane(object):
         """
 
         # first collect all of the items together
-        newS: Sequence[Shape]
+        newS: List[Shape]
         if isinstance(toUnion, CQ):
             newS = cast(List[Shape], toUnion.solids().vals())
             if len(newS) < 1:
@@ -3002,7 +3003,7 @@ class Workplane(object):
                     "CQ object  must have at least one solid on the stack to union!"
                 )
         elif isinstance(toUnion, (Solid, Compound)):
-            newS = (toUnion,)
+            newS = [toUnion]
         else:
             raise ValueError("Cannot union type '{}'".format(type(toUnion)))
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -695,7 +695,9 @@ class Workplane(object):
 
         return self._findType((Solid, Compound), searchStack, searchParents)
 
-    def findFace(self, searchStack: bool = True, searchParents: bool = True) -> Face:
+    def findFace(
+        self, searchStack: bool = True, searchParents: bool = True
+    ) -> Optional[Face]:
         """
         Finds the first face object in the chain, searching from the current node
         backwards through parents until one is found.

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1844,18 +1844,15 @@ class TestCadQuery(BaseTest):
         """
         r = Workplane("XY").box(1, 1, 1)
         dim = r.largestDimension()
-
         self.assertAlmostEqual(1.76, dim, 1)
 
         r = Workplane("XY").rect(1, 1).extrude(1)
         dim = r.largestDimension()
-
         self.assertAlmostEqual(1.76, dim, 1)
 
         r = Workplane("XY")
-        dim = r.largestDimension()
-
-        self.assertEqual(-1, dim)
+        with raises(ValueError):
+            r.largestDimension()
 
     def testOccBottle(self):
         """
@@ -3443,9 +3440,10 @@ class TestCadQuery(BaseTest):
         self.assertEqual(len(s.Solids()), 2)
         self.assertTrue(isinstance(s, Compound))
 
-        # if no solids are found, should return None
+        # if no solids are found, should raise ValueError
         w = Workplane().hLine(1).close()
-        self.assertEqual(w.findSolid(), None)
+        with raises(ValueError):
+            w.findSolid()
 
     def testSlot2D(self):
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -4241,14 +4241,17 @@ class TestCadQuery(BaseTest):
             w0.cutBlind(1)
 
     def testFindFace(self):
-        # if there are no faces to find, should return None
+        # if there are no faces to find, should raise ValueError
         w0 = Workplane()
-        self.assertEqual(w0.findFace(), None)
+        with raises(ValueError):
+            w0.findFace()
 
         w1 = Workplane().box(1, 1, 1).faces(">Z")
         self.assertTrue(isinstance(w1.findFace(), Face))
-        self.assertEqual(w1.findFace(searchStack=False), None)
+        with raises(ValueError):
+            w1.findFace(searchStack=False)
 
         w2 = w1.workplane().circle(0.1).extrude(0.1)
         self.assertTrue(isinstance(w2.findFace(searchParents=True), Face))
-        self.assertEqual(w2.findFace(searchParents=False), None)
+        with raises(ValueError):
+            w2.findFace(searchParents=False)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1517,6 +1517,11 @@ class TestCadQuery(BaseTest):
         sugar = currentS - toCut.val()
         self.assertEqual(resS.faces().size(), sugar.faces().size())
 
+        # test ValueError on no solid found
+        s0 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            s0.cut(toCut.val())
+
     def testIntersect(self):
         """
         Tests the intersect function.
@@ -1547,6 +1552,10 @@ class TestCadQuery(BaseTest):
         # Test syntactic sugar [__mul__ method]
         sugar = b1 & b2
         self.assertEqual(resS.val().Volume(), sugar.val().Volume())
+
+        # raise ValueError when no solid found
+        with raises(ValueError):
+            Workplane().intersect(toIntersect)
 
     def testBoundingBox(self):
         """
@@ -1645,6 +1654,11 @@ class TestCadQuery(BaseTest):
 
         self.assertTrue(r.val().isValid())
         self.assertEqual(r.faces().size(), 7)
+
+        # test ValueError when no solids found
+        w0 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            w0.cutThruAll()
 
     def testCutToFaceOffsetNOTIMPLEMENTEDYET(self):
         """
@@ -2018,6 +2032,11 @@ class TestCadQuery(BaseTest):
         self.saveModel(c)
         self.assertEqual(12, c.faces().size())
 
+        # should raise an error if no solid
+        c1 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            c1.fillet(0.1)
+
     def testChamfer(self):
         """
         Test chamfer API with a box shape
@@ -2025,6 +2044,11 @@ class TestCadQuery(BaseTest):
         cube = CQ(makeUnitCube()).faces(">Z").chamfer(0.1)
         self.saveModel(cube)
         self.assertEqual(10, cube.faces().size())
+
+        # should raise an error if no solid
+        c1 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            c1.chamfer(0.1)
 
     def testChamferAsymmetrical(self):
         """
@@ -2128,6 +2152,14 @@ class TestCadQuery(BaseTest):
         self.assertEqual(1, result.solids().size())
         self.assertEqual(8, result.solids().item(0).faces().size())
 
+    def testSplitError(self):
+        """
+        Test split produces the correct error when called with no solid to split.
+        """
+        w = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            w.split(keepTop=True)
+
     def testBoxDefaults(self):
         """
         Tests creating a single box
@@ -2155,6 +2187,11 @@ class TestCadQuery(BaseTest):
 
         s3 = Workplane().ellipse(4, 2).extrude(4).faces(">Z").shell(+2, kind="arc")
         self.assertEqual(6, s3.faces().size())
+
+        # test error on no solid found
+        s4 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            s4.shell(1)
 
     def testClosedShell(self):
         """
@@ -3406,6 +3443,10 @@ class TestCadQuery(BaseTest):
         self.assertEqual(len(s.Solids()), 2)
         self.assertTrue(isinstance(s, Compound))
 
+        # if no solids are found, should return None
+        w = Workplane().hLine(1).close()
+        self.assertEqual(w.findSolid(), None)
+
     def testSlot2D(self):
 
         decimal_places = 9
@@ -4177,3 +4218,26 @@ class TestCadQuery(BaseTest):
         self.assertTrue(Workplane().objects == [])
         self.assertTrue(Workplane().box(1, 1, 1).end().objects == [])
         self.assertTrue(Workplane().box(1, 1, 1).box(2, 2, 1).end(2).objects == [])
+
+    def testCutEach(self):
+
+        # base shape:
+        w = Workplane().box(3, 2, 2)
+        # cutter:
+        c = Workplane().box(2, 2, 2).val()
+        # cut all the corners off
+        w0 = w.vertices().cutEach(lambda loc: c.located(loc))
+        # we are left with a 1x2x2 box:
+        self.assertAlmostEqual(w0.val().Volume(), 4, 3)
+
+        # test error on no solid found
+        w1 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            w1.cutEach(lambda loc: c.located(loc))
+
+    def testCutBlind(self):
+        # cutBlind is already tested in several of the complicated tests, so this method is short.
+        # test ValueError on no solid found
+        w0 = Workplane().hLine(1).vLine(1).close()
+        with raises(ValueError):
+            w0.cutBlind(1)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -4241,3 +4241,16 @@ class TestCadQuery(BaseTest):
         w0 = Workplane().hLine(1).vLine(1).close()
         with raises(ValueError):
             w0.cutBlind(1)
+
+    def testFindFace(self):
+        # if there are no faces to find, should return None
+        w0 = Workplane()
+        self.assertEqual(w0.findFace(), None)
+
+        w1 = Workplane().box(1, 1, 1).faces(">Z")
+        self.assertTrue(isinstance(w1.findFace(), Face))
+        self.assertEqual(w1.findFace(searchStack=False), None)
+
+        w2 = w1.workplane().circle(0.1).extrude(0.1)
+        self.assertTrue(isinstance(w2.findFace(searchParents=True), Face))
+        self.assertEqual(w2.findFace(searchParents=False), None)


### PR DESCRIPTION
`Workplane.findSolid` had an incorrect docstring about it raising a ValueError when it didn't find any solids. It actually just returns None, and this is behaviour that a few other methods rely on (`union` for example). So I removed the line in the docstring.

There were several methods that treated the return from `findSolid` as just a Solid, and hence were trying to call methods on the `None` object and failing with an AttributeError. I added checks for `None` and ValueError exceptions to these methods.

Then I thought to myself, "This is mypy's job, why am I doing it?", and realised that `findSolid` needed the type hint Optional added to it's return value.

I also added tests for all the new exceptions. I realised `cutEach` isn't tested at all (except for probably in the examples), so I added a basic test for that as well.