### PR TITLE
Added the ability for the user to adjust the tolerance and angular tolerance of VRML tessellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ simple.step
 simple.stp
 simple.xml
 test.brep
+nested.caf
+nested.glb
+nested.stp
+nested.wrl
+nested.xml
+nested.zip

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -442,7 +442,7 @@ class Assembly(object):
         elif exportType == "XML":
             exportCAF(self, path)
         elif exportType == "VRML":
-            exportVRML(self, path)
+            exportVRML(self, path, tolerance, angularTolerance)
         elif exportType == "GLTF":
             exportGLTF(self, path, True, tolerance, angularTolerance)
         elif exportType == "VTKJS":

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -179,7 +179,7 @@ def toVTK(
     loc: Location = Location(),
     color: Tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
     tolerance: float = 1e-3,
-    angularTolerance: float = 0.1
+    angularTolerance: float = 0.1,
 ) -> vtkRenderer:
 
     loc = loc * assy.loc
@@ -189,7 +189,9 @@ def toVTK(
         color = assy.color.toTuple()
 
     if assy.shapes:
-        data = Compound.makeCompound(assy.shapes).toVtkPolyData(tolerance, angularTolerance)
+        data = Compound.makeCompound(assy.shapes).toVtkPolyData(
+            tolerance, angularTolerance
+        )
 
         mapper = vtkMapper()
         mapper.SetInputData(data)

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -179,6 +179,7 @@ def toVTK(
     loc: Location = Location(),
     color: Tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
     tolerance: float = 1e-3,
+    angularTolerance: float = 0.1
 ) -> vtkRenderer:
 
     loc = loc * assy.loc
@@ -188,7 +189,7 @@ def toVTK(
         color = assy.color.toTuple()
 
     if assy.shapes:
-        data = Compound.makeCompound(assy.shapes).toVtkPolyData(tolerance)
+        data = Compound.makeCompound(assy.shapes).toVtkPolyData(tolerance, angularTolerance)
 
         mapper = vtkMapper()
         mapper.SetInputData(data)

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -204,7 +204,7 @@ def toVTK(
         renderer.AddActor(actor)
 
     for child in assy.children:
-        renderer = toVTK(child, renderer, loc, color, tolerance)
+        renderer = toVTK(child, renderer, loc, color, tolerance, angularTolerance)
 
     return renderer
 

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -79,7 +79,7 @@ def exportCAF(assy: AssemblyProtocol, path: str) -> bool:
     return status == PCDM_StoreStatus.PCDM_SS_OK
 
 
-def _vtkRenderWindow(assy: AssemblyProtocol) -> vtkRenderWindow:
+def _vtkRenderWindow(assy: AssemblyProtocol, tolerance: float, angularTolerance: float) -> vtkRenderWindow:
     """
     Convert an assembly to a vtkRenderWindow. Used by vtk based exporters.
     """
@@ -87,7 +87,7 @@ def _vtkRenderWindow(assy: AssemblyProtocol) -> vtkRenderWindow:
     renderer = vtkRenderer()
     renderWindow = vtkRenderWindow()
     renderWindow.AddRenderer(renderer)
-    toVTK(assy, renderer)
+    toVTK(assy, renderer, tolerance=tolerance, angularTolerance=angularTolerance)
 
     renderer.ResetCamera()
     renderer.SetBackground(1, 1, 1)
@@ -111,14 +111,14 @@ def exportVTKJS(assy: AssemblyProtocol, path: str):
         make_archive(path, "zip", tmpdir)
 
 
-def exportVRML(assy: AssemblyProtocol, path: str):
+def exportVRML(assy: AssemblyProtocol, path: str, tolerance: float, angularTolerance: float):
     """
     Export an assembly to a vrml file using vtk.
     """
 
     exporter = vtkVRMLExporter()
     exporter.SetFileName(path)
-    exporter.SetRenderWindow(_vtkRenderWindow(assy))
+    exporter.SetRenderWindow(_vtkRenderWindow(assy, tolerance, angularTolerance))
     exporter.Write()
 
 

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -79,7 +79,9 @@ def exportCAF(assy: AssemblyProtocol, path: str) -> bool:
     return status == PCDM_StoreStatus.PCDM_SS_OK
 
 
-def _vtkRenderWindow(assy: AssemblyProtocol, tolerance: float=1e-3, angularTolerance: float=0.1) -> vtkRenderWindow:
+def _vtkRenderWindow(
+    assy: AssemblyProtocol, tolerance: float = 1e-3, angularTolerance: float = 0.1
+) -> vtkRenderWindow:
     """
     Convert an assembly to a vtkRenderWindow. Used by vtk based exporters.
     """
@@ -111,7 +113,12 @@ def exportVTKJS(assy: AssemblyProtocol, path: str):
         make_archive(path, "zip", tmpdir)
 
 
-def exportVRML(assy: AssemblyProtocol, path: str, tolerance: float=1e-3, angularTolerance: float=0.1):
+def exportVRML(
+    assy: AssemblyProtocol,
+    path: str,
+    tolerance: float = 1e-3,
+    angularTolerance: float = 0.1,
+):
     """
     Export an assembly to a vrml file using vtk.
     """

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -79,7 +79,7 @@ def exportCAF(assy: AssemblyProtocol, path: str) -> bool:
     return status == PCDM_StoreStatus.PCDM_SS_OK
 
 
-def _vtkRenderWindow(assy: AssemblyProtocol, tolerance: float, angularTolerance: float) -> vtkRenderWindow:
+def _vtkRenderWindow(assy: AssemblyProtocol, tolerance: float=1e-3, angularTolerance: float=0.1) -> vtkRenderWindow:
     """
     Convert an assembly to a vtkRenderWindow. Used by vtk based exporters.
     """
@@ -111,7 +111,7 @@ def exportVTKJS(assy: AssemblyProtocol, path: str):
         make_archive(path, "zip", tmpdir)
 
 
-def exportVRML(assy: AssemblyProtocol, path: str, tolerance: float, angularTolerance: float):
+def exportVRML(assy: AssemblyProtocol, path: str, tolerance: float=1e-3, angularTolerance: float=0.1):
     """
     Export an assembly to a vrml file using vtk.
     """


### PR DESCRIPTION
With the KiCAD 3D model generator the generated VRML files were 6MB, which was too large compared to the ~200KB original files. I added the ability for the user to adjust the `tolerance` and `angularTolerance` so that I could decrease the file size. I don't think I'll be able to keep the same quality at ~200MB, but I can get vast improvements in file size with these changes.