### PR TITLE
Support pyparsing version 3 

### DIFF
--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -31,13 +31,13 @@ from .occ_impl.shapes import (
     geom_LUT_FACE,
 )
 from pyparsing import (
+    pyparsing_common,
     Literal,
     Word,
     nums,
     Optional,
     Combine,
     oneOf,
-    upcaseTokens,
     CaselessLiteral,
     Group,
     infixNotation,
@@ -635,7 +635,7 @@ def _makeGrammar():
     cqtype = oneOf(
         set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()), caseless=True,
     )
-    cqtype = cqtype.setParseAction(upcaseTokens)
+    cqtype = cqtype.setParseAction(pyparsing_common.upcaseTokens)
 
     # type operator
     type_op = Literal("%")

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python {{ environ.get('PYTHON_VERSION') }}
     - ocp 7.5.2
     - hdf5 1.10.6 *1114
-    - pyparsing >= 2.1.9
+    - pyparsing >=2.1.9
     - ezdxf
     - ipython
     - typing_extensions

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python {{ environ.get('PYTHON_VERSION') }}
     - ocp 7.5.2
     - hdf5 1.10.6 *1114
-    - pyparsing 2.*
+    - pyparsing >= 2.1.9
     - ezdxf
     - ipython
     - typing_extensions

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.6
   - ipython
   - ocp=7.5.1
-  - pyparsing
+  - pyparsing>=2.1.9
   - sphinx=3.2.1
   - sphinx_rtd_theme
   - sphinx-autodoc-typehints


### PR DESCRIPTION
* Change pyparsing usage to be compatible with version 3  ( #906 )

  upcaseTokens -> pyparsing_common.upcaseTokens 