### PR TITLE
Mixin3D.shell: removed deprecated OCCT method

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2351,7 +2351,7 @@ class Mixin3D(object):
 
     def shell(
         self: Any,
-        faceList: Iterable[Face],
+        faceList: Optional[Iterable[Face]],
         thickness: float,
         tolerance: float = 0.0001,
         kind: Literal["arc", "intersection"] = "arc",
@@ -2375,8 +2375,9 @@ class Mixin3D(object):
         occ_faces_list = TopTools_ListOfShape()
         shell_builder = BRepOffsetAPI_MakeThickSolid()
 
-        for f in faceList:
-            occ_faces_list.Append(f.wrapped)
+        if faceList:
+            for f in faceList:
+                occ_faces_list.Append(f.wrapped)
 
         shell_builder.MakeThickSolidByJoin(
             self.wrapped,

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2357,12 +2357,14 @@ class Mixin3D(object):
         kind: Literal["arc", "intersection"] = "arc",
     ) -> Any:
         """
-            make a shelled solid of given  by removing the list of faces
+        Make a shelled solid of self.
 
-        :param faceList: list of face objects, which must be part of the solid.
-        :param thickness: floating point thickness. positive shells outwards, negative shells inwards
-        :param tolerance: modelling tolerance of the method, default=0.0001
-        :return: a shelled solid
+        :param faceList: List of faces to be removed, which must be part of the solid. Can
+          be an empty list.
+        :param thickness: Floating point thickness. Positive shells outwards, negative
+          shells inwards.
+        :param tolerance: Modelling tolerance of the method, default=0.0001.
+        :return: A shelled solid.
         """
 
         kind_dict = {
@@ -2371,45 +2373,38 @@ class Mixin3D(object):
         }
 
         occ_faces_list = TopTools_ListOfShape()
+        shell_builder = BRepOffsetAPI_MakeThickSolid()
+
+        for f in faceList:
+            occ_faces_list.Append(f.wrapped)
+
+        shell_builder.MakeThickSolidByJoin(
+            self.wrapped,
+            occ_faces_list,
+            thickness,
+            tolerance,
+            Intersection=True,
+            Join=kind_dict[kind],
+        )
+        shell_builder.Build()
 
         if faceList:
-            for f in faceList:
-                occ_faces_list.Append(f.wrapped)
-
-            shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped,
-                occ_faces_list,
-                thickness,
-                tolerance,
-                Intersection=True,
-                Join=kind_dict[kind],
-            )
-
-            shell_builder.Build()
-            rv = shell_builder.Shape()
+            rv = self.__class__(shell_builder.Shape())
 
         else:  # if no faces provided a watertight solid will be constructed
-            shell_builder = BRepOffsetAPI_MakeThickSolid(
-                self.wrapped,
-                occ_faces_list,
-                thickness,
-                tolerance,
-                Intersection=True,
-                Join=kind_dict[kind],
-            )
-
-            shell_builder.Build()
             s1 = self.__class__(shell_builder.Shape()).Shells()[0].wrapped
             s2 = self.Shells()[0].wrapped
 
             # s1 can be outer or inner shell depending on the thickness sign
             if thickness > 0:
-                rv = BRepBuilderAPI_MakeSolid(s1, s2).Shape()
+                sol = BRepBuilderAPI_MakeSolid(s1, s2)
             else:
-                rv = BRepBuilderAPI_MakeSolid(s2, s1).Shape()
+                sol = BRepBuilderAPI_MakeSolid(s2, s1)
 
-        # fix needed for the orientations
-        return self.__class__(rv) if faceList else self.__class__(rv).fix()
+            # fix needed for the orientations
+            rv = self.__class__(sol.Shape()).fix()
+
+        return rv
 
     def isInside(
         self: ShapeProtocol, point: VectorLike, tolerance: float = 1.0e-6

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2290,6 +2290,14 @@ class TestCadQuery(BaseTest):
         s3 = Workplane().polyline(pts).close().extrude(1).shell(-0.05)
         self.assertTrue(s3.val().isValid())
 
+        s4_shape = Workplane("XY").box(2, 2, 2).val()
+        # test that None and empty list both work and are equivalent
+        s4_shell_1 = s4_shape.shell(faceList=None, thickness=-0.1)
+        s4_shell_2 = s4_shape.shell(faceList=[], thickness=-0.1)
+        # this should be the same as the first shape
+        self.assertEqual(len(s4_shell_1.Faces()), s1.faces().size())
+        self.assertEqual(len(s4_shell_2.Faces()), s1.faces().size())
+
     def testOpenCornerShell(self):
         s = Workplane("XY").box(1, 1, 1)
         s1 = s.faces("+Z")


### PR DESCRIPTION
Will close #649.

I also shortened the code a bit, there was a few duplicated calls.