### PR TITLE
simple solution test

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -667,6 +667,7 @@ class Workplane(object):
         plane = Plane(offsetCenter, xDir, normal)
         s = self.__class__(plane)
         s.parent = self
+        s.objects = self.objects[:]
         s.ctx = self.ctx
 
         # a new workplane has the center of the workplane on the stack


### PR DESCRIPTION
Keep selected objects after workplane creation, it breaks quite a lof of tests, we need to investigate if the failing test can be rewritten or if it's really a breaking change