### PR TITLE
Make versioned conda builds between releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ simple.step
 simple.stp
 simple.xml
 test.brep
+.eggs/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-shallow_clone: true
+shallow_clone: false
 
 platform:
     - x64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,15 +7,8 @@ trigger:
 pr:
 - master
 
-resources:
-  repositories:
-    - repository: templates
-      type: github
-      name: CadQuery/conda-packages
-      endpoint: CadQuery
-
-jobs:  
-- template: conda-build.yml@templates
+jobs:
+- template: conda-build.yml
   parameters:
     name: Linux_38
     vmImage: 'ubuntu-18.04'
@@ -23,7 +16,7 @@ jobs:
     py_min: 8
     conda_bld: 3.21.6
 
-- template: conda-build.yml@templates
+- template: conda-build.yml
   parameters:
     name: macOS_38
     vmImage: 'macOS-10.15'
@@ -31,7 +24,7 @@ jobs:
     py_min: 8
     conda_bld: 3.21.6
 
-- template: conda-build.yml@templates
+- template: conda-build.yml
   parameters:
     name: Windows_38
     vmImage: 'vs2017-win2016'
@@ -39,7 +32,7 @@ jobs:
     py_min: 8
     conda_bld: 3.21.6
 
-- template: conda-build.yml@templates
+- template: conda-build.yml
   parameters:
     name: Linux_39
     vmImage: 'ubuntu-18.04'
@@ -47,7 +40,7 @@ jobs:
     py_min: 9
     conda_bld: 3.21.6
 
-- template: conda-build.yml@templates
+- template: conda-build.yml
   parameters:
     name: macOS_39
     vmImage: 'macOS-10.15'
@@ -55,7 +48,7 @@ jobs:
     py_min: 9
     conda_bld: 3.21.6
 
-- template: conda-build.yml@templates
+- template: conda-build.yml
   parameters:
     name: Windows_39
     vmImage: 'vs2017-win2016'

--- a/conda-build.yml
+++ b/conda-build.yml
@@ -1,0 +1,84 @@
+parameters:
+  name: 'Conda build job'
+  vmImage: 'Ubuntu-16.04'
+  py_maj: '3'
+  py_min: '6'
+  location: 'conda'
+  conda_bld: '3.16.3'
+
+jobs:
+- job: ${{ parameters.name }}_${{ parameters.py_maj }}_${{ parameters.py_min }}
+  timeoutInMinutes: 360
+
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+
+  steps:
+
+  #activate conda
+  - ${{ if or(contains(parameters.vmImage, 'macOS'),contains(parameters.vmImage, 'Ubuntu')) }}:
+    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: 'Add conda to PATH'
+  - ${{ if contains(parameters.vmImage, 'win') }}:
+    - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+      displayName: 'Add conda to PATH'
+
+  # this step is needed for OCC to find fonts
+  - ${{ if eq(parameters.vmImage, 'Ubuntu-16.04') }}:
+    - bash: |
+        sudo apt-get -q -y install gsfonts xfonts-utils && \
+        sudo mkfontscale /usr/share/fonts/type1/gsfonts/ && \
+        sudo mkfontdir /usr/share/fonts/type1/gsfonts/
+
+  # Ubunut install opengl items
+  - ${{ if contains(parameters.vmImage, 'Ubuntu') }}:
+    - bash: |
+        sudo apt-get update && \
+        sudo apt-get -q -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev
+      displayName: 'Install OpenGL headers'
+
+  # macOS ownership workaround
+  - ${{ if contains(parameters.vmImage, 'macOS') }}:
+    - bash: |
+        sudo chown -R $USER $CONDA && \
+        curl -o MacOSX10.9.sdk.tar.xz -L https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz && \
+        tar xf MacOSX10.9.sdk.tar.xz && \
+        sudo mv -v MacOSX10.9.sdk /opt/
+      displayName: 'MacOS ownership workaround + 10.9 SDK installation'
+
+  - bash: |
+        conda config --set anaconda_upload yes --set always_yes yes && \
+        conda update -q conda && \
+        conda info && \
+        conda list
+    displayName: 'Conda config and info'
+
+  - bash: conda create --yes --quiet --name build_env -c conda-forge conda-build=${{ parameters.conda_bld }} conda-verify libarchive python=3.7 anaconda-client
+    displayName: Create Anaconda environment
+
+  - bash: |
+      source activate build_env && \
+      cd ${{ parameters.location }} && \
+      conda build -c conda-forge -c cadquery . && \
+      anaconda -v -t $TOKEN upload -u cadquery --force `conda build --output -c conda-forge -c cadquery .` && \
+      cd ..
+    displayName: 'Run conda build'
+    failOnStderr: false
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    env:
+      PYTHON_VERSION: ${{ parameters.py_maj }}.${{ parameters.py_min }}
+      PACKAGE_VERSION: $(Build.SourceBranchName)
+      TOKEN: $(anaconda.TOKEN)
+
+  - bash: |
+      source activate build_env && \
+      cd ${{ parameters.location }} && \
+      conda build -c conda-forge -c cadquery . && \
+      cd ..
+    displayName: 'Run conda build without upload'
+    failOnStderr: false
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    env:
+      PYTHON_VERSION: ${{ parameters.py_maj }}.${{ parameters.py_min }}
+      PACKAGE_VERSION: $(Build.SourceBranchName)
+      TOKEN: $(anaconda.TOKEN)

--- a/conda-build.yml
+++ b/conda-build.yml
@@ -58,6 +58,7 @@ jobs:
 
   - bash: |
       source activate build_env && \
+      export PACKAGE_VERSION=$(python setup.py --version) && \
       cd ${{ parameters.location }} && \
       conda build -c conda-forge -c cadquery . && \
       anaconda -v -t $TOKEN upload -u cadquery --force `conda build --output -c conda-forge -c cadquery .` && \
@@ -67,11 +68,11 @@ jobs:
     condition: ne(variables['Build.Reason'], 'PullRequest')
     env:
       PYTHON_VERSION: ${{ parameters.py_maj }}.${{ parameters.py_min }}
-      PACKAGE_VERSION: $(Build.SourceBranchName)
       TOKEN: $(anaconda.TOKEN)
 
   - bash: |
       source activate build_env && \
+      export PACKAGE_VERSION=$(python setup.py --version) && \
       cd ${{ parameters.location }} && \
       conda build -c conda-forge -c cadquery . && \
       cd ..
@@ -80,5 +81,4 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     env:
       PYTHON_VERSION: ${{ parameters.py_maj }}.${{ parameters.py_min }}
-      PACKAGE_VERSION: $(Build.SourceBranchName)
       TOKEN: $(anaconda.TOKEN)

--- a/conda-build.yml
+++ b/conda-build.yml
@@ -61,13 +61,15 @@ jobs:
       export PACKAGE_VERSION=$(python setup.py --version) && \
       cd ${{ parameters.location }} && \
       conda build -c conda-forge -c cadquery . && \
-      anaconda -v -t $TOKEN upload -u cadquery --force `conda build --output -c conda-forge -c cadquery .` && \
+      [[ "$GIT_REF" =~ ^refs/tags/ ]] || export LABEL="--label dev" && \
+      anaconda -v -t $TOKEN upload -u cadquery $LABEL --force `conda build --output -c conda-forge -c cadquery .` && \
       cd ..
     displayName: 'Run conda build'
     failOnStderr: false
     condition: ne(variables['Build.Reason'], 'PullRequest')
     env:
       PYTHON_VERSION: ${{ parameters.py_maj }}.${{ parameters.py_min }}
+      GIT_REF: $(Build.SourceBranch)
       TOKEN: $(anaconda.TOKEN)
 
   - bash: |

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,6 +13,7 @@ requirements:
   build:
     - python {{ environ.get('PYTHON_VERSION') }}
     - setuptools
+    - setuptools-scm
   run:
     - python {{ environ.get('PYTHON_VERSION') }}
     - ocp 7.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options]
+setup_requires =
+  setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -11,19 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-from setuptools import setup, find_packages
-
-
-# if we are building in travis, use the build number as the sub-minor version
-version = "2.1"
-if "TRAVIS_TAG" in os.environ.keys():
-    version = os.environ["TRAVIS_TAG"]
-
+from setuptools import find_packages, setup
 
 setup(
     name="cadquery",
-    version=version,
+    use_scm_version=True,
     url="https://github.com/dcowden/cadquery",
     license="Apache Public License 2.0",
     author="David Cowden",


### PR DESCRIPTION
NOTE: this is a work in progress. PR opened for discussion and to get Pipelines running.

# What's the problem?
It's not possible to pin the package version in `conda` between releases. There's a ton of cool stuff in CadQuery only available in the development version that one might want to use without necessarily following the very bleeding edge of development. If I pin to `cadquery=master` today, I might get a different version tomorrow.

# What's my solution?

* Use `setuptools_scm` to automagically get version numbers based on git tags and history.
* Build conda packages and mark them using these version numbers. E.g. `cadquery-2.2.dev304+g45334d0-py3.8.tar.bz2`
* Publish development versions under the `dev` label (so that one can use `cadquery/label/dev` as a channel).
* Publish released versions under the `main` label, as usual.

# Is this even a good idea?
Well, is it? Feel free to let me know if you outright believe it to be a bad idea. I'm very open to discuss the nuances of this.