### PR TITLE
Fix Edge.makeEllipse HTML docs

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1357,7 +1357,8 @@ class Edge(Shape, Mixin1D):
         sense: Literal[-1, 1] = 1,
     ) -> "Edge":
         """
-        Makes an Ellipse centered at the provided point, having normal in the provided direction
+        Makes an Ellipse centered at the provided point, having normal in the provided direction.
+
         :param cls:
         :param x_radius: x radius of the ellipse (along the x-axis of plane the ellipse should lie in)
         :param y_radius: y radius of the ellipse (along the y-axis of plane the ellipse should lie in)


### PR DESCRIPTION
Currently HTML docs look like:
![screenshot2021-02-24-172453](https://user-images.githubusercontent.com/50230945/108960110-51ec2f00-76c5-11eb-927e-b44c7c8be247.png)

Just needed one blank line in the doc string.