### PR TITLE
let test_that_invalid_syntax_in_script_fails_immediately work in py3.10

### DIFF
--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -113,10 +113,13 @@ class TestCQGI(BaseTest):
             """
         )
 
-        with self.assertRaises(Exception) as context:
-            model = cqgi.CQModel(badscript)
+        xcptn = None
+        try:
+            cqgi.CQModel(badscript)
+        except Exception as e:
+            xcptn = e
 
-        self.assertTrue("invalid syntax" in context.exception.args)
+        self.assertIsInstance(xcptn, SyntaxError)
 
     def test_that_two_results_are_returned(self):
         script = textwrap.dedent(

--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -113,13 +113,13 @@ class TestCQGI(BaseTest):
             """
         )
 
-        xcptn = None
+        exception = None
         try:
             cqgi.CQModel(badscript)
         except Exception as e:
-            xcptn = e
+            exception = e
 
-        self.assertIsInstance(xcptn, SyntaxError)
+        self.assertIsInstance(exception, SyntaxError)
 
     def test_that_two_results_are_returned(self):
         script = textwrap.dedent(


### PR DESCRIPTION
fixes #933