### PR TITLE
Improve Inheriting Workplane Fluent Methods

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1904,10 +1904,7 @@ class Workplane(object):
         return self.newObject([rv_w if makeWire else e])
 
     def threePointArc(
-        self: T,
-        point1: VectorLike,
-        point2: VectorLike,
-        forConstruction: bool = False,
+        self: T, point1: VectorLike, point2: VectorLike, forConstruction: bool = False,
     ) -> T:
         """
         Draw an arc from the current point, through point1, and ending at point2
@@ -1936,10 +1933,7 @@ class Workplane(object):
         return self.newObject([arc])
 
     def sagittaArc(
-        self: T,
-        endPoint: VectorLike,
-        sag: float,
-        forConstruction: bool = False,
+        self: T, endPoint: VectorLike, sag: float, forConstruction: bool = False,
     ) -> T:
         """
         Draw an arc from the current point to endPoint with an arc defined by the sag (sagitta).
@@ -1977,10 +1971,7 @@ class Workplane(object):
         return self.threePointArc(sagPoint, endPoint, forConstruction)
 
     def radiusArc(
-        self: T,
-        endPoint: VectorLike,
-        radius: float,
-        forConstruction: bool = False,
+        self: T, endPoint: VectorLike, radius: float, forConstruction: bool = False,
     ) -> T:
         """
         Draw an arc from the current point to endPoint with an arc defined by the radius.
@@ -2707,10 +2698,7 @@ class Workplane(object):
     # TODO: almost all code duplicated!
     # but parameter list is different so a simple function pointer wont work
     def hole(
-        self: T,
-        diameter: float,
-        depth: Optional[float] = None,
-        clean: bool = True,
+        self: T, diameter: float, depth: Optional[float] = None, clean: bool = True,
     ) -> T:
         """
         Makes a hole for each item on the stack.
@@ -3001,10 +2989,7 @@ class Workplane(object):
         return self.newObject([r])
 
     def combine(
-        self: T,
-        clean: bool = True,
-        glue: bool = False,
-        tol: Optional[float] = None,
+        self: T, clean: bool = True, glue: bool = False, tol: Optional[float] = None,
     ) -> T:
         """
         Attempts to combine all of the items on the stack into a single item.
@@ -3143,9 +3128,7 @@ class Workplane(object):
         return self.cut(toUnion)
 
     def intersect(
-        self: T,
-        toIntersect: Union["Workplane", Solid, Compound],
-        clean: bool = True,
+        self: T, toIntersect: Union["Workplane", Solid, Compound], clean: bool = True,
     ) -> T:
         """
         Intersects the provided solid from the current solid.

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -240,9 +240,7 @@ class Workplane(object):
 
         return list(all.values())
 
-    def split(
-        self: T, keepTop: bool = False, keepBottom: bool = False
-    ) -> T:
+    def split(self: T, keepTop: bool = False, keepBottom: bool = False) -> T:
         """
         Splits a solid on the stack into two parts, optionally keeping the separate parts.
 
@@ -1001,9 +999,7 @@ class Workplane(object):
         """
         exportSVG(self, fileName)
 
-    def rotateAboutCenter(
-        self: T, axisEndPoint: VectorLike, angleDegrees: float
-    ) -> T:
+    def rotateAboutCenter(self: T, axisEndPoint: VectorLike, angleDegrees: float) -> T:
         """
         Rotates all items on the stack by the specified angle, about the specified axis
 
@@ -1212,9 +1208,7 @@ class Workplane(object):
         s = solid.fillet(radius, edgeList)
         return self.newObject([s.clean()])
 
-    def chamfer(
-        self: T, length: float, length2: Optional[float] = None
-    ) -> T:
+    def chamfer(self: T, length: float, length2: Optional[float] = None) -> T:
         """
         Chamfers a solid on the selected edges.
 
@@ -1465,9 +1459,7 @@ class Workplane(object):
 
         return self.pushPoints(locs)
 
-    def pushPoints(
-        self: T, pntList: Iterable[Union[VectorLike, Location]]
-    ) -> T:
+    def pushPoints(self: T, pntList: Iterable[Union[VectorLike, Location]]) -> T:
         """
         Pushes a list of points onto the stack as vertices.
         The points are in the 2-d coordinate space of the workplane face
@@ -1527,9 +1519,7 @@ class Workplane(object):
         n.plane.setOrigin2d(x, y)
         return n
 
-    def lineTo(
-        self: T, x: float, y: float, forConstruction: bool = False
-    ) -> T:
+    def lineTo(self: T, x: float, y: float, forConstruction: bool = False) -> T:
         """
         Make a line from the current point to the provided point
 
@@ -1551,9 +1541,7 @@ class Workplane(object):
         return self.newObject([p])
 
     # line a specified incremental amount from current point
-    def line(
-        self: T, xDist: float, yDist: float, forConstruction: bool = False
-    ) -> T:
+    def line(self: T, xDist: float, yDist: float, forConstruction: bool = False) -> T:
         """
         Make a line from the current point to the provided point, using
         dimensions relative to the current point
@@ -1567,9 +1555,7 @@ class Workplane(object):
         p = self._findFromPoint(True)  # return local coordinates
         return self.lineTo(p.x + xDist, yDist + p.y, forConstruction)
 
-    def vLine(
-        self: T, distance: float, forConstruction: bool = False
-    ) -> T:
+    def vLine(self: T, distance: float, forConstruction: bool = False) -> T:
         """
         Make a vertical line from the current point the provided distance
 
@@ -1578,9 +1564,7 @@ class Workplane(object):
         """
         return self.line(0, distance, forConstruction)
 
-    def hLine(
-        self: T, distance: float, forConstruction: bool = False
-    ) -> T:
+    def hLine(self: T, distance: float, forConstruction: bool = False) -> T:
         """
         Make a horizontal line from the current point the provided distance
 
@@ -1589,9 +1573,7 @@ class Workplane(object):
         """
         return self.line(distance, 0, forConstruction)
 
-    def vLineTo(
-        self: T, yCoord: float, forConstruction: bool = False
-    ) -> T:
+    def vLineTo(self: T, yCoord: float, forConstruction: bool = False) -> T:
         """
         Make a vertical line from the current point to the provided y coordinate.
 
@@ -1604,9 +1586,7 @@ class Workplane(object):
         p = self._findFromPoint(True)
         return self.lineTo(p.x, yCoord, forConstruction)
 
-    def hLineTo(
-        self: T, xCoord: float, forConstruction: bool = False
-    ) -> T:
+    def hLineTo(self: T, xCoord: float, forConstruction: bool = False) -> T:
         """
         Make a horizontal line from the current point to the provided x coordinate.
 
@@ -1691,9 +1671,7 @@ class Workplane(object):
         newCenter = p + Vector(xDist, yDist, 0)
         return self.newObject([self.plane.toWorldCoords(newCenter)])
 
-    def slot2D(
-        self: T, length: float, diameter: float, angle: float = 0
-    ) -> T:
+    def slot2D(self: T, length: float, diameter: float, angle: float = 0) -> T:
         """
         Creates a rounded slot for each point on the stack.
 
@@ -2390,9 +2368,7 @@ class Workplane(object):
         return self.eachpoint(lambda loc: w.moved(loc), True)
 
     # circle from current point
-    def circle(
-        self: T, radius: float, forConstruction: bool = False
-    ) -> T:
+    def circle(self: T, radius: float, forConstruction: bool = False) -> T:
         """
         Make a circle for each item on the stack.
 
@@ -3102,9 +3078,7 @@ class Workplane(object):
 
         return self.newObject([r])
 
-    def __or__(
-        self: T, toUnion: Union["Workplane", Solid, Compound]
-    ) -> T:
+    def __or__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
         Notice that `r = a | b` is equivalent to `r = a.union(b)` and `r = a + b`.
@@ -3116,9 +3090,7 @@ class Workplane(object):
         """
         return self.union(toUnion)
 
-    def __add__(
-        self: T, toUnion: Union["Workplane", Solid, Compound]
-    ) -> T:
+    def __add__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
         Notice that `r = a + b` is equivalent to `r = a.union(b)` and `r = a | b`.
@@ -3157,9 +3129,7 @@ class Workplane(object):
 
         return self.newObject([newS])
 
-    def __sub__(
-        self: T, toUnion: Union["Workplane", Solid, Compound]
-    ) -> T:
+    def __sub__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for cut.
         Notice that `r = a - b` is equivalent to `r = a.cut(b)`.
@@ -3206,9 +3176,7 @@ class Workplane(object):
 
         return self.newObject([newS])
 
-    def __and__(
-        self: T, toUnion: Union["Workplane", Solid, Compound]
-    ) -> T:
+    def __and__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for intersect.
         Notice that `r = a & b` is equivalent to `r = a.intersect(b)`.
@@ -3259,9 +3227,7 @@ class Workplane(object):
 
         return self.newObject([s])
 
-    def cutThruAll(
-        self: T, clean: bool = True, taper: float = 0
-    ) -> T:
+    def cutThruAll(self: T, clean: bool = True, taper: float = 0) -> T:
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
         Cuts through all material in both normal directions of workplane.

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -752,7 +752,8 @@ class Workplane(object):
         solids,shells, and other similar selector methods.  It is a useful extension point for
         plugin developers to make other selector methods.
         """
-        cq_obj = self._getTagged(tag) if tag else self
+        self_as_workplane: Workplane = self
+        cq_obj = self._getTagged(tag) if tag else self_as_workplane
         # A single list of all faces from all objects on the stack
         toReturn = cq_obj._collectProperty(objType)
 
@@ -2980,7 +2981,7 @@ class Workplane(object):
         r = self._sweep(
             path.wire(), multisection, makeSolid, isFrenet, transition, normal, auxSpine
         )  # returns a Solid (or a compound if there were multiple)
-        newS: "CQ"
+        newS: WorkplaneT
         if combine:
             newS = self._combineWithBase(r)
         else:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -62,7 +62,7 @@ from .selectors import (
 CQObject = Union[Vector, Location, Shape]
 VectorLike = Union[Tuple[float, float], Tuple[float, float, float], Vector]
 
-WorkplaneT = TypeVar("WorkplaneT", bound="Workplane")
+T = TypeVar("T", bound="Workplane")
 """A type variable used to make the return type of a method the same as the
 type of `self` or another argument.
 
@@ -195,7 +195,7 @@ class Workplane(object):
         self.ctx = CQContext()
         self._tag = None
 
-    def tag(self: WorkplaneT, name: str) -> WorkplaneT:
+    def tag(self: T, name: str) -> T:
         """
         Tags the current CQ object for later reference.
 
@@ -241,8 +241,8 @@ class Workplane(object):
         return list(all.values())
 
     def split(
-        self: WorkplaneT, keepTop: bool = False, keepBottom: bool = False
-    ) -> WorkplaneT:
+        self: T, keepTop: bool = False, keepBottom: bool = False
+    ) -> T:
         """
         Splits a solid on the stack into two parts, optionally keeping the separate parts.
 
@@ -327,7 +327,7 @@ class Workplane(object):
 
         return self.newObject([s])
 
-    def all(self: WorkplaneT) -> List[WorkplaneT]:
+    def all(self: T) -> List[T]:
         """
         Return a list of all CQ objects on the stack.
 
@@ -357,15 +357,15 @@ class Workplane(object):
         return self.objects
 
     @overload
-    def add(self: WorkplaneT, obj: "Workplane") -> WorkplaneT:
+    def add(self: T, obj: "Workplane") -> T:
         ...
 
     @overload
-    def add(self: WorkplaneT, obj: CQObject) -> WorkplaneT:
+    def add(self: T, obj: CQObject) -> T:
         ...
 
     @overload
-    def add(self: WorkplaneT, obj: Iterable[CQObject]) -> WorkplaneT:
+    def add(self: T, obj: Iterable[CQObject]) -> T:
         ...
 
     def add(self, obj):
@@ -426,14 +426,14 @@ class Workplane(object):
         return self.val().wrapped
 
     def workplane(
-        self: WorkplaneT,
+        self: T,
         offset: float = 0.0,
         invert: bool = False,
         centerOption: Literal[
             "CenterOfMass", "ProjectedOrigin", "CenterOfBoundBox"
         ] = "ProjectedOrigin",
         origin: Optional[VectorLike] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Creates a new 2-D workplane, located relative to the first face on the stack.
 
@@ -596,7 +596,7 @@ class Workplane(object):
         # a new workplane has the center of the workplane on the stack
         return s
 
-    def copyWorkplane(self, obj: WorkplaneT) -> WorkplaneT:
+    def copyWorkplane(self, obj: T) -> T:
         """
         Copies the workplane from obj.
 
@@ -621,7 +621,7 @@ class Workplane(object):
         out = self.copyWorkplane(tagged)
         return out
 
-    def first(self: WorkplaneT) -> WorkplaneT:
+    def first(self: T) -> T:
         """
         Return the first item on the stack
         :returns: the first item on the stack.
@@ -629,7 +629,7 @@ class Workplane(object):
         """
         return self.newObject(self.objects[0:1])
 
-    def item(self: WorkplaneT, i: int) -> WorkplaneT:
+    def item(self: T, i: int) -> T:
         """
 
         Return the ith item on the stack.
@@ -637,7 +637,7 @@ class Workplane(object):
         """
         return self.newObject([self.objects[i]])
 
-    def last(self: WorkplaneT) -> WorkplaneT:
+    def last(self: T) -> T:
         """
         Return the last item on the stack.
         :rtype: a CQ object
@@ -734,11 +734,11 @@ class Workplane(object):
         return found
 
     def _selectObjects(
-        self: WorkplaneT,
+        self: T,
         objType: Any,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Filters objects of the selected type with the specified selector,and returns results
 
@@ -768,10 +768,10 @@ class Workplane(object):
         return self.newObject(toReturn)
 
     def vertices(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select the vertices of objects on the stack, optionally filtering the selection. If there
         are multiple objects on the stack, the vertices of all objects are collected and a list of
@@ -805,10 +805,10 @@ class Workplane(object):
         return self._selectObjects("Vertices", selector, tag)
 
     def faces(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select the faces of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the faces of all objects are collected and a list of all the
@@ -841,10 +841,10 @@ class Workplane(object):
         return self._selectObjects("Faces", selector, tag)
 
     def edges(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select the edges of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the edges of all objects are collected and a list of all the
@@ -876,10 +876,10 @@ class Workplane(object):
         return self._selectObjects("Edges", selector, tag)
 
     def wires(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select the wires of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the wires of all objects are collected and a list of all the
@@ -903,10 +903,10 @@ class Workplane(object):
         return self._selectObjects("Wires", selector, tag)
 
     def solids(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select the solids of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the solids of all objects are collected and a list of all the
@@ -933,10 +933,10 @@ class Workplane(object):
         return self._selectObjects("Solids", selector, tag)
 
     def shells(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select the shells of objects on the stack, optionally filtering the selection. If there are
         multiple objects on the stack, the shells of all objects are collected and a list of all the
@@ -957,10 +957,10 @@ class Workplane(object):
         return self._selectObjects("Shells", selector, tag)
 
     def compounds(
-        self: WorkplaneT,
+        self: T,
         selector: Optional[Union[Selector, str]] = None,
         tag: Optional[str] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Select compounds on the stack, optionally filtering the selection. If there are multiple
         objects on the stack, they are collected and a list of all the distinct compounds
@@ -1002,8 +1002,8 @@ class Workplane(object):
         exportSVG(self, fileName)
 
     def rotateAboutCenter(
-        self: WorkplaneT, axisEndPoint: VectorLike, angleDegrees: float
-    ) -> WorkplaneT:
+        self: T, axisEndPoint: VectorLike, angleDegrees: float
+    ) -> T:
         """
         Rotates all items on the stack by the specified angle, about the specified axis
 
@@ -1039,11 +1039,11 @@ class Workplane(object):
         return self.each(_rot, False)
 
     def rotate(
-        self: WorkplaneT,
+        self: T,
         axisStartPoint: VectorLike,
         axisEndPoint: VectorLike,
         angleDegrees: float,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Returns a copy of all of the items on the stack rotated through and angle around the axis
         of rotation.
@@ -1066,13 +1066,13 @@ class Workplane(object):
         )
 
     def mirror(
-        self: WorkplaneT,
+        self: T,
         mirrorPlane: Union[
             Literal["XY", "YX", "XZ", "ZX", "YZ", "ZY"], VectorLike, Face, "Workplane"
         ] = "XY",
         basePointVector: Optional[VectorLike] = None,
         union: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Mirror a single CQ object.
 
@@ -1122,7 +1122,7 @@ class Workplane(object):
         else:
             return newS
 
-    def translate(self: WorkplaneT, vec: VectorLike) -> WorkplaneT:
+    def translate(self: T, vec: VectorLike) -> T:
         """
         Returns a copy of all of the items on the stack moved by the specified translation vector.
 
@@ -1138,8 +1138,8 @@ class Workplane(object):
         )
 
     def shell(
-        self: WorkplaneT, thickness: float, kind: Literal["arc", "intersection"] = "arc"
-    ) -> WorkplaneT:
+        self: T, thickness: float, kind: Literal["arc", "intersection"] = "arc"
+    ) -> T:
         """
         Remove the selected faces to create a shell of the specified thickness.
 
@@ -1183,7 +1183,7 @@ class Workplane(object):
         s = solidRef.shell(faces, thickness, kind=kind)
         return self.newObject([s])
 
-    def fillet(self: WorkplaneT, radius: float) -> WorkplaneT:
+    def fillet(self: T, radius: float) -> T:
         """
         Fillets a solid on the selected edges.
 
@@ -1213,8 +1213,8 @@ class Workplane(object):
         return self.newObject([s.clean()])
 
     def chamfer(
-        self: WorkplaneT, length: float, length2: Optional[float] = None
-    ) -> WorkplaneT:
+        self: T, length: float, length2: Optional[float] = None
+    ) -> T:
         """
         Chamfers a solid on the selected edges.
 
@@ -1253,8 +1253,8 @@ class Workplane(object):
         return self.newObject([s])
 
     def transformed(
-        self: WorkplaneT, rotate: VectorLike = (0, 0, 0), offset: VectorLike = (0, 0, 0)
-    ) -> WorkplaneT:
+        self: T, rotate: VectorLike = (0, 0, 0), offset: VectorLike = (0, 0, 0)
+    ) -> T:
         """
         Create a new workplane based on the current one.
         The origin of the new plane is located at the existing origin+offset vector, where offset is
@@ -1280,7 +1280,7 @@ class Workplane(object):
 
         return ns
 
-    def newObject(self: WorkplaneT, objlist: Iterable[CQObject]) -> WorkplaneT:
+    def newObject(self: T, objlist: Iterable[CQObject]) -> T:
         """
         Create a new workplane object from this one.
 
@@ -1360,13 +1360,13 @@ class Workplane(object):
         return rv
 
     def rarray(
-        self: WorkplaneT,
+        self: T,
         xSpacing: float,
         ySpacing: float,
         xCount: int,
         yCount: int,
         center: Union[bool, Tuple[bool, bool]] = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Creates an array of points and pushes them onto the stack.
         If you want to position the array at another point, create another workplane
@@ -1404,14 +1404,14 @@ class Workplane(object):
         return self.pushPoints(lpoints)
 
     def polarArray(
-        self: WorkplaneT,
+        self: T,
         radius: float,
         startAngle: float,
         angle: float,
         count: int,
         fill: bool = True,
         rotate: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Creates an polar array of points and pushes them onto the stack.
         The 0 degree reference angle is located along the local X-axis.
@@ -1466,8 +1466,8 @@ class Workplane(object):
         return self.pushPoints(locs)
 
     def pushPoints(
-        self: WorkplaneT, pntList: Iterable[Union[VectorLike, Location]]
-    ) -> WorkplaneT:
+        self: T, pntList: Iterable[Union[VectorLike, Location]]
+    ) -> T:
         """
         Pushes a list of points onto the stack as vertices.
         The points are in the 2-d coordinate space of the workplane face
@@ -1495,7 +1495,7 @@ class Workplane(object):
 
         return self.newObject(vecs)
 
-    def center(self: WorkplaneT, x: float, y: float) -> WorkplaneT:
+    def center(self: T, x: float, y: float) -> T:
         """
         Shift local coordinates to the specified location.
 
@@ -1528,8 +1528,8 @@ class Workplane(object):
         return n
 
     def lineTo(
-        self: WorkplaneT, x: float, y: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, x: float, y: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a line from the current point to the provided point
 
@@ -1552,8 +1552,8 @@ class Workplane(object):
 
     # line a specified incremental amount from current point
     def line(
-        self: WorkplaneT, xDist: float, yDist: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, xDist: float, yDist: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a line from the current point to the provided point, using
         dimensions relative to the current point
@@ -1568,8 +1568,8 @@ class Workplane(object):
         return self.lineTo(p.x + xDist, yDist + p.y, forConstruction)
 
     def vLine(
-        self: WorkplaneT, distance: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, distance: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a vertical line from the current point the provided distance
 
@@ -1579,8 +1579,8 @@ class Workplane(object):
         return self.line(0, distance, forConstruction)
 
     def hLine(
-        self: WorkplaneT, distance: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, distance: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a horizontal line from the current point the provided distance
 
@@ -1590,8 +1590,8 @@ class Workplane(object):
         return self.line(distance, 0, forConstruction)
 
     def vLineTo(
-        self: WorkplaneT, yCoord: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, yCoord: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a vertical line from the current point to the provided y coordinate.
 
@@ -1605,8 +1605,8 @@ class Workplane(object):
         return self.lineTo(p.x, yCoord, forConstruction)
 
     def hLineTo(
-        self: WorkplaneT, xCoord: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, xCoord: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a horizontal line from the current point to the provided x coordinate.
 
@@ -1620,8 +1620,8 @@ class Workplane(object):
         return self.lineTo(xCoord, p.y, forConstruction)
 
     def polarLine(
-        self: WorkplaneT, distance: float, angle: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, distance: float, angle: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a line of the given length, at the given angle from the current point
 
@@ -1635,8 +1635,8 @@ class Workplane(object):
         return self.line(x, y, forConstruction)
 
     def polarLineTo(
-        self: WorkplaneT, distance: float, angle: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, distance: float, angle: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a line from the current point to the given polar co-ordinates
 
@@ -1653,7 +1653,7 @@ class Workplane(object):
         return self.lineTo(x, y, forConstruction)
 
     # absolute move in current plane, not drawing
-    def moveTo(self: WorkplaneT, x: float = 0, y: float = 0) -> WorkplaneT:
+    def moveTo(self: T, x: float = 0, y: float = 0) -> T:
         """
         Move to the specified point, without drawing.
 
@@ -1672,7 +1672,7 @@ class Workplane(object):
         return self.newObject([self.plane.toWorldCoords(newCenter)])
 
     # relative move in current plane, not drawing
-    def move(self: WorkplaneT, xDist: float = 0, yDist: float = 0) -> WorkplaneT:
+    def move(self: T, xDist: float = 0, yDist: float = 0) -> T:
         """
         Move the specified distance from the current point, without drawing.
 
@@ -1692,8 +1692,8 @@ class Workplane(object):
         return self.newObject([self.plane.toWorldCoords(newCenter)])
 
     def slot2D(
-        self: WorkplaneT, length: float, diameter: float, angle: float = 0
-    ) -> WorkplaneT:
+        self: T, length: float, diameter: float, angle: float = 0
+    ) -> T:
         """
         Creates a rounded slot for each point on the stack.
 
@@ -1727,7 +1727,7 @@ class Workplane(object):
         return self.eachpoint(lambda loc: slot.moved(loc), True)
 
     def spline(
-        self: WorkplaneT,
+        self: T,
         listOfXYTuple: Iterable[VectorLike],
         tangents: Optional[Sequence[VectorLike]] = None,
         periodic: bool = False,
@@ -1737,7 +1737,7 @@ class Workplane(object):
         forConstruction: bool = False,
         includeCurrent: bool = False,
         makeWire: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Create a spline interpolated through the provided points.
 
@@ -1842,13 +1842,13 @@ class Workplane(object):
         return self.newObject([rv_w if makeWire else e])
 
     def parametricCurve(
-        self: WorkplaneT,
+        self: T,
         func: Callable[[float], VectorLike],
         N: int = 400,
         start: float = 0,
         stop: float = 1,
         makeWire: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Create a spline interpolated through the provided points.
 
@@ -1868,7 +1868,7 @@ class Workplane(object):
         return self.spline(allPoints, includeCurrent=False, makeWire=makeWire)
 
     def ellipseArc(
-        self: WorkplaneT,
+        self: T,
         x_radius: float,
         y_radius: float,
         angle1: float = 360,
@@ -1878,7 +1878,7 @@ class Workplane(object):
         forConstruction: bool = False,
         startAtCurrent: bool = True,
         makeWire: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """Draw an elliptical arc with x and y radiuses either with start point at current point or
         or current point being the center of the arc
 
@@ -1926,11 +1926,11 @@ class Workplane(object):
         return self.newObject([rv_w if makeWire else e])
 
     def threePointArc(
-        self: WorkplaneT,
+        self: T,
         point1: VectorLike,
         point2: VectorLike,
         forConstruction: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Draw an arc from the current point, through point1, and ending at point2
 
@@ -1958,11 +1958,11 @@ class Workplane(object):
         return self.newObject([arc])
 
     def sagittaArc(
-        self: WorkplaneT,
+        self: T,
         endPoint: VectorLike,
         sag: float,
         forConstruction: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Draw an arc from the current point to endPoint with an arc defined by the sag (sagitta).
 
@@ -1999,11 +1999,11 @@ class Workplane(object):
         return self.threePointArc(sagPoint, endPoint, forConstruction)
 
     def radiusArc(
-        self: WorkplaneT,
+        self: T,
         endPoint: VectorLike,
         radius: float,
         forConstruction: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Draw an arc from the current point to endPoint with an arc defined by the radius.
 
@@ -2034,11 +2034,11 @@ class Workplane(object):
             return self.sagittaArc(endPoint, -sag, forConstruction)
 
     def tangentArcPoint(
-        self: WorkplaneT,
+        self: T,
         endpoint: VectorLike,
         forConstruction: bool = False,
         relative: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Draw an arc as a tangent from the end of the current edge to endpoint.
 
@@ -2069,7 +2069,7 @@ class Workplane(object):
 
         return self.newObject([arc])
 
-    def mirrorY(self: WorkplaneT) -> WorkplaneT:
+    def mirrorY(self: T) -> T:
         """
         Mirror entities around the y axis of the workplane plane.
 
@@ -2099,7 +2099,7 @@ class Workplane(object):
         # attempt again to consolidate all of the wires
         return consolidated.consolidateWires()
 
-    def mirrorX(self: WorkplaneT) -> WorkplaneT:
+    def mirrorX(self: T) -> T:
         """
         Mirror entities around the x axis of the workplane plane.
 
@@ -2165,7 +2165,7 @@ class Workplane(object):
 
         return Wire.combine(wires)
 
-    def consolidateWires(self: WorkplaneT) -> WorkplaneT:
+    def consolidateWires(self: T) -> T:
         """
         Attempt to consolidate wires on the stack into a single.
         If possible, a new object with the results are returned.
@@ -2188,7 +2188,7 @@ class Workplane(object):
 
         return r
 
-    def wire(self: WorkplaneT, forConstruction: bool = False) -> WorkplaneT:
+    def wire(self: T, forConstruction: bool = False) -> T:
         """
         Returns a CQ object with all pending edges connected into a wire.
 
@@ -2229,10 +2229,10 @@ class Workplane(object):
         return self.newObject(others + [w])
 
     def each(
-        self: WorkplaneT,
+        self: T,
         callback: Callable[[CQObject], Shape],
         useLocalCoordinates: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Runs the provided function on each value in the stack, and collects the return values into
         a new CQ object.
@@ -2283,10 +2283,10 @@ class Workplane(object):
         return self.newObject(results)
 
     def eachpoint(
-        self: WorkplaneT,
+        self: T,
         callback: Callable[[Location], Shape],
         useLocalCoordinates: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Same as each(), except each item on the stack is converted into a point before it
         is passed into the callback function.
@@ -2331,12 +2331,12 @@ class Workplane(object):
         return self.newObject(res)
 
     def rect(
-        self: WorkplaneT,
+        self: T,
         xLen: float,
         yLen: float,
         centered: Union[bool, Tuple[bool, bool]] = True,
         forConstruction: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Make a rectangle for each item on the stack.
 
@@ -2391,8 +2391,8 @@ class Workplane(object):
 
     # circle from current point
     def circle(
-        self: WorkplaneT, radius: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, radius: float, forConstruction: bool = False
+    ) -> T:
         """
         Make a circle for each item on the stack.
 
@@ -2429,12 +2429,12 @@ class Workplane(object):
 
     # ellipse from current point
     def ellipse(
-        self: WorkplaneT,
+        self: T,
         x_radius: float,
         y_radius: float,
         rotation_angle: float = 0.0,
         forConstruction: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Make an ellipse for each item on the stack.
 
@@ -2469,8 +2469,8 @@ class Workplane(object):
         return self.eachpoint(lambda loc: e.moved(loc), True)
 
     def polygon(
-        self: WorkplaneT, nSides: int, diameter: float, forConstruction: bool = False
-    ) -> WorkplaneT:
+        self: T, nSides: int, diameter: float, forConstruction: bool = False
+    ) -> T:
         """
         Creates a polygon inscribed in a circle of the specified diameter for each point on
         the stack
@@ -2498,11 +2498,11 @@ class Workplane(object):
         return self.eachpoint(lambda loc: p.moved(loc), True)
 
     def polyline(
-        self: WorkplaneT,
+        self: T,
         listOfXYTuple: Sequence[VectorLike],
         forConstruction: bool = False,
         includeCurrent: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Create a polyline from a list of points
 
@@ -2541,7 +2541,7 @@ class Workplane(object):
 
         return self.newObject(edges)
 
-    def close(self: WorkplaneT) -> WorkplaneT:
+    def close(self: T) -> T:
         """
         End 2-d construction, and attempt to build a closed wire.
 
@@ -2591,11 +2591,11 @@ class Workplane(object):
         return compound.BoundingBox().DiagonalLength
 
     def cutEach(
-        self: WorkplaneT,
+        self: T,
         fcn: Callable[[Location], Shape],
         useLocalCoords: bool = False,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Evaluates the provided function at each point on the stack (ie, eachpoint)
         and then cuts the result from the context solid.
@@ -2619,13 +2619,13 @@ class Workplane(object):
 
     # but parameter list is different so a simple function pointer wont work
     def cboreHole(
-        self: WorkplaneT,
+        self: T,
         diameter: float,
         cboreDiameter: float,
         cboreDepth: float,
         depth: Optional[float] = None,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Makes a counterbored hole for each item on the stack.
 
@@ -2674,13 +2674,13 @@ class Workplane(object):
     # TODO: almost all code duplicated!
     # but parameter list is different so a simple function pointer wont work
     def cskHole(
-        self: WorkplaneT,
+        self: T,
         diameter: float,
         cskDiameter: float,
         cskAngle: float,
         depth: Optional[float] = None,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Makes a countersunk hole for each item on the stack.
 
@@ -2731,11 +2731,11 @@ class Workplane(object):
     # TODO: almost all code duplicated!
     # but parameter list is different so a simple function pointer wont work
     def hole(
-        self: WorkplaneT,
+        self: T,
         diameter: float,
         depth: Optional[float] = None,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Makes a hole for each item on the stack.
 
@@ -2774,12 +2774,12 @@ class Workplane(object):
 
     # TODO: duplicated code with _extrude and extrude
     def twistExtrude(
-        self: WorkplaneT,
+        self: T,
         distance: float,
         angleDegrees: float,
         combine: bool = True,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Extrudes a wire in the direction normal to the plane, but also twists by the specified
         angle over the length of the extrusion
@@ -2833,13 +2833,13 @@ class Workplane(object):
         return newS
 
     def extrude(
-        self: WorkplaneT,
+        self: T,
         distance: float,
         combine: bool = True,
         clean: bool = True,
         both: bool = False,
         taper: Optional[float] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Use all un-extruded wires in the parent chain to create a prismatic solid.
 
@@ -2878,13 +2878,13 @@ class Workplane(object):
         return newS
 
     def revolve(
-        self: WorkplaneT,
+        self: T,
         angleDegrees: float = 360.0,
         axisStart: Optional[VectorLike] = None,
         axisEnd: Optional[VectorLike] = None,
         combine: bool = True,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Use all un-revolved wires in the parent chain to create a solid.
 
@@ -2942,7 +2942,7 @@ class Workplane(object):
         return newS
 
     def sweep(
-        self: WorkplaneT,
+        self: T,
         path: "Workplane",
         multisection: bool = False,
         sweepAlongWires: Optional[bool] = None,
@@ -2953,7 +2953,7 @@ class Workplane(object):
         transition: Literal["right", "round", "transformed"] = "right",
         normal: Optional[VectorLike] = None,
         auxSpine: Optional["Workplane"] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Use all un-extruded wires in the parent chain to create a swept solid.
 
@@ -2981,7 +2981,7 @@ class Workplane(object):
         r = self._sweep(
             path.wire(), multisection, makeSolid, isFrenet, transition, normal, auxSpine
         )  # returns a Solid (or a compound if there were multiple)
-        newS: WorkplaneT
+        newS: T
         if combine:
             newS = self._combineWithBase(r)
         else:
@@ -2990,7 +2990,7 @@ class Workplane(object):
             newS = newS.clean()
         return newS
 
-    def _combineWithBase(self: WorkplaneT, obj: Shape) -> WorkplaneT:
+    def _combineWithBase(self: T, obj: Shape) -> T:
         """
         Combines the provided object with the base solid, if one can be found.
         :param obj:
@@ -3008,7 +3008,7 @@ class Workplane(object):
 
         return self.newObject([r])
 
-    def _cutFromBase(self: WorkplaneT, obj: Shape) -> WorkplaneT:
+    def _cutFromBase(self: T, obj: Shape) -> T:
         """
         Cuts the provided object from the base solid, if one can be found.
         :param obj:
@@ -3025,11 +3025,11 @@ class Workplane(object):
         return self.newObject([r])
 
     def combine(
-        self: WorkplaneT,
+        self: T,
         clean: bool = True,
         glue: bool = False,
         tol: Optional[float] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Attempts to combine all of the items on the stack into a single item.
         WARNING: all of the items must be of the same type!
@@ -3053,12 +3053,12 @@ class Workplane(object):
         return self.newObject([s])
 
     def union(
-        self: WorkplaneT,
+        self: T,
         toUnion: Optional[Union["Workplane", Solid, Compound]] = None,
         clean: bool = True,
         glue: bool = False,
         tol: Optional[float] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Unions all of the items on the stack of toUnion with the current solid.
         If there is no current solid, the items in toUnion are unioned together.
@@ -3103,8 +3103,8 @@ class Workplane(object):
         return self.newObject([r])
 
     def __or__(
-        self: WorkplaneT, toUnion: Union["Workplane", Solid, Compound]
-    ) -> WorkplaneT:
+        self: T, toUnion: Union["Workplane", Solid, Compound]
+    ) -> T:
         """
         Syntactic sugar for union.
         Notice that `r = a | b` is equivalent to `r = a.union(b)` and `r = a + b`.
@@ -3117,8 +3117,8 @@ class Workplane(object):
         return self.union(toUnion)
 
     def __add__(
-        self: WorkplaneT, toUnion: Union["Workplane", Solid, Compound]
-    ) -> WorkplaneT:
+        self: T, toUnion: Union["Workplane", Solid, Compound]
+    ) -> T:
         """
         Syntactic sugar for union.
         Notice that `r = a + b` is equivalent to `r = a.union(b)` and `r = a | b`.
@@ -3126,8 +3126,8 @@ class Workplane(object):
         return self.union(toUnion)
 
     def cut(
-        self: WorkplaneT, toCut: Union["Workplane", Solid, Compound], clean: bool = True
-    ) -> WorkplaneT:
+        self: T, toCut: Union["Workplane", Solid, Compound], clean: bool = True
+    ) -> T:
         """
         Cuts the provided solid from the current solid, IE, perform a solid subtraction
 
@@ -3158,8 +3158,8 @@ class Workplane(object):
         return self.newObject([newS])
 
     def __sub__(
-        self: WorkplaneT, toUnion: Union["Workplane", Solid, Compound]
-    ) -> WorkplaneT:
+        self: T, toUnion: Union["Workplane", Solid, Compound]
+    ) -> T:
         """
         Syntactic sugar for cut.
         Notice that `r = a - b` is equivalent to `r = a.cut(b)`.
@@ -3173,10 +3173,10 @@ class Workplane(object):
         return self.cut(toUnion)
 
     def intersect(
-        self: WorkplaneT,
+        self: T,
         toIntersect: Union["Workplane", Solid, Compound],
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Intersects the provided solid from the current solid.
 
@@ -3207,8 +3207,8 @@ class Workplane(object):
         return self.newObject([newS])
 
     def __and__(
-        self: WorkplaneT, toUnion: Union["Workplane", Solid, Compound]
-    ) -> WorkplaneT:
+        self: T, toUnion: Union["Workplane", Solid, Compound]
+    ) -> T:
         """
         Syntactic sugar for intersect.
         Notice that `r = a & b` is equivalent to `r = a.intersect(b)`.
@@ -3222,11 +3222,11 @@ class Workplane(object):
         return self.intersect(toUnion)
 
     def cutBlind(
-        self: WorkplaneT,
+        self: T,
         distanceToCut: float,
         clean: bool = True,
         taper: Optional[float] = None,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
 
@@ -3260,8 +3260,8 @@ class Workplane(object):
         return self.newObject([s])
 
     def cutThruAll(
-        self: WorkplaneT, clean: bool = True, taper: float = 0
-    ) -> WorkplaneT:
+        self: T, clean: bool = True, taper: float = 0
+    ) -> T:
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
         Cuts through all material in both normal directions of workplane.
@@ -3292,8 +3292,8 @@ class Workplane(object):
         return self.newObject(rv)
 
     def loft(
-        self: WorkplaneT, filled: bool = True, ruled: bool = False, combine: bool = True
-    ) -> WorkplaneT:
+        self: T, filled: bool = True, ruled: bool = False, combine: bool = True
+    ) -> T:
         """
         Make a lofted solid, through the set of wires.
         :return: a CQ object containing the created loft
@@ -3450,7 +3450,7 @@ class Workplane(object):
         return Compound.makeCompound(toFuse)
 
     def interpPlate(
-        self: WorkplaneT,
+        self: T,
         surf_edges: Union[Sequence[VectorLike], Sequence[Edge]],
         surf_pts: Sequence[VectorLike] = [],
         thickness: float = 0,
@@ -3466,7 +3466,7 @@ class Workplane(object):
         tolCurv: float = 0.1,
         maxDeg: int = 8,
         maxSegments: int = 9,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Returns a plate surface that is 'thickness' thick, enclosed by 'surf_edge_pts' points,  and going through 'surf_pts' points.  Using pushpoints directly with interpPlate and combine=True, can be very ressources intensive depending on the complexity of the shape. In this case set combine=False.
 
@@ -3533,14 +3533,14 @@ class Workplane(object):
             return self.union(plates, clean=clean)
 
     def box(
-        self: WorkplaneT,
+        self: T,
         length: float,
         width: float,
         height: float,
         centered: Union[bool, Tuple[bool, bool, bool]] = True,
         combine: bool = True,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Return a 3d box with specified dimensions for each object on the stack.
 
@@ -3610,7 +3610,7 @@ class Workplane(object):
             return self.union(boxes, clean=clean)
 
     def sphere(
-        self: WorkplaneT,
+        self: T,
         radius: float,
         direct: VectorLike = (0, 0, 1),
         angle1: float = -90,
@@ -3619,7 +3619,7 @@ class Workplane(object):
         centered: Union[bool, Tuple[bool, bool, bool]] = True,
         combine: bool = True,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Returns a 3D sphere with the specified radius for each point on the stack
 
@@ -3680,7 +3680,7 @@ class Workplane(object):
             return self.union(spheres, clean=clean)
 
     def wedge(
-        self: WorkplaneT,
+        self: T,
         dx: float,
         dy: float,
         dz: float,
@@ -3693,7 +3693,7 @@ class Workplane(object):
         centered: Union[bool, Tuple[bool, bool, bool]] = True,
         combine: bool = True,
         clean: bool = True,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         :param dx: Distance along the X axis
         :param dy: Distance along the Y axis
@@ -3753,7 +3753,7 @@ class Workplane(object):
         else:
             return self.union(wedges, clean=clean)
 
-    def clean(self: WorkplaneT) -> WorkplaneT:
+    def clean(self: T) -> T:
         """
         Cleans the current solid by removing unwanted edges from the
         faces.
@@ -3782,7 +3782,7 @@ class Workplane(object):
         return self.newObject(cleanObjects)
 
     def text(
-        self: WorkplaneT,
+        self: T,
         txt: str,
         fontsize: float,
         distance: float,
@@ -3794,7 +3794,7 @@ class Workplane(object):
         kind: Literal["regular", "bold", "italic"] = "regular",
         halign: Literal["center", "left", "right"] = "center",
         valign: Literal["center", "top", "bottom"] = "center",
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Create a 3D text
 
@@ -3843,7 +3843,7 @@ class Workplane(object):
             newS = newS.clean()
         return newS
 
-    def section(self: WorkplaneT, height: float = 0.0) -> WorkplaneT:
+    def section(self: T, height: float = 0.0) -> T:
         """
         Slices current solid at the given height.
 
@@ -3862,7 +3862,7 @@ class Workplane(object):
 
         return self.newObject([r])
 
-    def toPending(self: WorkplaneT) -> WorkplaneT:
+    def toPending(self: T) -> T:
         """
         Adds wires/edges to pendingWires/pendingEdges.
 
@@ -3875,11 +3875,11 @@ class Workplane(object):
         return self
 
     def offset2D(
-        self: WorkplaneT,
+        self: T,
         d: float,
         kind: Literal["arc", "intersection", "tangent"] = "arc",
         forConstruction: bool = False,
-    ) -> WorkplaneT:
+    ) -> T:
         """
         Creates a 2D offset wire.
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -234,7 +234,7 @@ class TestCadQuery(BaseTest):
         class ExtendedWorkplane(Workplane):
             def nonExistentInWorkplane(self):
                 pass
-        
+
         # Call an inherited fluent method:
         wp = ExtendedWorkplane("XY").moveTo(1, 2)
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -225,6 +225,27 @@ class TestCadQuery(BaseTest):
         self.assertEqual(26, s.faces().size())
         self.saveModel(s)
 
+    def testFluentMethodInheritance(self):
+        """
+        Tests that a derived class inherits fluent methods which return
+        instances of derived class when inherited.
+        """
+
+        class ExtendedWorkplane(Workplane):
+            def nonExistentInWorkplane(self):
+                pass
+        
+        # Call an inherited fluent method:
+        wp = ExtendedWorkplane("XY").moveTo(1, 2)
+
+        # Verify that the inherited method returned an instance of the derived
+        # class:
+        self.assertEqual(type(wp), ExtendedWorkplane)
+
+        # The following is redundant, but can make the use case clearer.
+        # This must not raise an AttributeError:
+        wp.nonExistentInWorkplane()
+
     def testPointList(self):
         """
         Tests adding points and using them


### PR DESCRIPTION
* Updated `Workplane.workplane()`, `Workplane.copyWorkplane()`, `Workplane.newObject()` to return instances of a type that's based on the input parameters (such as `self`).
* Updated type hints to reflect that return types of fluent methods depend on the type of method arguments.
* Added a unit test to verify fluent methods in a derived class return instances of the derived class.

This is a pull request for issue #673.