### PR TITLE
Fix broken references in documentation

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -1,5 +1,7 @@
 .. _examples:
 
+.. currentmodule:: cadquery
+
 *********************************
 CadQuery Examples
 *********************************


### PR DESCRIPTION
So far I have eliminated 180 warnings about missing reference targets by adding a currentmodule directive to examples.rst. This was an easy fix, but I will continue to chip away at broken references. Also, it might be good to add nitpicky warning output from sphinx-build to the CI process to ensure high-quality documentation