### PR TITLE
VTK.js camera default position

### DIFF
--- a/cadquery/cq_directive.py
+++ b/cadquery/cq_directive.py
@@ -183,6 +183,7 @@ function render(data, parent_element, ratio){
 
     renderWindow.addRenderer(renderer);
     updateViewPort(container, renderer);
+    renderer.getActiveCamera().set({ position: [-1, -1, -0.7], viewUp: [0, 0, -1] });
     renderer.resetCamera();
 
     RENDERERS[ID] = renderer;

--- a/cadquery/cq_directive.py
+++ b/cadquery/cq_directive.py
@@ -183,7 +183,7 @@ function render(data, parent_element, ratio){
 
     renderWindow.addRenderer(renderer);
     updateViewPort(container, renderer);
-    renderer.getActiveCamera().set({ position: [-1, -1, 0.7], viewUp: [0, 0, 1] });
+    renderer.getActiveCamera().set({ position: [1, -1, 0.7], viewUp: [0, 0, 1] });
     renderer.resetCamera();
 
     RENDERERS[ID] = renderer;

--- a/cadquery/cq_directive.py
+++ b/cadquery/cq_directive.py
@@ -183,7 +183,7 @@ function render(data, parent_element, ratio){
 
     renderWindow.addRenderer(renderer);
     updateViewPort(container, renderer);
-    renderer.getActiveCamera().set({ position: [1, -1, 0.7], viewUp: [0, 0, 1] });
+    renderer.getActiveCamera().set({ position: [1, -1, 1], viewUp: [0, 0, 1] });
     renderer.resetCamera();
 
     RENDERERS[ID] = renderer;

--- a/cadquery/cq_directive.py
+++ b/cadquery/cq_directive.py
@@ -183,7 +183,7 @@ function render(data, parent_element, ratio){
 
     renderWindow.addRenderer(renderer);
     updateViewPort(container, renderer);
-    renderer.getActiveCamera().set({ position: [-1, -1, -0.7], viewUp: [0, 0, -1] });
+    renderer.getActiveCamera().set({ position: [-1, -1, -0.7], viewUp: [0, 0, 1] });
     renderer.resetCamera();
 
     RENDERERS[ID] = renderer;

--- a/cadquery/cq_directive.py
+++ b/cadquery/cq_directive.py
@@ -183,7 +183,7 @@ function render(data, parent_element, ratio){
 
     renderWindow.addRenderer(renderer);
     updateViewPort(container, renderer);
-    renderer.getActiveCamera().set({ position: [-1, -1, -0.7], viewUp: [0, 0, 1] });
+    renderer.getActiveCamera().set({ position: [-1, -1, 0.7], viewUp: [0, 0, 1] });
     renderer.resetCamera();
 
     RENDERERS[ID] = renderer;


### PR DESCRIPTION
Here is the default isometric view from CQ-editor:
![screenshot2021-07-11-160947](https://user-images.githubusercontent.com/50230945/125185234-ddc0bb00-e262-11eb-8b45-1f77c66cac17.png)

Here is [the current doc's view](https://cadquery.readthedocs.io/en/latest/examples.html#splitting-an-object):
![screenshot2021-07-11-161351](https://user-images.githubusercontent.com/50230945/125185246-fe891080-e262-11eb-9959-add012a2ba8f.png)

Here is [this PR's view](https://cadquery--822.org.readthedocs.build/en/822/examples.html#splitting-an-object):
![screenshot2021-07-11-161436](https://user-images.githubusercontent.com/50230945/125185269-1e203900-e263-11eb-98bd-f5de449cf610.png)
