### PR TITLE
Face.makeFromWires - check that wires are closed

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2260,6 +2260,9 @@ class Face(Shape):
         Makes a planar face from one or more wires
         """
 
+        if innerWires and not outerWire.IsClosed():
+            raise ValueError("Cannot build face(s): outer wire is not closed")
+
         # check if wires are coplanar
         ws = Compound.makeCompound([outerWire] + innerWires)
         if not BRepLib_FindSurface(ws.wrapped, OnlyPlane=True).Found():
@@ -2273,6 +2276,8 @@ class Face(Shape):
         face_builder = BRepBuilderAPI_MakeFace(wo, True)
 
         for w in innerWires:
+            if not w.IsClosed():
+                raise ValueError("Cannot build face(s): inner wire is not closed")
             face_builder.Add(w.wrapped)
 
         face_builder.Build()

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -4782,6 +4782,56 @@ class TestCadQuery(BaseTest):
         with raises(ValueError):
             r.chamfer2D(0.25, [vs[0]])
 
+    def test_Face_makeFromWires(self):
+
+        w0 = Wire.assembleEdges(
+            [
+                Edge.makeLine(Vector(), Vector(0, 1)),
+                Edge.makeLine(Vector(0, 1), Vector(1, 1)),
+                Edge.makeLine(Vector(1, 1), Vector(1, 0)),
+                Edge.makeLine(Vector(1, 0), Vector(0, 0)),
+            ]
+        )
+        w1 = Wire.assembleEdges(
+            [
+                Edge.makeLine(Vector(0.25, 0.25), Vector(0.25, 0.75)),
+                Edge.makeLine(Vector(0.25, 0.75), Vector(0.75, 0.75)),
+                Edge.makeLine(Vector(0.75, 0.75), Vector(0.75, 0.25)),
+                Edge.makeLine(Vector(0.75, 0.25), Vector(0.25, 0.25)),
+            ]
+        )
+        f = Face.makeFromWires(w0, [w1])
+        assert f.isValid()
+
+        with raises(ValueError):
+            w0 = Wire.assembleEdges([Edge.makeLine(Vector(), Vector(0, 1)),])
+            w1 = Wire.assembleEdges([Edge.makeLine(Vector(0, 1), Vector(1, 1)),])
+            f = Face.makeFromWires(w0, [w1])
+
+        with raises(ValueError):
+            w0 = Wire.assembleEdges([Edge.makeLine(Vector(), Vector(0, 1)),])
+            w1 = Wire.assembleEdges(
+                [
+                    Edge.makeLine(Vector(), Vector(1, 1)),
+                    Edge.makeLine(Vector(1, 1), Vector(2, 0)),
+                    Edge.makeLine(Vector(2, 0), Vector(0, 0)),
+                ]
+            )
+            f = Face.makeFromWires(w0, [w1])
+
+        with raises(ValueError):
+            w0 = Wire.assembleEdges(
+                [
+                    Edge.makeLine(Vector(), Vector(1, 1)),
+                    Edge.makeLine(Vector(1, 1), Vector(2, 0)),
+                    Edge.makeLine(Vector(2, 0), Vector(0, 0)),
+                ]
+            )
+            w1 = Wire.assembleEdges(
+                [Edge.makeLine(Vector(0.1, 0.1), Vector(0.2, 0.2)),]
+            )
+            f = Face.makeFromWires(w0, [w1])
+
     def testSplineApprox(self):
 
         from .naca import naca5305

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -84,8 +84,9 @@ class TestImporters(BaseTest):
 
         filename = os.path.join(testdataDir, "gear.dxf")
 
-        obj = importers.importDXF(filename)
-        self.assertFalse(obj.val().isValid())
+        with self.assertRaises(ValueError):
+            # tol >~ 2e-4 required for closed wires
+            obj = importers.importDXF(filename)
 
         obj = importers.importDXF(filename, tol=1e-3)
         self.assertTrue(obj.val().isValid())

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -344,6 +344,12 @@ def test_assemble():
     s1.segment((0.0, 0), (0.0, 2.0))
     s1.segment(Vector(4.0, -1)).close().arc((0.7, 0.6), 0.4, 0.0, 360.0).assemble()
 
+    s2 = Sketch()
+    s2.segment((0, 0), (1, 0))
+    s2.segment((2, 0), (3, 0))
+    with raises(ValueError):
+        s2.assemble()
+
 
 def test_finalize():
 


### PR DESCRIPTION
This is to resolve #944.  The segfault occurs when the outer wire is open and inner wires exist. 

An exception (for now?) to the closed wire check is the outer wire need not be closed if inner wires is empty.  Existing tests rely on this (Wire.fillet2D, chamfer2D).

Example of an open outer wire that would still be allowed: 

```
s = (
    cq.Sketch()
    .segment((0, 0), (0, 1.0))
    .segment((0, 1.0), (1.0, 1.0))
    .assemble()
)

r = cq.Workplane().placeSketch(s).extrude(0.1)
```



DXF import previously could result in the following when the inner wire was not closed:
![gear](https://user-images.githubusercontent.com/16394272/147894096-2115d5e0-184f-418f-9549-c686fbdeb1eb.png)


With the inner wire IsClosed() check, the DXF import results in ValueError with message:

```
  File "/home/lorenzn/devel/cadquery/cadquery/occ_impl/shapes.py", line 2280, in makeFromWires
    raise ValueError("Cannot build face(s): inner wire is not closed")
ValueError: Cannot build face(s): inner wire is not closed
```
