### PR TITLE
Handle constraints from infinite faces

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -135,9 +135,6 @@ class Constraint(object):
         else:
             center = arg.Center()
 
-        if center.Length > 1e98:
-            raise ValueError(f"{arg} has unrealistic Center of {center}")
-
         return center.toPnt()
 
     def toPOD(self) -> ConstraintPOD:

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2264,6 +2264,17 @@ class Face(Shape):
 
         return self.__class__(chamfer_builder.Shape()).fix()
 
+    def toPln(self) -> gp_Pln:
+        """
+        Convert this face to a gp_Pln.
+
+        Note the Location of the resulting plane may not equal the center of this face,
+        however the resulting plane will still contain the center of this face.
+        """
+
+        adaptor = BRepAdaptor_Surface(self.wrapped)
+        return adaptor.Plane()
+
 
 class Shell(Shape):
     """

--- a/cadquery/occ_impl/solver.py
+++ b/cadquery/occ_impl/solver.py
@@ -256,7 +256,7 @@ class ConstraintSolver(object):
         opt.set_ftol_abs(0)
         opt.set_ftol_rel(0)
         opt.set_xtol_rel(TOL)
-        opt.set_xtol_abs(0)
+        opt.set_xtol_abs(TOL * 1e-3)
         opt.set_maxeval(MAXITER)
 
         x = opt.optimize(x0)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -4595,3 +4595,26 @@ class TestCadQuery(BaseTest):
 
         self.assertTrue(si.isValid())
         self.assertAlmostEqual(si.Volume(), 1)
+
+    def testFaceToPln(self):
+
+        origin = (1, 2, 3)
+        normal = (1, 1, 1)
+        f0 = Face.makePlane(length=None, width=None, basePnt=origin, dir=normal)
+        p0 = f0.toPln()
+
+        self.assertTrue(Vector(p0.Location()) == Vector(origin))
+        self.assertTrue(Vector(p0.Axis().Direction()) == Vector(normal).normalized())
+
+        origin1 = (0, 0, -3)
+        normal1 = (-1, 1, -1)
+        f1 = Face.makePlane(length=0.1, width=100, basePnt=origin1, dir=normal1)
+        p1 = f1.toPln()
+
+        self.assertTrue(Vector(p1.Location()) == Vector(origin1))
+        self.assertTrue(Vector(p1.Axis().Direction()) == Vector(normal1).normalized())
+
+        f2 = Workplane().box(1, 1, 10, centered=False).faces(">Z").val()
+        p2 = f2.toPln()
+        self.assertTrue(p2.Contains(f2.Center().toPnt(), 0.1))
+        self.assertTrue(Vector(p2.Axis().Direction()) == f2.normalAt())


### PR DESCRIPTION
Will close #758, where I wanted to specify a plane for a constraint (defined by an origin and a normal), so the obvious Shape to use was from `Face.makePlane(width=None, length=None)`, but this shape has a center at 1e99.

To handle it I had to use `gp_Pln` a lot because it turns out two offset infinite faces will still have the same Center:
```python
>>> a = cq.Face.makePlane(width=None, length=None, basePnt=(1, 2, 3), dir=(1, 1, 1))
>>> a.Center()
Vector: (5e+99, -5e+99, 5e+99)
>>> b = cq.Face.makePlane(width=None, length=None, basePnt=(1000, 0, 0), dir=(1, 1, 1))
>>> b.Center()
Vector: (5e+99, -5e+99, 5e+99)
>>> a.Center() == b.Center()
True
```

But now by converting them to `gp_Pln` you can get the origin that the user intends:
```python
>>> cq.Vector(a.toPln().Location())
Vector: (1.0, 2.0, 3.0)
```