### PR TITLE
Fix VTK based assembly export rotation issue

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -426,8 +426,8 @@ class Assembly(object):
 
         :param path: filepath
         :param exportType: export format (default: None, results in format being inferred form the path)
-        :param tolerance: the deflection tolerance, in model units. Only used for GLTF. Default 0.1.
-        :param angularTolerance: the angular tolerance, in radians. Only used for GLTF. Default 0.1.
+        :param tolerance: the deflection tolerance, in model units. Only used for GLTF, VRML. Default 0.1.
+        :param angularTolerance: the angular tolerance, in radians. Only used for GLTF, VRML. Default 0.1.
         """
 
         if exportType is None:

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -1,5 +1,6 @@
 from typing import Iterable, Tuple, Dict, overload, Optional, Any, List
 from typing_extensions import Protocol
+from math import degrees
 
 from OCP.TDocStd import TDocStd_Document
 from OCP.TCollection import TCollection_ExtendedString
@@ -199,7 +200,7 @@ def toVTK(
         actor = vtkActor()
         actor.SetMapper(mapper)
         actor.SetPosition(*trans)
-        actor.SetOrientation(*rot)
+        actor.SetOrientation(*map(degrees, rot))
         actor.GetProperty().SetColor(*color[:3])
         actor.GetProperty().SetOpacity(color[3])
 

--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -63,7 +63,7 @@ class deprecate_kwarg_name:
 
             if f_sig_params[self.name]:
                 warn(
-                    f"Kwarg <{self.name}> will be removed. Plase use <{self.new_name}>",
+                    f"Kwarg <{self.name}> will be removed. Please use <{self.new_name}>",
                     FutureWarning,
                 )
 


### PR DESCRIPTION
To resolve #1069.  As a test, I'm checking a line of the VRML file itself.  The file is less than 50 lines.
```
#VRML V2.0 utf8
# VRML file written by the visualization toolkit

    Background {
    skyColor [1.000000 1.000000 1.000000, ]
    }
     Viewpoint
      {
      fieldOfView 0.523599
      position -1.000000 0.000000 1.931852
      description "Default View"
      orientation 0 0 1 0
      }
    NavigationInfo {
      type ["EXAMINE","FLY"]
      speed 4.000000
      headlight TRUE}

    DirectionalLight { ambientIntensity 1 intensity 0 # ambient light
      color 1.000000 1.000000 1.000000 }

    Transform {
      translation 0 0 0
      rotation 1 0 0 1.5707963267948966
      scale 1 1 1
      children [
        Shape {
          appearance Appearance {
            material Material {
              ambientIntensity 0
              emissiveColor 0 0 0
              diffuseColor 1 1 1
              specularColor 0 0 0
              shininess 0.0078125
              transparency 0
              }
            }
          geometry PointSet {
            coord Coordinate {              point [                            -1 0 0,
              ]
            }
          }
        }
      ]
    }
```

*rotation 1 0 0 1.5707963267948966*

This is X rotation, 90 degrees.

