### PR TITLE
Fix installation doc - use rst, not markdown

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -16,11 +16,11 @@ Command Line Installation
 
 CadQuery development moves very quickly, so you will need to choose whether you want the latest features or an older, probably more stable, version of CadQuery.
 
-To get the latest features (recommended), once you have Anaconda or Miniconda installed, activate the [conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) you want to use and type::
+To get the latest features (recommended), once you have Anaconda or Miniconda installed, activate the `conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ you want to use and type::
 
         conda install -c cadquery -c conda-forge cadquery=master
 
-If you want an older, more stable version of CadQuery, once you have Anaconda or Miniconda installed, activate the [conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) you want to use and type::
+If you want an older, more stable version of CadQuery, once you have Anaconda or Miniconda installed, activate the `conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ you want to use and type::
 
         conda install -c conda-forge -c cadquery cadquery=2
 


### PR DESCRIPTION
Sorry guys, fixing my own mistake – in https://github.com/CadQuery/cadquery/pull/908 I incorrectly assumed that documentation is formatted in Markdown, but it's actually in RST. As a result, the links are currently [not showing](https://cadquery.readthedocs.io/en/latest/installation.html) properly. This time I checked my changes in online RST previewer, so it should be good.