### PR TITLE
Fixed OCP Dependency bug (#790)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.6
   - ipython
-  - ocp=7.5
+  - ocp=7.5.1
   - pyparsing
   - sphinx=3.2.1
   - sphinx_rtd_theme


### PR DESCRIPTION
Having `ocp=7.5` was causing errors -- as can be seen in #790 -- because the latest OCP version seemed to be problematic with CADQuery. OCP `v7.5.1` is the latest OCP version supported right now.