### PR TITLE
text() docstring update

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3930,7 +3930,7 @@ class Workplane(object):
         :param fontPath: path to font file
         :param kind: font type (default: regular)
         :param halign: horizontal alignment
-        :param valign: vertical alignment (default: center)
+        :param valign: vertical alignment
         :return: a CQ object with the resulting solid selected
 
         The returned object is always a CQ object, and depends on whether combine is True, and

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3946,7 +3946,7 @@ class Workplane(object):
 
         Specify the font (name), and kind to use an installed system font::
 
-            cq.Workplane().text("CadQuery",5,1,font="Liberation Sans Narrow", kind="italic")
+            cq.Workplane().text("CadQuery", 5, 1, font="Liberation Sans Narrow", kind="italic")
 
         Specify fontPath to use a font from a given file::
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3928,7 +3928,7 @@ class Workplane(object):
         :param clean: call :py:meth:`clean` afterwards to have a clean shape
         :param font: font name
         :param fontPath: path to font file
-        :param kind: font type (default: regular)
+        :param kind: font type
         :param halign: horizontal alignment
         :param valign: vertical alignment
         :return: a CQ object with the resulting solid selected

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3942,7 +3942,7 @@ class Workplane(object):
 
         Examples::
 
-            cq.Workplane().text("CadQuery",5,1)
+            cq.Workplane().text("CadQuery", 5, 1)
 
         Specify the font (name), and kind to use an installed system font::
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3954,7 +3954,7 @@ class Workplane(object):
 
         Cutting text into a solid::
 
-            cq.Workplane().box(8,8,8).faces(">Z").workplane().text("Z", 5,-1.0)
+            cq.Workplane().box(8, 8, 8).faces(">Z").workplane().text("Z", 5, -1.0)
 
         """
         r = Compound.makeText(

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3929,7 +3929,7 @@ class Workplane(object):
         :param font: font name
         :param fontPath: path to font file
         :param kind: font type (default: regular)
-        :param halign: horizontal alignment (default: center)
+        :param halign: horizontal alignment
         :param valign: vertical alignment (default: center)
         :return: a CQ object with the resulting solid selected
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3950,7 +3950,7 @@ class Workplane(object):
 
         Specify fontPath to use a font from a given file::
 
-            cq.Workplane().text("CadQuery",5,1, fontPath="/opt/fonts/texgyrecursor-bold.otf")
+            cq.Workplane().text("CadQuery", 5, 1, fontPath="/opt/fonts/texgyrecursor-bold.otf")
 
         Cutting text into a solid::
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3933,7 +3933,7 @@ class Workplane(object):
         :param valign: vertical alignment
         :return: a CQ object with the resulting solid selected
 
-        The returned object is always a CQ object, and depends on whether combine is True, and
+        The returned object is always a Workplane object, and depends on whether combine is True, and
         whether a context solid is already defined:
 
         *  if combine is False, the new value is pushed onto the stack.

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3926,7 +3926,7 @@ class Workplane(object):
         :param cut: True to cut the resulting solid from the parent solids if found
         :param combine: True to combine the resulting solid with parent solids if found
         :param clean: call :py:meth:`clean` afterwards to have a clean shape
-        :param font: font name (default: Arial)
+        :param font: font name
         :param fontPath: path to font file
         :param kind: font type (default: regular)
         :param halign: horizontal alignment (default: center)

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3919,20 +3919,21 @@ class Workplane(object):
         """
         Create a 3D text
 
-        :param str txt: text to be rendered
-        :param distance: the distance to extrude, normal to the workplane plane
+        :param self:
+        :type self: Workplane
+        :param txt: text to be rendered
+        :param fontsize: size of the font in model units
+        :param distance: the distance to extrude or cut, normal to the workplane plane
         :type distance: float, negative means opposite the normal direction
-        :param float fontsize: size of the font
-        :param boolean cut: True to cut the resulting solid from the parent solids if found.
-        :param boolean combine: True to combine the resulting solid with parent solids if found.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :param str font: fontname (default: Arial)
-        :param str kind: font type (default: Normal)
-        :param str halign: horizontal alignment (default: center)
-        :param str valign: vertical alignment (default: center)
-        :return: a CQ object with the resulting solid selected.
-
-        extrude always *adds* material to a part.
+        :param cut: True to cut the resulting solid from the parent solids if found
+        :param combine: True to combine the resulting solid with parent solids if found
+        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param font: font name (default: Arial)
+        :param fontPath: path to font file
+        :param kind: font type (default: regular)
+        :param halign: horizontal alignment (default: center)
+        :param valign: vertical alignment (default: center)
+        :return: a CQ object with the resulting solid selected
 
         The returned object is always a CQ object, and depends on whether combine is True, and
         whether a context solid is already defined:
@@ -3940,6 +3941,22 @@ class Workplane(object):
         *  if combine is False, the new value is pushed onto the stack.
         *  if combine is true, the value is combined with the context solid if it exists,
            and the resulting solid becomes the new context solid.
+
+        Examples::
+
+            cq.Workplane().text("CadQuery",5,1)
+
+        Specify the font (name), and kind to use an installed system font::
+
+            cq.Workplane().text("CadQuery",5,1,font="Liberation Sans Narrow", kind="italic")
+
+        Specify fontPath to use a font from a given file::
+
+            cq.Workplane().text("CadQuery",5,1, fontPath="/opt/fonts/texgyrecursor-bold.otf")
+
+        Cutting text into a solid::
+
+            cq.Workplane().box(8,8,8).faces(">Z").workplane().text("Z", 5,-1.0)
 
         """
         r = Compound.makeText(

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3919,8 +3919,6 @@ class Workplane(object):
         """
         Create a 3D text
 
-        :param self:
-        :type self: Workplane
         :param txt: text to be rendered
         :param fontsize: size of the font in model units
         :param distance: the distance to extrude or cut, normal to the workplane plane


### PR DESCRIPTION
    * Remove following line from docstring (appears to be copy/paste error from extrude())

       extrude always *adds* material to a part.

    * Swap order of :param distance: and :param fontsize: to match argument order

    * Mention fontsize is in model units (fix #463)

    * distance: mention distance is for both extrude/cut

    * Update kind default in docstring as "regular" not "Normal"

    * Add missing fontPath arg description

    * Add examples of usage

      - Using an installed system font

      - Using a font at provided path (when font not installed on system)

        I tested with the free fonts from http://www.gust.org.pl/projects/e-foundry/tex-gyre

      - Cut text into solid

    * Change docstring to fix autodoc-typehints issue where the Parameters section is duplicated (see screenshot)

  If this fix looks good, I can follow up with a similar docstring fix for the duplicate Parameters issue on other methods.

current

![docs_text_current_duplicate_parameters](https://user-images.githubusercontent.com/16394272/124514971-4b28a380-ddac-11eb-87ca-9797d17ae959.png)



update:

![doc_text_update](https://user-images.githubusercontent.com/16394272/124514996-554aa200-ddac-11eb-8d9a-403734eb350b.png)
