### PR TITLE
Add Workplane.placeSketch to the API Reference documentation

### DIFF
--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -149,7 +149,7 @@ All 2D operations require a **Workplane** object to be created.
 	Workplane.polarArray
 	Workplane.slot2D
 	Workplane.offset2D
-    Workplane.placeSketch
+	Workplane.placeSketch
 
 .. _3doperations:
 

--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -149,6 +149,7 @@ All 2D operations require a **Workplane** object to be created.
 	Workplane.polarArray
 	Workplane.slot2D
 	Workplane.offset2D
+    Workplane.placeSketch
 
 .. _3doperations:
 


### PR DESCRIPTION
This is an important method for combining the sketch and 3D workflows,
therefore it should be included in the API reference to improve discoverability

resolves #1052 