### PR TITLE
Add STL to Assemblys export formats

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -27,7 +27,7 @@ from .selectors import _expression_grammar as _selector_grammar
 # type definitions
 AssemblyObjects = Union[Shape, Workplane, None]
 ConstraintKinds = Literal["Plane", "Point", "Axis", "PointInPlane"]
-ExportLiterals = Literal["STEP", "XML", "GLTF", "VTKJS", "VRML"]
+ExportLiterals = Literal["STEP", "XML", "GLTF", "VTKJS", "VRML", "STL"]
 
 PATH_DELIM = "/"
 
@@ -455,7 +455,7 @@ class Assembly(object):
 
         if exportType is None:
             t = path.split(".")[-1].upper()
-            if t in ("STEP", "XML", "VRML", "VTKJS", "GLTF"):
+            if t in ("STEP", "XML", "VRML", "VTKJS", "GLTF", "STL"):
                 exportType = cast(ExportLiterals, t)
             else:
                 raise ValueError("Unknown extension, specify export type explicitly")
@@ -470,6 +470,8 @@ class Assembly(object):
             exportGLTF(self, path, True, tolerance, angularTolerance)
         elif exportType == "VTKJS":
             exportVTKJS(self, path)
+        elif exportType == "STL":
+            self.toCompound().exportStl(path, tolerance, angularTolerance)
         else:
             raise ValueError(f"Unknown format: {exportType}")
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -247,6 +247,7 @@ def test_toJSON(simple_assy, nested_assy, empty_top_assy):
         ("stp", ("STEP",)),
         ("caf", ("XML",)),
         ("wrl", ("VRML",)),
+        ("stl", ("STL",)),
     ],
 )
 def test_save(extension, args, nested_assy, nested_assy_sphere):


### PR DESCRIPTION
Turn the assembly into a compound and use Shapes export method to export
the assembly. This way the export function does not need to be
duplicated, and it is what users have been doing manually to get their
objects.

Should solve https://github.com/CadQuery/cadquery/issues/965