### PR TITLE
Fix Sketch rarray bug when used with push

### DIFF
--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -331,7 +331,7 @@ class Sketch(object):
             selection = [Vector()]
 
         return self.push(
-            (el * l if isinstance(el, Location) else Location(el.Center())) * l
+            (l * el if isinstance(el, Location) else l * Location(el.Center()))
             for l in locs
             for el in selection
         )

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -133,6 +133,9 @@ def test_distribute():
 
     assert s5._faces.Area() == approx(18 * 0.25)
     assert len(s5._faces.Faces()) == 18
+    assert s5.reset().vertices(">(1,1,0)")._selection[0].toTuple() == approx(
+        (3.25, 3.25, 0)
+    )
 
     s6 = Sketch().push([(0, 0), (1, 1)]).parray(2, 0, 90, 3).rect(0.5, 0.5)
 


### PR DESCRIPTION
An extra translation is applied when `rarray` is used with `push`.  Compare with/without `push` (easy to see with `push([(0,0)]`).

The form of the `parray` `return` statement is correct.  I would have liked to add a similar test for `parray` anyway but did not finish testing it yet.