### PR TITLE
Added cylinder 3D primitive to Workplane.

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3802,8 +3802,8 @@ class Workplane(object):
 
     def cylinder(
         self: T,
-        radius: float,
         height: float,
+        radius: float,
         direct: Vector = Vector(0, 0, 1),
         angle: float = 360,
         centered: Union[bool, Tuple[bool, bool, bool]] = True,
@@ -3813,10 +3813,10 @@ class Workplane(object):
         """
         Returns a cylinder with the specified radius and height for each point on the stack
 
-        :param radius: The radius of the cylinder
-        :type radius: float > 0
         :param height: The height of the cylinder
         :type height: float > 0
+        :param radius: The radius of the cylinder
+        :type radius: float > 0
         :param direct: The direction axis for the creation of the cylinder
         :type direct: A three-tuple
         :param angle: The angle to sweep the cylinder arc through

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3804,11 +3804,12 @@ class Workplane(object):
         self: T,
         radius: float,
         height: float,
+        direct: Vector = Vector(0, 0, 1),
+        angle: float = 360,
         centered: Union[bool, Tuple[bool, bool, bool]] = True,
         combine: bool = True,
         clean: bool = True,
     ) -> T:
-
         """
         Returns a cylinder with the specified radius and height for each point on the stack
 
@@ -3816,6 +3817,10 @@ class Workplane(object):
         :type radius: float > 0
         :param height: The height of the cylinder
         :type height: float > 0
+        :param direct: The direction axis for the creation of the cylinder
+        :type direct: A three-tuple
+        :param angle: The angle to sweep the cylinder arc through
+        :type angle: float > 0
         :param centered: If True, the cylinder will be centered around the reference point. If False,
             the corner of a bounding box around the cylinder will be on the reference point and it
             will extend in the positive x, y and z directions. Can also use a 3-tuple to specify
@@ -3845,12 +3850,12 @@ class Workplane(object):
         if not centered[1]:
             offset += Vector(0, radius, 0)
         if centered[2]:
-            offset += Vector(0, 0, -height/2)
+            offset += Vector(0, 0, -height / 2)
 
-        c = self.circle(radius)._extrude(height).move(Location(offset))
+        s = Solid.makeCylinder(radius, height, offset, direct, angle)
 
         # We want a cylinder for each point on the workplane
-        cylinders = self.eachpoint(lambda loc: c.moved(loc), True)
+        cylinders = self.eachpoint(lambda loc: s.moved(loc), True)
 
         # If we don't need to combine everything, just return the created cylinders
         if not combine:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3801,13 +3801,13 @@ class Workplane(object):
             return self.union(spheres, clean=clean)
 
     def cylinder(
-            self: T,
-            radius: float,
-            height: float,
-            centered: Union[bool, Tuple[bool, bool, bool]] = True,
-            combine: bool = True,
-            clean: bool = True,
-        ) -> T:
+        self: T,
+        radius: float,
+        height: float,
+        centered: Union[bool, Tuple[bool, bool, bool]] = True,
+        combine: bool = True,
+        clean: bool = True,
+    ) -> T:
 
         """
         Returns a cylinder with the specified radius and height for each point on the stack

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3832,7 +3832,7 @@ class Workplane(object):
         :return: A cylinder object for each point on the stack
 
         One cylinder is created for each item on the current stack. If no items are on the stack, one
-        box using the current workplane center is created.
+        cylinder using the current workplane center is created.
 
         If combine is true, the result will be a single object on the stack. If a solid was found
         in the chain, the result is that solid with all cylinders produced fused onto it otherwise,

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3832,7 +3832,7 @@ class Workplane(object):
         :return: A cylinder object for each point on the stack
 
         One cylinder is created for each item on the current stack. If no items are on the stack, one
-        cylinder using the current workplane center is created.
+        cylinder is created using the current workplane center.
 
         If combine is true, the result will be a single object on the stack. If a solid was found
         in the chain, the result is that solid with all cylinders produced fused onto it otherwise,

--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -90,6 +90,7 @@ Some 3-d operations also require an active 2-d workplane, but some do not.
 	Workplane.cutThruAll
 	Workplane.box
 	Workplane.sphere
+	Workplane.cylinder
 	Workplane.union
 	Workplane.combine
 	Workplane.intersect

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -81,7 +81,6 @@ rotation/transform that return a copy
 primitive creation
     Need primitive creation for:
         * cone
-        * cylinder
         * torus
         * wedge
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2445,7 +2445,6 @@ class TestCadQuery(BaseTest):
 
     def testCylinderDefaults(self):
         s = Workplane("XY").cylinder(20, 10)
-        self.saveModel(s)
         self.assertEqual(1, s.size())
         self.assertEqual(1, s.solids().size())
         self.assertEqual(3, s.faces().size())

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2458,20 +2458,24 @@ class TestCadQuery(BaseTest):
         b = (True, False)
         expected_x = (0, radius)
         expected_y = (0, radius)
-        expected_z = (0, height/2)
+        expected_z = (0, height / 2)
         for (xopt, xval), (yopt, yval), (zopt, zval) in product(
             zip(b, expected_x), zip(b, expected_y), zip(b, expected_z)
         ):
             s = Workplane("XY").cylinder(radius, height, centered=(xopt, yopt, zopt))
             self.assertEqual(1, s.size())
-            self.assertTupleAlmostEquals(s.val().Center().toTuple(), (xval, yval, zval), 3)
+            self.assertTupleAlmostEquals(
+                s.val().Center().toTuple(), (xval, yval, zval), 3
+            )
         # check centered=True produces the same result as centered=(True, True, True)
         for val in b:
             s0 = Workplane("XY").cylinder(radius, height, centered=val)
             self.assertEqual(s0.size(), 1)
             s1 = Workplane("XY").cylinder(radius, height, centered=(val, val, val))
             self.assertEqual(s1.size(), 1)
-            self.assertTupleAlmostEquals(s0.val().Center().toTuple(), s1.val().Center().toTuple(), 3)
+            self.assertTupleAlmostEquals(
+                s0.val().Center().toTuple(), s1.val().Center().toTuple(), 3
+            )
 
     def testWedgeDefaults(self):
         s = Workplane("XY").wedge(10, 10, 10, 5, 5, 5, 5)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2444,7 +2444,7 @@ class TestCadQuery(BaseTest):
         self.assertEqual(4, s.faces().size())
 
     def testCylinderDefaults(self):
-        s = Workplane("XY").cylinder(10, 20)
+        s = Workplane("XY").cylinder(20, 10)
         self.saveModel(s)
         self.assertEqual(1, s.size())
         self.assertEqual(1, s.solids().size())
@@ -2462,16 +2462,16 @@ class TestCadQuery(BaseTest):
         for (xopt, xval), (yopt, yval), (zopt, zval) in product(
             zip(b, expected_x), zip(b, expected_y), zip(b, expected_z)
         ):
-            s = Workplane("XY").cylinder(radius, height, centered=(xopt, yopt, zopt))
+            s = Workplane("XY").cylinder(height, radius, centered=(xopt, yopt, zopt))
             self.assertEqual(1, s.size())
             self.assertTupleAlmostEquals(
                 s.val().Center().toTuple(), (xval, yval, zval), 3
             )
         # check centered=True produces the same result as centered=(True, True, True)
         for val in b:
-            s0 = Workplane("XY").cylinder(radius, height, centered=val)
+            s0 = Workplane("XY").cylinder(height, radius, centered=val)
             self.assertEqual(s0.size(), 1)
-            s1 = Workplane("XY").cylinder(radius, height, centered=(val, val, val))
+            s1 = Workplane("XY").cylinder(height, radius, centered=(val, val, val))
             self.assertEqual(s1.size(), 1)
             self.assertTupleAlmostEquals(
                 s0.val().Center().toTuple(), s1.val().Center().toTuple(), 3

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2443,6 +2443,36 @@ class TestCadQuery(BaseTest):
         self.assertEqual(1, s.solids().size())
         self.assertEqual(4, s.faces().size())
 
+    def testCylinderDefaults(self):
+        s = Workplane("XY").cylinder(10, 20)
+        self.saveModel(s)
+        self.assertEqual(1, s.size())
+        self.assertEqual(1, s.solids().size())
+        self.assertEqual(3, s.faces().size())
+        self.assertEqual(2, s.vertices().size())
+        self.assertTupleAlmostEquals(s.val().Center().toTuple(), (0, 0, 0), 3)
+
+    def testCylinderCentering(self):
+        radius = 10
+        height = 40
+        b = (True, False)
+        expected_x = (0, radius)
+        expected_y = (0, radius)
+        expected_z = (0, height/2)
+        for (xopt, xval), (yopt, yval), (zopt, zval) in product(
+            zip(b, expected_x), zip(b, expected_y), zip(b, expected_z)
+        ):
+            s = Workplane("XY").cylinder(radius, height, centered=(xopt, yopt, zopt))
+            self.assertEqual(1, s.size())
+            self.assertTupleAlmostEquals(s.val().Center().toTuple(), (xval, yval, zval), 3)
+        # check centered=True produces the same result as centered=(True, True, True)
+        for val in b:
+            s0 = Workplane("XY").cylinder(radius, height, centered=val)
+            self.assertEqual(s0.size(), 1)
+            s1 = Workplane("XY").cylinder(radius, height, centered=(val, val, val))
+            self.assertEqual(s1.size(), 1)
+            self.assertTupleAlmostEquals(s0.val().Center().toTuple(), s1.val().Center().toTuple(), 3)
+
     def testWedgeDefaults(self):
         s = Workplane("XY").wedge(10, 10, 10, 5, 5, 5, 5)
         self.saveModel(s)


### PR DESCRIPTION
I've added a cylinder 3D primitive to the `Workplane`, as per item on the roadmap, https://github.com/CadQuery/cadquery/blob/master/doc/roadmap.rst

My first submission to cadquery so a review is very much appreciated, and I'm happy to make any changes requested.