### PR TITLE
#926 Initialize assy metadata

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - template: conda-build.yml@templates
   parameters:
     name: Linux_38
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-18.04'
     py_maj: 3
     py_min: 8
     conda_bld: 3.21.6
@@ -42,7 +42,7 @@ jobs:
 - template: conda-build.yml@templates
   parameters:
     name: Linux_39
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-18.04'
     py_maj: 3
     py_min: 9
     conda_bld: 3.21.6

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - template: conda-build.yml@templates
   parameters:
     name: Linux_38
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
     py_maj: 3
     py_min: 8
     conda_bld: 3.21.6
@@ -42,7 +42,7 @@ jobs:
 - template: conda-build.yml@templates
   parameters:
     name: Linux_39
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
     py_maj: 3
     py_min: 9
     conda_bld: 3.21.6

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -196,7 +196,7 @@ class Assembly(object):
         loc: Optional[Location] = None,
         name: Optional[str] = None,
         color: Optional[Color] = None,
-        metadata: Optional[dict] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         construct an assembly
@@ -224,7 +224,7 @@ class Assembly(object):
         self.loc = loc if loc else Location()
         self.name = name if name else str(uuid())
         self.color = color if color else None
-        self.metadata = metadata if metadata else None
+        self.metadata = metadata if metadata else {}
         self.parent = None
 
         self.children = []

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -196,14 +196,16 @@ class Assembly(object):
         loc: Optional[Location] = None,
         name: Optional[str] = None,
         color: Optional[Color] = None,
+        metadata: Optional[dict] = None,
     ):
         """
         construct an assembly
 
         :param obj: root object of the assembly (default: None)
         :param loc: location of the root object (default: None, interpreted as identity transformation)
-        :param name: unique name of the root object (default: None, reasulting in an UUID being generated)
+        :param name: unique name of the root object (default: None, resulting in an UUID being generated)
         :param color: color of the added object (default: None)
+        :param metadata: a store for user-defined metadata (default: None)
         :return: An Assembly object.
 
 
@@ -222,6 +224,7 @@ class Assembly(object):
         self.loc = loc if loc else Location()
         self.name = name if name else str(uuid())
         self.color = color if color else None
+        self.metadata = metadata if metadata else None
         self.parent = None
 
         self.children = []
@@ -235,7 +238,7 @@ class Assembly(object):
         Make a deep copy of an assembly
         """
 
-        rv = self.__class__(self.obj, self.loc, self.name, self.color)
+        rv = self.__class__(self.obj, self.loc, self.name, self.color, self.metadata)
 
         for ch in self.children:
             ch_copy = ch._copy()

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -87,6 +87,35 @@ def box_and_vertex():
     return assy
 
 
+@pytest.fixture
+def metadata_assy():
+
+    b1 = cq.Solid.makeBox(1, 1, 1)
+    b2 = cq.Workplane().box(1, 1, 2)
+
+    assy = cq.Assembly(
+        b1,
+        loc=cq.Location(cq.Vector(2, -5, 0)),
+        name="base",
+        metadata={"b1": "base-data"},
+    )
+    sub_assy = cq.Assembly(
+        b2, loc=cq.Location(cq.Vector(1, 1, 1)), name="sub", metadata={"b2": "sub-data"}
+    )
+    assy.add(sub_assy)
+    return assy
+
+
+def test_metadata(metadata_assy):
+    """Verify the metadata is present in both the base and sub assemblies"""
+    assert metadata_assy.metadata["b1"] == "base-data"
+    # The metadata should be able to be modified
+    metadata_assy.metadata["b2"] = 0
+    assert len(metadata_assy.metadata) == 2
+    # Test that metadata was copied by _copy() during the processing of adding the subassembly
+    assert metadata_assy.children[0].metadata["b2"] == "sub-data"
+
+
 def solve_result_check(solve_result: dict) -> bool:
     checks = [
         solve_result["status"] == nlopt.XTOL_REACHED,


### PR DESCRIPTION
With this change `metadata` is a full instance variable of the `Assembly` class with a default of `None`. The `_copy()` method was changed to copy metadata ensuring that metadata added in a sub-assembly is maintained.

A new test verifies that the metadata is present and editable in both the base and sub-assembly.