### PR TITLE
stop `eachpoint(..., useLocalCoordinates=False)` from manipulating the object's location

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2476,7 +2476,7 @@ class Workplane(object):
         if useLocalCoordinates:
             res = [callback(p).move(loc) for p in pnts]
         else:
-            res = [callback(p * loc) for p in pnts]
+            res = [callback(p) for p in pnts]
 
         for r in res:
             if isinstance(r, Wire) and not r.forConstruction:

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5119,7 +5119,7 @@ class TestCadQuery(BaseTest):
                     Face.makePlane(1, 1),
                 ]
             )
-            .eachpoint(lambda l: Face.makePlane(1, 1).locate(l))
+            .eachpoint(lambda l: Face.makePlane(1, 1).locate(l), True)
         )
 
         self.assertTrue(len(r1.objects) == 4)


### PR DESCRIPTION
fixes https://github.com/CadQuery/cadquery/issues/1099