### PR TITLE
Remove authors file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,0 @@
-# Core CQ Developers
-
-* [Dave Cowden](https://github.com/dcowden), Creator - Lead Developer
-* [Jeremy Wright](https://github.com/jmwright) (a.k.a [innovationstech](https://github.com/innovationstech))


### PR DESCRIPTION
Currently, there are only two authors: Dave Cowden and Jeremy Wright. There is no mention to Adam Urbańczyk. So, we can add Adam to the file or just remove it. Anyone can already see the authors of CadQuery [here](https://github.com/CadQuery/cadquery/graphs/contributors).

Don't get me wrong, authors are import and the three leaders of CadQuery deserve recognition for their work. But I just feel like we should remove the file and move on.