### PR TITLE
Convert int text sizes to floats

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3050,7 +3050,9 @@ class Compound(Shape, Mixin3D):
 
         builder = Font_BRepTextBuilder()
         font_i = StdPrs_BRepFont(
-            NCollection_Utf8String(font_t.FontName().ToCString()), font_kind, size
+            NCollection_Utf8String(font_t.FontName().ToCString()),
+            font_kind,
+            float(size),
         )
         text_flat = Shape(builder.Perform(font_i, NCollection_Utf8String(text)))
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3293,6 +3293,15 @@ class TestCadQuery(BaseTest):
         # verify that the number of solids is correct
         self.assertEqual(len(obj5.solids().vals()), 5)
 
+        # check it doesn't fall over with int sizes
+        obj1 = (
+            box.faces(">Z")
+            .workplane()
+            .text(
+                "CQ 2.0", 10, -1, cut=True, halign="left", valign="bottom", font="Sans",
+            )
+        )
+
     def testParametricCurve(self):
 
         from math import sin, cos, pi


### PR DESCRIPTION
A quick fix for #762.

Even if we remove the `occ_impl/shapes.py` change at a later date after fixing this somewhere upstream, I think the test should stay.