### PR TITLE
Docstring and error message fixes

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3040,7 +3040,7 @@ class Workplane(object):
     ) -> T:
         """
         Unions all of the items on the stack of toUnion with the current solid.
-        If there is no current solid, the items in toUnion are unironed together.
+        If there is no current solid, the items in toUnion are unioned together.
 
         :param toUnion:
         :type toUnion: a solid object, or a CQ object having a solid,

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -477,7 +477,7 @@ class Workplane(object):
         The result will be a 2-d working plane
         with a new coordinate system set up as follows:
 
-           * The centerOption paramter sets how the center is defined.
+           * The centerOption parameter sets how the center is defined.
              Options are 'CenterOfMass', 'CenterOfBoundBox', or 'ProjectedOrigin'.
              'CenterOfMass' and 'CenterOfBoundBox' are in relation to the selected
              face(s) or vertex (vertices). 'ProjectedOrigin' uses by default the current origin
@@ -1443,7 +1443,7 @@ class Workplane(object):
             false, angle is the angle between elements.
         :param count: Number of elements in array. ( > 0 )
         :param fill: Interpret the angle as total if True (default: True).
-        :param rotate: Rorate every item (default: True).
+        :param rotate: Rotate every item (default: True).
         """
 
         if count <= 0:
@@ -2778,7 +2778,7 @@ class Workplane(object):
         complex geometries
 
         :param distance: the distance to extrude normal to the workplane
-        :param angle: angline ( in degrees) to rotate through the extrusion
+        :param angle: angle (in degrees) to rotate through the extrusion
         :param boolean combine: True to combine the resulting solid with parent solids if found.
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
         :return: a CQ object with the resulting solid selected.
@@ -2791,7 +2791,7 @@ class Workplane(object):
         eDir = self.plane.zDir.multiply(distance)
 
         # one would think that fusing faces into a compound and then extruding would work,
-        # but it doesnt-- the resulting compound appears to look right, ( right number of faces, etc)
+        # but it doesn't-- the resulting compound appears to look right, ( right number of faces, etc)
         # but then cutting it from the main solid fails with BRep_NotDone.
         # the work around is to extrude each and then join the resulting solids, which seems to work
 
@@ -2955,7 +2955,7 @@ class Workplane(object):
             from warnings import warn
 
             warn(
-                "sweepAlongWires keyword argument is is depracated and will "
+                "sweepAlongWires keyword argument is is deprecated and will "
                 "be removed in the next version; use multisection instead",
                 DeprecationWarning,
             )
@@ -3040,7 +3040,7 @@ class Workplane(object):
     ) -> T:
         """
         Unions all of the items on the stack of toUnion with the current solid.
-        If there is no current solid, the items in toUnion are unioned together.
+        If there is no current solid, the items in toUnion are unironed together.
 
         :param toUnion:
         :type toUnion: a solid object, or a CQ object having a solid,

--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -384,7 +384,7 @@ class Plane(object):
         :param stdName: one of (XY|YZ|ZX|XZ|YX|ZY|front|back|left|right|top|bottom)
         :type stdName: string
         :param origin: the desired origin, specified in global coordinates
-        :type origin: 3-tuple of the origin of the new plane, in global coorindates.
+        :type origin: 3-tuple of the origin of the new plane, in global coordinates.
 
         Available named planes are as follows. Direction references refer to
         the global directions.
@@ -879,7 +879,7 @@ class Location(object):
 
     @overload
     def __init__(self, t: Vector) -> None:
-        """Location with translation t with respect to the orignal location."""
+        """Location with translation t with respect to the original location."""
         ...
 
     @overload

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -869,7 +869,7 @@ class Shape(object):
         transformations.
 
         If your transformation is only translation and rotation, it is safer to
-        use :py:meth:`transformShape`, which doesnt change the underlying type
+        use :py:meth:`transformShape`, which doesn't change the underlying type
         of the geometry, but cannot handle skew transformations.
 
         :param tMatrix: The transformation matrix
@@ -1607,7 +1607,7 @@ class Wire(Shape, Mixin1D):
         cls: Type["Wire"], listOfWires: Iterable[Union["Wire", Edge]], tol: float = 1e-9
     ) -> List["Wire"]:
         """
-        Attempt to combine a list of wires and egdes into a new wire.
+        Attempt to combine a list of wires and edges into a new wire.
         :param cls:
         :param listOfWires:
         :param tol: default 1e-9
@@ -2248,7 +2248,7 @@ class Solid(Shape, Mixin3D):
         :param surf_pts = [] (uses only edges if [])
         :type surf_pts: list of [x,y,z] float coordinates
         :param thickness = 0 (returns 2D surface if 0)
-        :type thickness: float (may be negative or positive depending on thicknening direction)
+        :type thickness: float (may be negative or positive depending on thickening direction)
         :param Degree = 3 (OCCT default)
         :type Degree: Integer >= 2
         :param NbPtsOnCur = 15 (OCCT default)
@@ -2423,7 +2423,7 @@ class Solid(Shape, Mixin3D):
     ) -> "Solid":
         """
         makeTorus(radius1,radius2,[pnt,dir,angle1,angle2,angle]) --
-        Make a torus with agiven radii and angles
+        Make a torus with a given radii and angles
         By default pnt=Vector(0,0,0),dir=Vector(0,0,1),angle1=0
         ,angle1=360 and angle=360'
         """

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -425,7 +425,7 @@ class DirectionMinMaxSelector(CenterNthSelector):
         CQ(aCube).faces(DirectionMinMaxSelector((0, 0, 1), True)
 
     Means to select the face having the center of mass farthest in the positive
-    z direction, and is the same as:
+    z direction, and is the same as::
 
         CQ(aCube).faces(">Z")
 
@@ -487,49 +487,49 @@ class AreaNthSelector(_NthSelector):
     Selects the object(s) with Nth area
 
     Applicability:
-        Faces, Shells, Solids - Shape.Area() is used to compute area
-        closed planar Wires - a temporary face is created to compute area
+        - Faces, Shells, Solids - Shape.Area() is used to compute area
+        - closed planar Wires - a temporary face is created to compute area
 
     Will ignore non-planar or non-closed wires.
     
     Among other things can be used to select one of
     the nested coplanar wires or faces.
 
-    For example to create a fillet on a shank:
+    For example to create a fillet on a shank::
 
-        result = (
-            cq.Workplane("XY")
-            .circle(5)
-            .extrude(2)
-            .circle(2)
-            .extrude(10)
-            .faces(">Z[-2]")
-            .wires(AreaNthSelector(0))
-            .fillet(2)
-        )
+       result = (
+           cq.Workplane("XY")
+           .circle(5)
+           .extrude(2)
+           .circle(2)
+           .extrude(10)
+           .faces(">Z[-2]")
+           .wires(AreaNthSelector(0))
+           .fillet(2)
+       )
 
-    Or to create a lip on a case seam:
+    Or to create a lip on a case seam::
 
-        result = (
-            cq.Workplane("XY")
-            .rect(20, 20)
-            .extrude(10)
-            .edges("|Z or <Z")
-            .fillet(2)
-            .faces(">Z")
-            .shell(2)
-            .faces(">Z")
-            .wires(AreaNthSelector(-1))
-            .toPending()
-            .workplane()
-            .offset2D(-1)
-            .extrude(1)
-            .faces(">Z[-2]")
-            .wires(AreaNthSelector(0))
-            .toPending()
-            .workplane()
-            .cutBlind(2)
-        )
+       result = (
+           cq.Workplane("XY")
+           .rect(20, 20)
+           .extrude(10)
+           .edges("|Z or <Z")
+           .fillet(2)
+           .faces(">Z")
+           .shell(2)
+           .faces(">Z")
+           .wires(AreaNthSelector(-1))
+           .toPending()
+           .workplane()
+           .offset2D(-1)
+           .extrude(1)
+           .faces(">Z[-2]")
+           .wires(AreaNthSelector(0))
+           .toPending()
+           .workplane()
+           .cutBlind(2)
+       )
     """
 
     def key(self, obj: Shape) -> float:

--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -17,7 +17,7 @@ class deprecate_kwarg:
 
             if self.name not in f_sig_bound.kwargs:
                 warn(
-                    f"Default walue of {self.name} will change in the next relase to {self.new_value}",
+                    f"Default value of {self.name} will change in the next release to {self.new_value}",
                     FutureWarning,
                 )
 
@@ -31,7 +31,7 @@ class deprecate:
         @wraps(f)
         def wrapped(*args, **kwargs):
 
-            warn(f"{f.__name__} will be removed in the next relase.", FutureWarning)
+            warn(f"{f.__name__} will be removed in the next release.", FutureWarning)
 
             return f(*args, **kwargs)
 


### PR DESCRIPTION
- Fixed code examples in AreaNthSelector docstring (previously were not formatted as code blocks).
- Fixed some typos caught with Code Spell Checker VS Code extension