### PR TITLE
Add a dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+# Usage:
+#     docker run --rm -i cadquery python < ./box.py > box.svg
+#     docker run --rm -it -v $(pwd)/examples:/home/cq cadquery
+
+FROM continuumio/miniconda3:4.10.3
+
+RUN adduser --disabled-password --gecos "Default user" --uid 1000 cq && \
+    apt-get update -y && \
+    apt-get install --no-install-recommends -y libgl1-mesa-glx libglu1-mesa && \
+    apt-get clean
+
+RUN conda create -n cq -c default -c conda-forge -c cadquery python=3.8 cadquery=master && \
+    conda clean --all && \
+    find / -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
+
+WORKDIR /home/cq
+USER cq
+
+ENV PATH="/opt/conda/envs/cq/bin:${PATH}"


### PR DESCRIPTION
I created a dockerfile for cadquery ([here on docker hub](https://hub.docker.com/r/cadquery/cadquery)). This is an easy way to try cq without having to install Conda.

Does it make sense for you to add it to this repo?

## Usage

Let's suppose we have the following script:

```py
import cadquery as cq
box = cq.Workplane("XY").box(1, 2, 3)
print(box.toSvg())
```

You can generate the svg with:

    docker run -i --rm cadquery/cadquery python < ./box.py > box.svg

If you need more control to your project (installing Python dependencies, use external files, etc), you can create a docker volume:

    docker run --rm -it -v $(pwd)/examples:/home/cq cadquery/cadquery

It will open a shell prompt on which you can work.