### PR TITLE
Edit doc referring to old centerOption behaviour

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -59,7 +59,7 @@ Plate with Hole
 A rectangular box, but with a hole added.
 
 "\>Z" selects the top most face of the resulting box.  The hole is located in the center because the default origin
-of a working plane is at the center of the face.  The default hole depth is through the entire part.
+of a working plane is the projected origin of the last Workplane, the last Worplane having origin at (0,0,0) the projection is at the center of the face.  The default hole depth is through the entire part.
 
 .. cadquery::
 


### PR DESCRIPTION
This part of the doc was referring to the centerOption being the centerOfMass of a face by default. I changed it to refer to the new behaviour