### PR TITLE
popPendingEdges and Wires

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -93,6 +93,30 @@ class CQContext(object):
         self.tolerance = 0.0001  # user specified tolerance
         self.tags = {}
 
+    def popPendingEdges(self, errorOnEmpty: bool = True) -> List[Edge]:
+        """
+        Get and clear pending edges.
+
+        :raises ValueError: if errorOnEmpty is True and no edges are present.
+        """
+        if errorOnEmpty and not self.pendingEdges:
+            raise ValueError("No pending edges present")
+        out = self.pendingEdges
+        self.pendingEdges = []
+        return out
+
+    def popPendingWires(self, errorOnEmpty: bool = True) -> List[Wire]:
+        """
+        Get and clear pending wires.
+
+        :raises ValueError: if errorOnEmpty is True and no wires are present.
+        """
+        if errorOnEmpty and not self.pendingWires:
+            raise ValueError("No pending wires present")
+        out = self.pendingWires
+        self.pendingWires = []
+        return out
+
 
 class Workplane(object):
     """

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -4255,3 +4255,38 @@ class TestCadQuery(BaseTest):
         self.assertTrue(isinstance(w2.findFace(searchParents=True), Face))
         with raises(ValueError):
             w2.findFace(searchParents=False)
+
+    def testPopPending(self):
+        # test pending edges
+        w0 = Workplane().hLine(1)
+        self.assertEqual(len(w0.ctx.pendingEdges), 1)
+        edges = w0.ctx.popPendingEdges()
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0], w0.val())
+        # pending edges should now be cleared
+        self.assertEqual(len(w0.ctx.pendingEdges), 0)
+
+        # test pending wires
+        w1 = Workplane().hLine(1).vLine(1).close()
+        wire = w1.val()
+        self.assertEqual(w1.ctx.pendingWires[0], wire)
+        pop_pending_output = w1.ctx.popPendingWires()
+        self.assertEqual(pop_pending_output[0], wire)
+        # pending wires should now be cleared
+        self.assertEqual(len(w1.ctx.pendingWires), 0)
+
+        # test error when empty pending edges
+        w2 = Workplane()
+        # the following 2 should not raise an exception
+        w2.ctx.popPendingEdges(errorOnEmpty=False)
+        w2.ctx.popPendingWires(errorOnEmpty=False)
+
+        # empty edges
+        w3 = Workplane().hLine(1).vLine(1).close()
+        with self.assertRaises(ValueError):
+            w3.ctx.popPendingEdges()
+
+        # empty wires
+        w4 = Workplane().circle(1).extrude(1)
+        with self.assertRaises(ValueError):
+            w4.ctx.popPendingWires()


### PR DESCRIPTION
Will close #621. To summarise:

* More informative exception when pendingWires or pendingEdges is empty
* Minimise code duplication
* More consistent method to pop pending Edges/Wires

I'm keeping this a draft PR until I see the test coverage, if it goes down then I'll fix that.