### PR TITLE
Pin nptyping

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - ezdxf
     - ipython
     - typing_extensions
-    - nptyping 2.0.0
+    - nptyping 2.0.1
     - nlopt
     - multimethod 1.6
     - casadi

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - ezdxf
     - ipython
     - typing_extensions
-    - nptyping >=2.0.0
+    - nptyping 2.0.0
     - nlopt
     - multimethod 1.6
     - casadi

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - ezdxf
   - ipython
   - typing_extensions
-  - nptyping=2.0.0
+  - nptyping=2.0.1
   - nlopt
   - path
   - casadi

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - ezdxf
   - ipython
   - typing_extensions
-  - nptyping>=2.0.0
+  - nptyping=2.0.0
   - nlopt
   - path
   - casadi


### PR DESCRIPTION
The `mypy cadquery` check fails with nptyping version 2.1.0 (released ~7 hours ago).

```
$ mypy cadquery
cadquery/occ_impl/sketch_solver.py:266: error: Type argument "floating[Any]" of "ndarray" must be a subtype of "dtype[Any]"
cadquery/occ_impl/sketch_solver.py:267: error: Type argument "floating[Any]" of "ndarray" must be a subtype of "dtype[Any]"
cadquery/occ_impl/sketch_solver.py:344: error: Incompatible return value type (got "Tuple[Callable[[Any], float], Callable[[Any, Any], None], ndarray[Any, dtype[Any]], ndarray[Any, dtype[Any]]]", expected "Tuple[Callable[[ndarray[Any, floating[Any]]], float], Callable[[ndarray[Any, floating[Any]], ndarray[Any, floating[Any]]], None], ndarray[Any, floating[Any]], ndarray[Any, floating[Any]]]")
cadquery/occ_impl/sketch_solver.py:349: error: Argument 1 to "_cost" of "SketchConstraintSolver" has incompatible type "ndarray[Any, dtype[Any]]"; expected "ndarray[Any, floating[Any]]"
Found 4 errors in 1 file (checked 30 source files)
```
