### PR TITLE
removed pyparsing limit

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python {{ environ.get('PYTHON_VERSION') }}
     - ocp 7.5.3
-    - pyparsing >=2.1.9
+    - pyparsing
     - ezdxf
     - ipython
     - typing_extensions


### PR DESCRIPTION
Following on from #907 can we consider removing the version limit for pyparsing.

I've built a conda package locally for this as well, see [this](https://github.com/CadQuery/cadquery/pull/907#issuecomment-1057366001) comment on #907