### PR TITLE
Added AreaNthSelector

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -290,14 +290,7 @@ geom_LUT_EDGE = {
 }
 
 Shapes = Literal[
-    "Vertex", 
-    "Edge", 
-    "Wire", 
-    "Face", 
-    "Shell", 
-    "Solid", 
-    "CompSolid", 
-    "Compound"
+    "Vertex", "Edge", "Wire", "Face", "Shell", "Solid", "CompSolid", "Compound"
 ]
 Geoms = Literal[
     "Vertex",

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -290,7 +290,14 @@ geom_LUT_EDGE = {
 }
 
 Shapes = Literal[
-    "Vertex", "Edge", "Wire", "Face", "Shell", "Solid", "CompSolid", "Compound"
+    "Vertex", 
+    "Edge", 
+    "Wire", 
+    "Face", 
+    "Shell", 
+    "Solid", 
+    "CompSolid", 
+    "Compound"
 ]
 Geoms = Literal[
     "Vertex",

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -47,7 +47,7 @@ from pyparsing import (
     Keyword,
 )
 from functools import reduce
-from typing import List, Union, Sequence, cast
+from typing import List, Union, Sequence
 
 
 class Selector(object):

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -453,6 +453,7 @@ class DirectionNthSelector(ParallelDirSelector, CenterNthSelector):
         objectlist = _NthSelector.filter(self, objectlist)
         return objectlist
 
+
 class AreaNthSelector(_NthSelector):
     """
     Selects object(s) with Nth area.
@@ -495,23 +496,20 @@ class AreaNthSelector(_NthSelector):
             .toPending()\
             .workplane()\
             .cutBlind(2)    
-    """    
-    def key(self, obj: Shape) -> float:        
+    """
+
+    def key(self, obj: Shape) -> float:
         shape_type = obj.ShapeType()
 
-        if shape_type in ("Face", 
-                          "Shell", 
-                          "Solid"):
+        if shape_type in ("Face", "Shell", "Solid"):
             return obj.Area()
         elif shape_type == "Wire":
-            return Face.makeFromWires(
-                            cast(Wire, obj))\
-                       .Area()
+            return Face.makeFromWires(cast(Wire, obj)).Area()
         else:
             raise TypeError(
-                "AreaNthSelector supports only Wires, "\
-                "Faces, Shells and Solids, not {}"\
-                .format(shape_type))       
+                "AreaNthSelector supports only Wires, "
+                "Faces, Shells and Solids, not {}".format(shape_type)
+            )
 
 
 class BinarySelector(Selector):

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -488,10 +488,12 @@ class AreaNthSelector(_NthSelector):
 
     Applicability:
         Faces, Shells, Solids - Shape.Area() is used to compute area
-        planar Wires - a temporary face is created to compute area
+        closed planar Wires - a temporary face is created to compute area
 
-    Among other things can be used to select one of 
-    the nested coplanar wires or faces. 
+    Will ignore non-planar or non-closed wires.
+    
+    Among other things can be used to select one of
+    the nested coplanar wires or faces.
 
     For example to create a fillet on a shank:
 
@@ -507,7 +509,7 @@ class AreaNthSelector(_NthSelector):
         )
 
     Or to create a lip on a case seam:
-        
+
         result = (
             cq.Workplane("XY")
             .rect(20, 20)
@@ -534,7 +536,12 @@ class AreaNthSelector(_NthSelector):
         if isinstance(obj, (Face, Shell, Solid)):
             return obj.Area()
         elif isinstance(obj, Wire):
-            return Face.makeFromWires(obj).Area()
+            try:
+                return Face.makeFromWires(obj).Area()
+            except Exception as ex:
+                raise ValueError(
+                    f"Can not compute area of the Wire: {ex}. AreaNthSelector supports only closed planar Wires."
+                )
         else:
             raise ValueError(
                 f"AreaNthSelector supports only Wires, Faces, Shells and Solids, not {type(obj).__name__}"

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -37,7 +37,7 @@ from pyparsing import (
     Keyword,
 )
 from functools import reduce
-from typing import List, Union, Sequence
+from typing import List, Union, Sequence, cast
 
 
 class Selector(object):
@@ -504,7 +504,9 @@ class AreaNthSelector(_NthSelector):
                           "Solid"):
             return obj.Area()
         elif shape_type == "Wire":
-            return Face.makeFromWires(obj).Area()
+            return Face.makeFromWires(
+                            cast(Wire, obj))\
+                       .Area()
         else:
             raise TypeError(
                 "AreaNthSelector supports only Wires, "\

--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -177,6 +177,8 @@ as a basis for futher operations.
         ParallelDirSelector
         DirectionSelector
         DirectionNthSelector
+		LengthNthSelector
+		AreaNthSelector
         RadiusNthSelector
         PerpendicularDirSelector
         TypeSelector

--- a/doc/classreference.rst
+++ b/doc/classreference.rst
@@ -66,6 +66,8 @@ Selector Classes
     CenterNthSelector
     DirectionMinMaxSelector
     DirectionNthSelector
+    LengthNthSelector
+    AreaNthSelector
     BinarySelector
     AndSelector
     SumSelector

--- a/examples/Ex026_Case_Seam_Lip.py
+++ b/examples/Ex026_Case_Seam_Lip.py
@@ -4,19 +4,19 @@ from cadquery.selectors import AreaNthSelector
 case_bottom = (
     cq.Workplane("XY")
     .rect(20, 20)
-    .extrude(10) # solid 20x20x10 box
+    .extrude(10)  # solid 20x20x10 box
     .edges("|Z or <Z")
-    .fillet(2) # rounding all edges except 4 edges of the top face
+    .fillet(2)  # rounding all edges except 4 edges of the top face
     .faces(">Z")
-    .shell(2) # shell of thickness 2 with top face open
+    .shell(2)  # shell of thickness 2 with top face open
     .faces(">Z")
-    .wires(AreaNthSelector(-1)) # selecting top outer wire
+    .wires(AreaNthSelector(-1))  # selecting top outer wire
     .toPending()
     .workplane()
-    .offset2D(-1) # creating centerline wire of case seam face
-    .extrude(1) # covering the sell with temporary "lid"
-    .faces(">Z[-2]")\
-    .wires(AreaNthSelector(0)) # selecting case crossection wire
+    .offset2D(-1)  # creating centerline wire of case seam face
+    .extrude(1)  # covering the sell with temporary "lid"
+    .faces(">Z[-2]")
+    .wires(AreaNthSelector(0))  # selecting case crossection wire
     .toPending()
     .workplane()
     .cutBlind(2)  # cutting through the "lid" leaving a lip on case seam surface
@@ -24,7 +24,7 @@ case_bottom = (
 
 # similar process repeated for the top part
 # but instead of "growing" an inner lip
-# material is removed inside case seam centerline 
+# material is removed inside case seam centerline
 # to create an outer lip
 case_top = (
     cq.Workplane("XY")
@@ -42,6 +42,6 @@ case_top = (
     .offset2D(-1)
     .cutBlind(-1)
 )
-      
+
 show_object(case_bottom)
-show_object(case_top, options={"alpha":0.5})
+show_object(case_top, options={"alpha": 0.5})

--- a/examples/Ex026_Case_Seam_Lip.py
+++ b/examples/Ex026_Case_Seam_Lip.py
@@ -1,0 +1,46 @@
+import cadquery as cq
+
+case_bottom = (
+    cq.Workplane("XY")
+    .rect(20, 20)
+    .extrude(10) # solid 20x20x10 box
+    .edges("|Z or <Z")
+    .fillet(2) # rounding all edges except 4 edges of the top face
+    .faces(">Z")
+    .shell(2) # shell of thickness 2 with top face open
+    .faces(">Z")
+    .wires(AreaNthSelector(-1)) # selecting top outer wire
+    .toPending()
+    .workplane()
+    .offset2D(-1) # creating centerline wire of case seam face
+    .extrude(1) # covering the sell with temporary "lid"
+    .faces(">Z[-2]")\
+    .wires(AreaNthSelector(0)) # selecting case crossection wire
+    .toPending()
+    .workplane()
+    .cutBlind(2)  # cutting through the "lid" leaving a lip on case seam surface
+)
+
+# similar process repeated for the top part
+# but instead of "growing" an inner lip
+# material is removed inside case seam centerline 
+# to create an outer lip
+case_top = (
+    cq.Workplane("XY")
+    .move(25)
+    .rect(20, 20)
+    .extrude(5)
+    .edges("|Z or >Z")
+    .fillet(2)
+    .faces("<Z")
+    .shell(2)
+    .faces("<Z")
+    .wires(AreaNthSelector(-1))
+    .toPending()
+    .workplane()
+    .offset2D(-1)
+    .cutBlind(-1)
+)
+      
+show_object(case_bottom)
+show_object(case_top, options={"alpha":0.5})

--- a/examples/Ex026_Case_Seam_Lip.py
+++ b/examples/Ex026_Case_Seam_Lip.py
@@ -1,4 +1,5 @@
 import cadquery as cq
+from cadquery.selectors import AreaNthSelector
 
 case_bottom = (
     cq.Workplane("XY")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,9 +47,9 @@ def toTuple(v):
 
 
 class BaseTest(unittest.TestCase):
-    def assertTupleAlmostEquals(self, expected, actual, places):
+    def assertTupleAlmostEquals(self, expected, actual, places, msg=None):
         for i, j in zip(actual, expected):
-            self.assertAlmostEqual(i, j, places)
+            self.assertAlmostEqual(i, j, places, msg=msg)
 
 
 __all__ = [

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -701,14 +701,31 @@ class TestCQSelectors(BaseTest):
         )
 
     def testAreaNthSelector_Vertices(self):
+        """
+        Raising exception when AreaNthSelector is used 
+        on unsupported Shapes (Vertices)
+        """
         with self.assertRaises(TypeError):
-            wp = Workplane("XY").box(10, 10, 10).vertices(selectors.AreaNthSelector(0))
+            Workplane("XY").box(10, 10, 10).vertices(selectors.AreaNthSelector(0))
 
     def testAreaNthSelector_Edges(self):
+        """
+        Raising exception when AreaNthSelector is used 
+        on unsupported Shapes (Edges)
+        """
         with self.assertRaises(TypeError):
-            wp = Workplane("XY").box(10, 10, 10).edges(selectors.AreaNthSelector(0))
+            Workplane("XY").box(10, 10, 10).edges(selectors.AreaNthSelector(0))
 
     def testAreaNthSelector_Wires(self):
+        """
+        Tests key parts of case seam leap creation algorithm 
+        (see example 26)
+
+        - Selecting top outer wire 
+        - Applying Offset2D and extruding a "lid"
+        - Selecting the innermost of three wires in preparation to
+          cut through the lid and leave a lip on the case seam
+        """
         # selecting top outermost wire of square box
         wp = (
             Workplane("XY")
@@ -723,12 +740,12 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(
             len(wp.vals()),
             1,
-            msg="Failed to select top outermost wire " "of the box: wrong N wires",
+            msg="Failed to select top outermost wire of the box: wrong N wires",
         )
         self.assertAlmostEqual(
             Face.makeFromWires(wp.val()).Area(),
             50 * 50,
-            msg="Failed to select top outermost wire " "of the box: wrong wire area",
+            msg="Failed to select top outermost wire of the box: wrong wire area",
         )
 
         # preparing to add an inside lip to the box
@@ -740,39 +757,42 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(
             len(wp_outer_wire.vals()),
             1,
-            msg="Failed to select outermost wire " "of 2 faces: wrong N wires",
+            msg="Failed to select outermost wire of 2 faces: wrong N wires",
         )
         self.assertAlmostEqual(
             Face.makeFromWires(wp_outer_wire.val()).Area(),
             50 * 50,
-            msg="Failed to select outermost wire " "of 2 faces: wrong area",
+            msg="Failed to select outermost wire of 2 faces: wrong area",
         )
 
         wp_mid_wire = wp.wires(selectors.AreaNthSelector(1))
         self.assertEqual(
             len(wp_mid_wire.vals()),
             1,
-            msg="Failed to select middle wire " "of 2 faces: wrong N wires",
+            msg="Failed to select middle wire of 2 faces: wrong N wires",
         )
         self.assertAlmostEqual(
             Face.makeFromWires(wp_mid_wire.val()).Area(),
             (50 - 2 * 2) * (50 - 2 * 2),
-            msg="Failed to select middle wire " "of 2 faces: wrong area",
+            msg="Failed to select middle wire of 2 faces: wrong area",
         )
 
         wp_inner_wire = wp.wires(selectors.AreaNthSelector(0))
         self.assertEqual(
             len(wp_inner_wire.vals()),
             1,
-            msg="Failed to select inner wire " "of 2 faces: wrong N wires",
+            msg="Failed to select inner wire of 2 faces: wrong N wires",
         )
         self.assertAlmostEqual(
             Face.makeFromWires(wp_inner_wire.val()).Area(),
             (50 - 5 * 2) * (50 - 5 * 2),
-            msg="Failed to select inner wire " "of 2 faces: wrong area",
+            msg="Failed to select inner wire of 2 faces: wrong area",
         )
 
     def testAreaNthSelector_Faces(self):
+        """
+        Selecting two faces of 10x20x30 box with intermediate area.
+        """
         wp = Workplane("XY").box(10, 20, 30).faces(selectors.AreaNthSelector(1))
 
         self.assertEqual(
@@ -790,6 +810,9 @@ class TestCQSelectors(BaseTest):
         )
 
     def testAreaNthSelector_Shells(self):
+        """
+        Selecting one of three shells with the smallest surface area
+        """
         shells = [
             Shell.makeShell(Workplane("XY").box(20, 20, 20).faces().vals()),
             Shell.makeShell(Workplane("XY").box(10, 10, 10).faces().vals()),
@@ -810,6 +833,9 @@ class TestCQSelectors(BaseTest):
         )
 
     def testAreaNthSelector_Solids(self):
+        """
+        Selecting one of three solids with the smallest surface area
+        """
         shells = [
             Workplane("XY").box(20, 20, 20).solids().val(),
             Workplane("XY").box(10, 10, 10).solids().val(),

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -826,7 +826,7 @@ class TestCQSelectors(BaseTest):
         with self.assertRaises(IndexError):
             Workplane("XY").box(10, 10, 10).edges(selectors.AreaNthSelector(0))
 
-    def testAreaNthSelector_Wires(self):
+    def testAreaNthSelector_NestedWires(self):
         """
         Tests key parts of case seam leap creation algorithm
         (see example 26)
@@ -897,6 +897,33 @@ class TestCQSelectors(BaseTest):
             Face.makeFromWires(wp_inner_wire.val()).Area(),
             (50 - 5 * 2) * (50 - 5 * 2),
             msg="Failed to select inner wire of 2 faces: wrong area",
+        )
+
+    def testAreaNthSelector_NonplanarWire(self):
+        """
+        AreaNthSelector should raise ValueError when
+        used on non-planar wires so that they are ignored by
+        _NthSelector.
+
+        Non-planar wires in stack should not prevent selection of
+        planar wires.
+        """
+        wp = Workplane("XY").circle(10).extrude(50)
+
+        with self.assertRaises(IndexError):
+            wp.wires(selectors.AreaNthSelector(1))
+
+        cylinder_flat_ends = wp.wires(selectors.AreaNthSelector(0))
+        self.assertEqual(
+            len(cylinder_flat_ends.vals()),
+            2,
+            msg="Failed to select cylinder flat end wires: wrong N wires",
+        )
+        self.assertTupleAlmostEquals(
+            [math.pi * 10 ** 2] * 2,
+            [Face.makeFromWires(wire).Area() for wire in cylinder_flat_ends.vals()],
+            5,
+            msg="Failed to select cylinder flat end wires: wrong area",
         )
 
     def testAreaNthSelector_Faces(self):

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -702,149 +702,132 @@ class TestCQSelectors(BaseTest):
 
     def testAreaNthSelector_Vertices(self):
         with self.assertRaises(TypeError):
-            wp = \
-            Workplane("XY")\
-            .box(10,10,10)\
-            .vertices(selectors.AreaNthSelector(0))
+            wp = Workplane("XY").box(10, 10, 10).vertices(selectors.AreaNthSelector(0))
 
     def testAreaNthSelector_Edges(self):
         with self.assertRaises(TypeError):
-            wp = \
-            Workplane("XY")\
-            .box(10,10,10)\
-            .edges(selectors.AreaNthSelector(0))        
+            wp = Workplane("XY").box(10, 10, 10).edges(selectors.AreaNthSelector(0))
 
     def testAreaNthSelector_Wires(self):
         # selecting top outermost wire of square box
-        wp = \
-            Workplane("XY")\
-            .rect(50,50)\
-            .extrude(50)\
-            .faces(">Z")\
-            .shell(-5, "intersection")\
-            .faces(">Z")\
+        wp = (
+            Workplane("XY")
+            .rect(50, 50)
+            .extrude(50)
+            .faces(">Z")
+            .shell(-5, "intersection")
+            .faces(">Z")
             .wires(selectors.AreaNthSelector(-1))
-        
-        self.assertEqual(
-            len(wp.vals()), 
-            1,
-            msg="Failed to select top outermost wire "\
-                 "of the box: wrong N wires")
-        self.assertAlmostEqual(
-            Face.makeFromWires(wp.val()).Area(), 
-            50 * 50,
-            msg="Failed to select top outermost wire "\
-                 "of the box: wrong wire area")
+        )
 
-        # preparing to add an inside lip to the box        
-        wp = \
-            wp.toPending()\
-            .workplane()\
-            .offset2D(-2)\
-            .extrude(1)\
-            .faces(">Z[-2]")
-        # workplane now has 2 faces selected: 
+        self.assertEqual(
+            len(wp.vals()),
+            1,
+            msg="Failed to select top outermost wire " "of the box: wrong N wires",
+        )
+        self.assertAlmostEqual(
+            Face.makeFromWires(wp.val()).Area(),
+            50 * 50,
+            msg="Failed to select top outermost wire " "of the box: wrong wire area",
+        )
+
+        # preparing to add an inside lip to the box
+        wp = wp.toPending().workplane().offset2D(-2).extrude(1).faces(">Z[-2]")
+        # workplane now has 2 faces selected:
         # a square and a thin rectangular frame
 
-        wp_outer_wire = \
-            wp.wires(selectors.AreaNthSelector(-1))        
+        wp_outer_wire = wp.wires(selectors.AreaNthSelector(-1))
         self.assertEqual(
-            len(wp_outer_wire.vals()), 
+            len(wp_outer_wire.vals()),
             1,
-            msg="Failed to select outermost wire "\
-                 "of 2 faces: wrong N wires")
+            msg="Failed to select outermost wire " "of 2 faces: wrong N wires",
+        )
         self.assertAlmostEqual(
-            Face.makeFromWires(wp_outer_wire.val()).Area(), 
+            Face.makeFromWires(wp_outer_wire.val()).Area(),
             50 * 50,
-            msg="Failed to select outermost wire "\
-                 "of 2 faces: wrong area")
+            msg="Failed to select outermost wire " "of 2 faces: wrong area",
+        )
 
-        wp_mid_wire = \
-            wp.wires(selectors.AreaNthSelector(1))        
+        wp_mid_wire = wp.wires(selectors.AreaNthSelector(1))
         self.assertEqual(
-            len(wp_mid_wire.vals()), 
+            len(wp_mid_wire.vals()),
             1,
-            msg="Failed to select middle wire "\
-                 "of 2 faces: wrong N wires")
+            msg="Failed to select middle wire " "of 2 faces: wrong N wires",
+        )
         self.assertAlmostEqual(
-            Face.makeFromWires(wp_mid_wire.val()).Area(), 
-            (50-2*2) * (50-2*2),
-            msg="Failed to select middle wire "\
-                 "of 2 faces: wrong area")
+            Face.makeFromWires(wp_mid_wire.val()).Area(),
+            (50 - 2 * 2) * (50 - 2 * 2),
+            msg="Failed to select middle wire " "of 2 faces: wrong area",
+        )
 
-        wp_inner_wire = \
-            wp.wires(selectors.AreaNthSelector(0))        
+        wp_inner_wire = wp.wires(selectors.AreaNthSelector(0))
         self.assertEqual(
-            len(wp_inner_wire.vals()), 
+            len(wp_inner_wire.vals()),
             1,
-            msg="Failed to select inner wire "\
-                 "of 2 faces: wrong N wires")
+            msg="Failed to select inner wire " "of 2 faces: wrong N wires",
+        )
         self.assertAlmostEqual(
-            Face.makeFromWires(wp_inner_wire.val()).Area(), 
-            (50-5*2) * (50-5*2),
-            msg="Failed to select inner wire "\
-                 "of 2 faces: wrong area")
+            Face.makeFromWires(wp_inner_wire.val()).Area(),
+            (50 - 5 * 2) * (50 - 5 * 2),
+            msg="Failed to select inner wire " "of 2 faces: wrong area",
+        )
 
     def testAreaNthSelector_Faces(self):
-        wp = \
-            Workplane("XY")\
-            .box(10, 20, 30)\
-            .faces(selectors.AreaNthSelector(1))
-        
+        wp = Workplane("XY").box(10, 20, 30).faces(selectors.AreaNthSelector(1))
+
         self.assertEqual(
-            len(wp.vals()), 
+            len(wp.vals()),
             2,
-            msg="Failed to select two faces of 10-20-30 box "\
-                 "with intermediate area: wrong N faces")
-        self.assertTupleAlmostEquals(            
-            (wp.vals()[0].Area(), wp.vals()[1].Area()), 
-            (10*30, 10*30),
+            msg="Failed to select two faces of 10-20-30 box "
+            "with intermediate area: wrong N faces",
+        )
+        self.assertTupleAlmostEquals(
+            (wp.vals()[0].Area(), wp.vals()[1].Area()),
+            (10 * 30, 10 * 30),
             7,
-            msg="Failed to select two faces of 10-20-30 box "\
-                 "with intermediate area: wrong area")
+            msg="Failed to select two faces of 10-20-30 box "
+            "with intermediate area: wrong area",
+        )
 
     def testAreaNthSelector_Shells(self):
-        shells = \
-            [Shell.makeShell(
-                Workplane("XY").box(20, 20, 20).faces().vals()),
-             Shell.makeShell(
-                 Workplane("XY").box(10, 10, 10).faces().vals()),
-             Shell.makeShell(
-                 Workplane("XY").box(30, 30, 30).faces().vals())]
-            
-        selected_shells = \
-            selectors.AreaNthSelector(0).filter(shells)        
-        
+        shells = [
+            Shell.makeShell(Workplane("XY").box(20, 20, 20).faces().vals()),
+            Shell.makeShell(Workplane("XY").box(10, 10, 10).faces().vals()),
+            Shell.makeShell(Workplane("XY").box(30, 30, 30).faces().vals()),
+        ]
+
+        selected_shells = selectors.AreaNthSelector(0).filter(shells)
+
         self.assertEqual(
-            len(selected_shells), 
+            len(selected_shells),
             1,
-            msg="Failed to select the smallest shell "\
-                 ": wrong N shells")
-        self.assertAlmostEqual(            
-            selected_shells[0].Area(), 
-            10*10*6,
-            msg="Failed to select the smallest shell "\
-                 ": wrong area")
+            msg="Failed to select the smallest shell: wrong N shells",
+        )
+        self.assertAlmostEqual(
+            selected_shells[0].Area(),
+            10 * 10 * 6,
+            msg="Failed to select the smallest shell: wrong area",
+        )
 
     def testAreaNthSelector_Solids(self):
-        shells = \
-            [Workplane("XY").box(20, 20, 20).solids().val(),
-             Workplane("XY").box(10, 10, 10).solids().val(),
-             Workplane("XY").box(30, 30, 30).solids().val()]
-            
-        selected_shells = \
-            selectors.AreaNthSelector(0).filter(shells)        
-        
+        shells = [
+            Workplane("XY").box(20, 20, 20).solids().val(),
+            Workplane("XY").box(10, 10, 10).solids().val(),
+            Workplane("XY").box(30, 30, 30).solids().val(),
+        ]
+
+        selected_shells = selectors.AreaNthSelector(0).filter(shells)
+
         self.assertEqual(
-            len(selected_shells), 
+            len(selected_shells),
             1,
-            msg="Failed to select the smallest solid "\
-                 ": wrong N shells")
-        self.assertAlmostEqual(            
-            selected_shells[0].Area(), 
-            10*10*6,
-            msg="Failed to select the smallest solid "\
-                 ": wrong area")
+            msg="Failed to select the smallest solid: wrong N shells",
+        )
+        self.assertAlmostEqual(
+            selected_shells[0].Area(),
+            10 * 10 * 6,
+            msg="Failed to select the smallest solid: wrong area",
+        )
 
     def testAndSelector(self):
         c = CQ(makeUnitCube())


### PR DESCRIPTION
Added AreaNthSelector that is useful for nested features selection. Especially to select one of coplanar nested wires for subsequent extrusion, cutting or filleting.

This selector was developed as a result of discussion in #684