### PR TITLE
fix nptyping dependency

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - ezdxf
     - ipython
     - typing_extensions
-    - nptyping
+    - nptyping <2
     - nlopt
     - multimethod 1.6
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - ezdxf
   - ipython
   - typing_extensions
-  - nptyping
+  - nptyping<2
   - nlopt
   - path
   - pip


### PR DESCRIPTION
Use nptyping<2 as dependency, because the new [nptyping 2.0 release](https://github.com/ramonhagenaars/nptyping/releases/tag/v2.0.0) introduced a bug (`nptyping.error.InvalidArgumentsError`).

Fix #1046.