### PR TITLE
Updated setup.py with OCP being available on PyPi now

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,3 @@
 version: 2
-
 conda:
   environment: environment.yml
-
-python:
-  version: 3.8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,7 @@
 version: 2
-python:
-  setup_py_install: false
+
 conda:
   environment: environment.yml
+
+python:
+  version: 3.8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
 version: 2
+python:
+  setup_py_install: false
 conda:
   environment: environment.yml

--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -4,7 +4,7 @@ try:
     __version__ = version("cadquery")
 except PackageNotFoundError:
     # package is not installed
-    pass
+    __version__ = "2.2-dev"
 
 # these items point to the OCC implementation
 from .occ_impl.geom import Plane, BoundBox, Vector, Matrix, Location
@@ -77,5 +77,3 @@ __all__ = [
     "plugins",
     "Sketch",
 ]
-
-__version__ = "2.1"

--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version, PackageNotFoundError
 
 try:
-    version__ = version("cadquery")
+    __version__ = version("cadquery")
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -1,3 +1,11 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    version__ = version("cadquery")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
 # these items point to the OCC implementation
 from .occ_impl.geom import Plane, BoundBox, Vector, Matrix, Location
 from .occ_impl.shapes import (

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - casadi
   - pip
   - pip:
-    - "--no-deps --editable=."
+    - "--no-deps"
+    - "--editable=."
     - sphinxcadquery
     - multimethod

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - nlopt
   - path
   - casadi
-  - pip>=22
+  - pip
   - pip:
     - "--editable=."
     - sphinxcadquery

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,6 @@ dependencies:
   - path
   - pip
   - pip:
-    - "--editable=."
     - sphinxcadquery
     - multimethod
+    # - "--editable=."

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,6 @@ dependencies:
   - casadi
   - pip
   - pip:
-    - "--editable=."
+    - "--no-deps --editable=."
     - sphinxcadquery
     - multimethod

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - casadi
   - pip
   - pip:
-    - "--no-deps"
+    - "--install-option=\"--no-deps\""
     - "--editable=."
     - sphinxcadquery
     - multimethod

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - nlopt
   - path
   - casadi
-  - pip
+  - pip>=22
   - pip:
     - "--editable=."
     - sphinxcadquery

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.6
+  - python>=3.8
   - ipython
   - ocp=7.5.3
   - vtk=9.0.1
@@ -23,8 +23,8 @@ dependencies:
   - nptyping>=2.0.0
   - nlopt
   - path
-  - pip
+  - pip>=22
   - pip:
+    - "--editable=."
     - sphinxcadquery
     - multimethod
-    # - "--editable=."

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,8 @@ dependencies:
   - nptyping>=2.0.0
   - nlopt
   - path
-  - pip>=22
+  - casadi
+  - pip
   - pip:
     - "--editable=."
     - sphinxcadquery

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from setuptools import setup, find_packages
 version = "2.1"
 
 reqs = []
+setup_reqs = []
 
 # ReadTheDocs and AppVeyor will break if we do not handle the separately
 is_rtd = False
@@ -39,6 +40,8 @@ if not is_rtd and not is_appveyor:
         "path",
     ]
 
+    setup_reqs = ["setuptools_scm"]
+
 setup(
     name="cadquery",
     # version=version,
@@ -51,7 +54,7 @@ setup(
     long_description=open("README.md").read(),
     packages=find_packages(exclude=("tests",)),
     python_requires=">=3.8,<3.11",
-    setup_requires=["setuptools_scm"],
+    setup_requires=setup_reqs,
     install_requires=reqs,
     extras_require={
         "dev": ["docutils", "ipython", "pytest", "black==19.10b0", "click==8.0.4",],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ if not is_rtd and not is_appveyor:
 
 setup(
     name="cadquery",
-    version=version,
+    # version=version,
+    use_scm_version=True,
     url="https://github.com/CadQuery/cadquery",
     license="Apache Public License 2.0",
     author="David Cowden",
@@ -50,6 +51,7 @@ setup(
     long_description=open("README.md").read(),
     packages=find_packages(exclude=("tests",)),
     python_requires=">=3.8,<3.11",
+    setup_requires=["setuptools_scm"],
     install_requires=reqs,
     extras_require={
         "dev": ["docutils", "ipython", "pytest", "black==19.10b0", "click==8.0.4",],

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,16 @@ setup_reqs = []
 # ReadTheDocs and AppVeyor will break if we do not handle the separately
 is_rtd = False
 is_appveyor = False
+is_azure = False
 if "READTHEDOCS" in os.environ:
     is_rtd = os.environ["READTHEDOCS"]
 if "APPVEYOR" in os.environ:
     is_appveyor = os.environ["APPVEYOR"]
+if "TF_BUILD" in os.environ:
+    is_azure = os.environ["TF_BUILD"]
 
 # Only include the installation dependencies if we are not running on RTD or AppVeyor
-if not is_rtd and not is_appveyor:
+if not is_rtd and not is_appveyor and not is_azure:
     reqs = [
         "cadquery-ocp",
         "ezdxf",

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,14 @@ from setuptools import setup, find_packages
 
 version = "2.1"
 
-is_rtd = os.environ['READTHEDOCS']
+reqs = []
+
+is_rtd = False
+if "READTHEDOCS" in os.environ:
+    is_rtd = os.environ['READTHEDOCS']
+
 print(is_rtd)
-if is_rtd:
-    reqs = []
-else:
+if not is_rtd:
     reqs = [
         "cadquery-ocp",
         "ezdxf",

--- a/setup.py
+++ b/setup.py
@@ -19,17 +19,10 @@ version = "2.1"
 reqs = []
 setup_reqs = []
 
-# ReadTheDocs and AppVeyor will break if we do not handle the separately
-is_rtd = False
-is_appveyor = False
-is_azure = False
-if "READTHEDOCS" in os.environ:
-    is_rtd = os.environ["READTHEDOCS"]
-if "APPVEYOR" in os.environ:
-    is_appveyor = os.environ["APPVEYOR"]
-if "CONDA_PY" in os.environ:
-    is_azure = True
-print(os.environ)
+# ReadTheDocs, AppVeyor and Azure builds will break when trying to instal pip deps in a conda env
+is_rtd = "READTHEDOCS" in os.environ
+is_appveyor = "APPVEYOR" in os.environ
+is_azure = "CONDA_PY" in os.environ
 
 # Only include the installation dependencies if we are not running on RTD or AppVeyor
 if not is_rtd and not is_appveyor and not is_azure:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if "READTHEDOCS" in os.environ:
     is_rtd = os.environ["READTHEDOCS"]
 if "APPVEYOR" in os.environ:
     is_appveyor = os.environ["APPVEYOR"]
-if "System.TeamProjectId" in os.environ:
+if "CONDA_PY" in os.environ:
     is_azure = True
 print(os.environ)
 

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ if "APPVEYOR" in os.environ:
     is_appveyor = os.environ["APPVEYOR"]
 if "System.TeamProjectId" in os.environ:
     is_azure = True
-print("System.TeamProjectId" in os.environ)
-print("TF_BUILD" in os.environ)
+print(os.environ)
 
 # Only include the installation dependencies if we are not running on RTD or AppVeyor
 if not is_rtd and not is_appveyor and not is_azure:

--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,20 @@
 import os
 from setuptools import setup, find_packages
 
+version = "2.1"
+
 setup(
     name="cadquery",
     version=version,
-    url="https://github.com/dcowden/cadquery",
+    url="https://github.com/CadQuery/cadquery",
     license="Apache Public License 2.0",
     author="David Cowden",
     author_email="dave.cowden@gmail.com",
     description="CadQuery is a parametric  scripting language for creating and traversing CAD models",
     long_description=open("README.md").read(),
     packages=find_packages(exclude=("tests",)),
-    install_requires=["cadquery-ocp", "ezdxf", "multimethod", "nlopt", "nptyping", "typish", "casadi", "path"],
+    python_requires=">=3.8,<3.11",
+    install_requires=["cadquery-ocp", "ezdxf", "multimethod", "nlopt", "nptyping>=2", "typish", "casadi", "path"],
     extras_require = {
         "dev": [
             "docutils",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,22 @@ from setuptools import setup, find_packages
 
 version = "2.1"
 
+is_rtd = os.environ['READTHEDOCS']
+print(is_rtd)
+if is_rtd:
+    reqs = []
+else:
+    reqs = [
+        "cadquery-ocp",
+        "ezdxf",
+        "multimethod",
+        "nlopt",
+        "nptyping>=2",
+        "typish",
+        "casadi",
+        "path",
+    ]
+
 setup(
     name="cadquery",
     version=version,
@@ -27,16 +43,7 @@ setup(
     long_description=open("README.md").read(),
     packages=find_packages(exclude=("tests",)),
     python_requires=">=3.8,<3.11",
-    install_requires=[
-        "cadquery-ocp",
-        "ezdxf",
-        "multimethod",
-        "nlopt",
-        "nptyping>=2",
-        "typish",
-        "casadi",
-        "path",
-    ],
+    install_requires=reqs,
     extras_require={
         "dev": ["docutils", "ipython", "pytest", "black==19.10b0", "click==8.0.4",],
         "ipython": ["ipython",],

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@
 import os
 from setuptools import setup, find_packages
 
-version = "2.1"
-
 reqs = []
 setup_reqs = []
 
@@ -41,7 +39,6 @@ if not is_rtd and not is_appveyor and not is_azure:
 
 setup(
     name="cadquery",
-    # version=version,
     use_scm_version=True,
     url="https://github.com/CadQuery/cadquery",
     license="Apache Public License 2.0",

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,10 @@ if "READTHEDOCS" in os.environ:
     is_rtd = os.environ["READTHEDOCS"]
 if "APPVEYOR" in os.environ:
     is_appveyor = os.environ["APPVEYOR"]
-if "TF_BUILD" in os.environ:
-    is_azure = os.environ["TF_BUILD"]
+if "System.TeamProjectId" in os.environ:
+    is_azure = True
+print("System.TeamProjectId" in os.environ)
+print("TF_BUILD" in os.environ)
 
 # Only include the installation dependencies if we are not running on RTD or AppVeyor
 if not is_rtd and not is_appveyor and not is_azure:

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,16 @@ version = "2.1"
 
 reqs = []
 
+# ReadTheDocs and AppVeyor will break if we do not handle the separately
 is_rtd = False
+is_appveyor = False
 if "READTHEDOCS" in os.environ:
-    is_rtd = os.environ['READTHEDOCS']
+    is_rtd = os.environ["READTHEDOCS"]
+if "APPVEYOR" in os.environ:
+    is_appveyor = os.environ["APPVEYOR"]
 
-print(is_rtd)
-if not is_rtd:
+# Only include the installation dependencies if we are not running on RTD or AppVeyor
+if not is_rtd and not is_appveyor:
     reqs = [
         "cadquery-ocp",
         "ezdxf",

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,6 @@
 import os
 from setuptools import setup, find_packages
 
-
-# if we are building in travis, use the build number as the sub-minor version
-version = "2.1"
-if "TRAVIS_TAG" in os.environ.keys():
-    version = os.environ["TRAVIS_TAG"]
-
-
 setup(
     name="cadquery",
     version=version,
@@ -31,6 +24,17 @@ setup(
     description="CadQuery is a parametric  scripting language for creating and traversing CAD models",
     long_description=open("README.md").read(),
     packages=find_packages(exclude=("tests",)),
+    install_requires=["cadquery-ocp", "ezdxf", "multimethod", "nlopt", "nptyping", "typish", "casadi", "path"],
+    extras_require = {
+        "dev": [
+            "docutils",
+            "ipython",
+            "pytest",
+        ],
+        "ipython": [
+            "ipython",
+        ]
+    },
     include_package_data=True,
     zip_safe=False,
     platforms="any",

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,19 @@ setup(
     long_description=open("README.md").read(),
     packages=find_packages(exclude=("tests",)),
     python_requires=">=3.8,<3.11",
-    install_requires=["cadquery-ocp", "ezdxf", "multimethod", "nlopt", "nptyping>=2", "typish", "casadi", "path"],
-    extras_require = {
-        "dev": [
-            "docutils",
-            "ipython",
-            "pytest",
-        ],
-        "ipython": [
-            "ipython",
-        ]
+    install_requires=[
+        "cadquery-ocp",
+        "ezdxf",
+        "multimethod",
+        "nlopt",
+        "nptyping>=2",
+        "typish",
+        "casadi",
+        "path",
+    ],
+    extras_require={
+        "dev": ["docutils", "ipython", "pytest", "black==19.10b0", "click==8.0.4",],
+        "ipython": ["ipython",],
     },
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
When I test locally this takes care of all dependencies, and gives users a couple options (development and IPython installs).

@dcowden Does this look good to you from your experience with setup.py for CQ 1.x?

@adam-urbanczyk Do you think not installing IPython by default will cause any problems? I've made IPython an optional install that the user has to specifically opt into. I did this because I believe that IPython is only used for jupyter_tools.py, which many users don't need. IPython brings its own set of dependencies which most users won't use.