### PR TITLE
fix eachpoint() with useLocalCoordinates=False coordinate transformation

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2476,7 +2476,7 @@ class Workplane(object):
         if useLocalCoordinates:
             res = [callback(p).move(loc) for p in pnts]
         else:
-            res = [callback(p * loc) for p in pnts]
+            res = [callback(loc * p) for p in pnts]
 
         for r in res:
             if isinstance(r, Wire) and not r.forConstruction:


### PR DESCRIPTION
I think the coordinate transformation for the eachpoint() function with `useLocalCoordinates=False` was backwards