### PR TITLE
Revamping Cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ cmd /K ""%USERPROFILE%/Miniforge3/Scripts/activate.bat" "%USERPROFILE%/Miniforge
 ```
 You might want to consider using `/NoScripts=0` to have an activation shortcut added to the start menu.
 
+### CQ-editor GUI
+
+CQ-editor is an IDE that allows users to edit CadQuery model scripts in a GUI environment. It includes features such as:
+
+* A graphical debugger that allows you to step through your scripts.
+* A CadQuery stack inspector.
+* Export to various formats, including STEP and STL, directly from the menu.
+
+The installation instructions for CQ-editor can be found [here](https://github.com/CadQuery/CQ-editor#installation).
+
+<img src="https://raw.githubusercontent.com/CadQuery/CQ-editor/master/screenshots/screenshot3.png" alt="CQ editor screenshot" width="800"/>
+
 ### Jupyter
 
 CadQuery supports Jupyter notebook out of the box using the jupyter-cadquery extension created by @bernhard-42:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The original version of CadQuery was built on the FreeCAD API. This was great be
 
 To learn more about designing with CadQuery, visit the [documentation](https://cadquery.readthedocs.io/en/latest/intro.html), [examples](https://cadquery.readthedocs.io/en/latest/examples.html), and [cheatsheet](https://cadquery.readthedocs.io/en/latest/_static/cadquery_cheatsheet.html).
 
-It is currently possible to use CadQuery for your own projects in 3 different ways:
+To get started playing around with CadQuery and see it's capabilities, take a look at the [CQ-editor GUI](https://github.com/CadQuery/CQ-editor). This easy-to-use IDE is a great way to get started desiging with CadQuery.
+
 * Using the [CQ-editor GUI](https://github.com/CadQuery/CQ-editor)
 * From a [Jupyter notebook](https://github.com/bernhard-42/jupyter-cadquery)
 * As a standalone library

--- a/README.md
+++ b/README.md
@@ -38,13 +38,27 @@ To learn more about designing with CadQuery, visit the [documentation](https://c
 
 To get started playing around with CadQuery and see it's capabilities, take a look at the [CQ-editor GUI](https://github.com/CadQuery/CQ-editor). This easy-to-use IDE is a great way to get started desiging with CadQuery.
 
+There are currently 4 different ways to use CadQuery for designing your next project:
 * Using the [CQ-editor GUI](https://github.com/CadQuery/CQ-editor)
 * From a [Jupyter notebook](https://github.com/bernhard-42/jupyter-cadquery)
+* Using a [VSCode extension](https://marketplace.visualstudio.com/items?itemName=roipoussiere.cadquery)
 * As a standalone library
     * Linux [installation video](https://youtu.be/sjLTePOq8bQ)
     * Windows [installation video](https://youtu.be/3Tg_RJhqZRg)
 
-There are two ways to install CadQuery and its dependencies. One is using conda, and the other is using pip. Pip is shown first below, followed by two sections on installing CadQuery via conda, and a non-intrusive way to install conda on a system.
+There are two ways to install the CadQuery library and its dependencies. One is using conda, and the other is using pip. Pip is shown first below, followed by two sections on installing CadQuery via conda, and a non-intrusive way to install conda on a system.
+
+### CQ-editor GUI
+
+CQ-editor is an IDE that allows users to edit CadQuery model scripts in a GUI environment. It includes features such as:
+
+* A graphical debugger that allows you to step through your scripts.
+* A CadQuery stack inspector.
+* Export to various formats, including STEP and STL, directly from the menu.
+
+The installation instructions for CQ-editor can be found [here](https://github.com/CadQuery/CQ-editor#installation).
+
+<img src="https://raw.githubusercontent.com/CadQuery/CQ-editor/master/screenshots/screenshot3.png" alt="CQ editor screenshot" width="800"/>
 
 ### CadQuery Installation Via Pip
 
@@ -114,18 +128,6 @@ start /wait "" miniforge.exe /InstallationType=JustMe /RegisterPython=0 /NoRegis
 cmd /K ""%USERPROFILE%/Miniforge3/Scripts/activate.bat" "%USERPROFILE%/Miniforge3""
 ```
 You might want to consider using `/NoScripts=0` to have an activation shortcut added to the start menu.
-
-### CQ-editor GUI
-
-CQ-editor is an IDE that allows users to edit CadQuery model scripts in a GUI environment. It includes features such as:
-
-* A graphical debugger that allows you to step through your scripts.
-* A CadQuery stack inspector.
-* Export to various formats, including STEP and STL, directly from the menu.
-
-The installation instructions for CQ-editor can be found [here](https://github.com/CadQuery/CQ-editor#installation).
-
-<img src="https://raw.githubusercontent.com/CadQuery/CQ-editor/master/screenshots/screenshot3.png" alt="CQ editor screenshot" width="800"/>
 
 ### Jupyter
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4498634.svg)](https://doi.org/10.5281/zenodo.4498634)
 
 
+---
+
+### Quick Links
+[***Documentation***](https://cadquery.readthedocs.io/en/latest/) | [***Cheatsheet***](https://cadquery.readthedocs.io/en/latest/_static/cadquery_cheatsheet.html) | [***Discord***](https://discord.com/invite/Bj9AQPsCfx) | [***Google Group***](https://groups.google.com/g/cadquery) | [***GUI Editor***](https://github.com/CadQuery/CQ-editor)
+
+---
+
 ## What is CadQuery
 
 CadQuery is an intuitive, easy-to-use Python module for building parametric 3D CAD models. Using CadQuery, you can write short, simple scripts that produce high quality CAD models. It is easy to make many different objects using a single script that can be customized.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ The original version of CadQuery was built on the FreeCAD API. This was great be
 
 ## Getting started
 
-To quickly play around with CadQuery and see it's capabilities, see the [CQ-editor GUI](https://github.com/CadQuery/CQ-editor) manual.  
-If you want to use CadQuery for your own project, keep reading: 
+To learn more about designing with CadQuery, visit the [documentation](https://cadquery.readthedocs.io/en/latest/intro.html), [examples](https://cadquery.readthedocs.io/en/latest/examples.html), and [cheatsheet](https://cadquery.readthedocs.io/en/latest/_static/cadquery_cheatsheet.html).
 
 It is currently possible to use CadQuery for your own projects in 3 different ways:
 * Using the [CQ-editor GUI](https://github.com/CadQuery/CQ-editor)

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -140,7 +140,7 @@
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.fillet">Sketch.fillet</a><br>(d)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.chamfer">Sketch.chamfer</a><br>(d)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.clean">Sketch.clean</a><br>()</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.finalize">Sketch.finalize</a><br>()</td>
             </tr>
           </table>
       </div>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -7,6 +7,7 @@
 
     <style type="text/css">
     body {
+      width: 100vw;
       margin: 0;
       text-align: center;
     }
@@ -16,12 +17,14 @@
     }
     #section-container {
       display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around; row-gap: 10px;
+      overflow-y: scroll;
+      width: 100%
     }
     .section {
       margin: 0.5em;
       padding: 0px 0.5em 0.5em;
       background-color: #EBEBEB;
-      min-width: 300px;
+      min-width: 340px;
       max-width: min(50vw, 100%);
     }
     .section-subtitle {
@@ -48,6 +51,11 @@
     }
     h2 {
       display: inline;
+    }
+    @media only screen and (max-width: 600px) {
+      body{
+        font-size: 70%
+      }
     }
     </style>
   </head>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -17,7 +17,7 @@
     }
     #section-container {
       display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around; row-gap: 10px;
-      overflow-y: scroll;
+      overflow: scroll;
       width: 100%
     }
     .section {
@@ -26,6 +26,7 @@
       background-color: #EBEBEB;
       min-width: 340px;
       max-width: min(50vw, 100%);
+      overflow-x: scroll;
     }
     .section-subtitle {
       margin-bottom: 4px;
@@ -52,9 +53,12 @@
     h2 {
       display: inline;
     }
-    @media only screen and (max-width: 600px) {
+    @media only screen and (max-width: 1000px) {
       body{
-        font-size: 70%
+        font-size: 75%
+      }
+      .section {
+        max-width: 96%;
       }
     }
     </style>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -3,6 +3,7 @@
   <head>
     <title>CadQuery Cheatsheet</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style type="text/css">
     .section {
@@ -10,10 +11,10 @@
       padding: 0px 0.5em 0.5em;
       background-color: #EBEBEB;
       min-width: 300px;
-      max-width: 30vw;
+      max-width: min(50vw, 100%);
     }
-     {
-
+    .section-subtitle {
+      margin-bottom: 4px;
     }
     h2 a, h2 a:visited, .section a,.section a:visited {
       color: #1f4b8f;
@@ -41,16 +42,16 @@
       <h1><img src="https://cadquery.readthedocs.io/en/latest/_static/cadquery_logo_dark.svg" height=30> Cheatsheet</h1>
       <i>A Quick Guide To The Most Commonly Used Functions! 
       <br/>
-      <sub>For the full API ref <a href="https://cadquery.readthedocs.io/en/latest/apireference.html" target="_blank">click here!</a></sub></i>
+      <sub>For the full API ref <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html" target="_blank">click here!</a></sub></i>
     </div>
-    <div style="display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around;">
+    <div style="display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around; row-gap: 10px;">
       <div class="section" hidden>
         <h2>Documentation</h2>
         <ul style="background-color:#ffffff;margin-bottom:0px;margin-top:0px;">
-          <li><a href="https://cadquery.readthedocs.io/en/latest/">CadQuery Documentation</a></li>
-          <li><a href="https://github.com/CadQuery/cadquery/blob/master/README.md">CadQuery Readme</a></li>
-          <li><a href="https://github.com/CadQuery/cadquery/tree/master/examples">CadQuery Examples</a></li>
-          <li><a href="https://cadquery.readthedocs.io/en/latest/apireference.html">CadQuery API Reference</a></li>
+          <li><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/">CadQuery Documentation</a></li>
+          <li><a target="_blank" href="https://github.com/CadQuery/cadquery/blob/master/README.md">CadQuery Readme</a></li>
+          <li><a target="_blank" href="https://github.com/CadQuery/cadquery/tree/master/examples">CadQuery Examples</a></li>
+          <li><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html">CadQuery API Reference</a></li>
         </ul>
       </div>
       <div class="section">
@@ -162,8 +163,77 @@
         </table>
       </div>
       <div class="section">
+        <h2>Selector String Modifiers</h2><br />
+        <div class="section-subtitle">See <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/selectors.html">CadQuery String Selectors</a> for more information.<br />
+        Axis Strings are: X, Y, Z, XY, YZ, XZ</div>
+        <table style="width:100%;">
+          <tr>
+            <th style="width:10%;">Modifier</th>
+            <th style="width:90%;">Description</th>
+          </tr>
+          <tr>
+            <td>&#124;</td>
+            <td>Parallel to = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.ParallelDirSelector">ParallelDirSelector</a></td>
+          </tr>
+          <tr>
+            <td>&#35;</td>
+            <td>Perpendicular to = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.PerpendicularDirSelector">PerpendicularDirSelector</a></td>
+          </tr>
+          <tr>
+            <td>&#43;</td>
+            <td>Positive direction = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a></td>
+          </tr>
+          <tr>
+            <td>&#45;</td>
+            <td>Negative direction = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a></td>
+          </tr>
+          <tr>
+            <td>&gt;</td>
+            <td>Max = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(directionMax=True)</td>
+          </tr>
+          <tr>
+            <td>&lt;</td>
+            <td>Min = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(directionMax=False)</td>
+          </tr>
+          <tr>
+            <td>&#37;</td>
+            <td>Curve/surface type = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.TypeSelector">TypeSelector</a></td>
+          </tr>
+        </table>
+      </div>
+      <div class="section">
+        <h2>Selector Methods</h2><br />
+        <div class="section-subtitle">CadQuery selector strings and classes allow filtering to select objects.</div>
+        <table style="width:100%;">
+          <tr>
+            <th style="width:40%;">Selector Methods</th>
+            <th style="width:60%;">Selector Classes
+            </th>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.faces">CQ.faces</a>(selector)</td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.NearestToPointSelector">NearestToPointSelector</a>(pnt)</td>
+          <tr>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.edges">CQ.edges</a>(selector)</td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.ParallelDirSelector">ParallelDirSelector</a>(vector)</td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vertices">CQ.vertices</a>(selector)</td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionSelector">DirectionSelector</a>(vector)</td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.solids">CQ.solids</a>(selector)</td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(vector)</td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shells">CQ.shells</a>(selector)</td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.TypeSelector">TypeSelector</a>(typeString)</td>
+          </tr>
+        </table>
+      </div>
+      <div class="section">
         <h2>Named Planes</h2><br />
-        <i></i>Direction references refer to the global directions.</i>
+        <div class="section-subtitle">Direction references refer to the global directions.</div>
         <table style="width:100%;">
           <tr>
             <th style="width:25%;">Name</th>
@@ -227,6 +297,7 @@
           </tr>
         </table>
       </div>
+
       <div class="section" hidden>
         <h2>Core Classes</h2><br />
         <table style="width:100%;">
@@ -248,80 +319,13 @@
           </tr>
         </table>
       </div>
-      <div class="section">
-        <h2>Selector String Modifiers</h2><br />
-        Selectors are a complex topic: see <a href="https://cadquery.readthedocs.io/en/latest/selectors.html">CadQuery String Selectors</a> for more information.<br />
-        Axis Strings are: X, Y, Z, XY, YZ, XZ
-        <table style="width:100%;">
-          <tr>
-            <th style="width:10%;">Modifier</th>
-            <th style="width:90%;">Description</th>
-          </tr>
-          <tr>
-            <td>&#124;</td>
-            <td>Parallel to (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.ParallelDirSelector">ParallelDirSelector</a>). Can return multiple objects.</td>
-          </tr>
-          <tr>
-            <td>&#35;</td>
-            <td>Perpendicular to (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.PerpendicularDirSelector">PerpendicularDirSelector</a>)</td>
-          </tr>
-          <tr>
-            <td>&#43;</td>
-            <td>Positive direction (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a>)</td>
-          </tr>
-          <tr>
-            <td>&#45;</td>
-            <td>Negative direction (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a>)</td>
-          </tr>
-          <tr>
-            <td>&gt;</td>
-            <td>Maximize (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a> with directionMax=True)</td>
-          </tr>
-          <tr>
-            <td>&lt;</td>
-            <td>Minimize (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a> with directionMax=False)</td>
-          </tr>
-          <tr>
-            <td>&#37;</td>
-            <td>Curve/surface type (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.TypeSelector">TypeSelector</a>)</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section">
-        <h2>Selector Methods</h2><br />
-        CadQuery selector strings allow filtering various types of object lists.
-        Most commonly, Edges, Faces, and Vertices are used, but all objects types can be filtered.<br />
-        <table style="width:100%;">
-          <tr>
-            <th style="width:40%;">Selector Methods</th>
-            <th style="width:60%;">Selector Classes
-            </th>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.faces">CQ.faces</a>(selector)</td>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.NearestToPointSelector">NearestToPointSelector</a>(pnt)</td>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.edges">CQ.edges</a>(selector)</td>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.ParallelDirSelector">ParallelDirSelector</a>(vector)</td>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vertices">CQ.vertices</a>(selector)</td>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionSelector">DirectionSelector</a>(vector)</td>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.solids">CQ.solids</a>(selector)</td>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(vector)</td>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shells">CQ.shells</a>(selector)</td>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.TypeSelector">TypeSelector</a>(typeString)</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section">
+
+      <div class="section" style="max-width: 600px">
         <h2>Examples of Filtering Faces</h2><br />
-        All types of filters work on faces. In most cases, the selector refers to the direction of the normal vector of the face.
-        If a face is not planar, selectors are evaluated at the center of mass of the face. This can lead to results that are quite unexpected.
+        <div class="section-subtitle">
+          All types of filters work on faces. In most cases, the selector refers to the direction of the normal vector of the face.
+          If a face is not planar, selectors are evaluated at the center of mass of the face. This can lead to results that are quite unexpected.
+        </div>
         <table style="width:100%;">
           <tr>
             <th style="width:10%;">Selector</th>
@@ -373,10 +377,12 @@
           </tr>
         </table>
       </div>
-      <div class="section">
+      <div class="section" style="max-width: 600px">
         <h2>Examples of Filtering Edges</h2><br />
-        Some filter types are not supported for edges. The selector usually refers to the direction of the edge.
-        Non-linear edges are not selected for any selectors except type (%). Non-linear edges are never returned when these filters are applied.
+        <div class="section-subtitle">
+          Some filter types are not supported for edges. The selector usually refers to the direction of the edge.
+          Non-linear edges are not selected for any selectors except type (%). Non-linear edges are never returned when these filters are applied.
+        </div>
         <table style="width:100%;">
           <tr>
             <th style="width:10%;">Selector</th>
@@ -428,27 +434,34 @@
           </tr>
         </table>
       </div>
-      <div class="section">
+      <div class="section" style="max-width: 600px">
         <h2>Examples of Filtering Vertices</h2><br />
-        Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter.
+        <div class="section-subtitle">Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter.</div>
         <table style="width:100%;">
           <tr>
             <th style="width:10%;">Selector</th>
             <th style="width:40%;">Selector Class</th>
             <th style="width:40%;">Selects</th>
-            <th style="width:10%;"># Objects Returned</th>
           </tr>
           <tr>
             <td>&gt;Y</td>
             <td>DirectionMinMaxSelector</td>
-            <td>Vertices farthest in the positive y dir</td>
-            <td>0 or 1</td>
+            <td>Vertices farthest in the +Y dir</td>
           </tr>
           <tr>
             <td>&lt;Y</td>
             <td>DirectionMinMaxSelector</td>
-            <td>Vertices farthest in the negative y dir</td>
-            <td>0 or 1</td>
+            <td>Vertices farthest in the -Y dir</td>
+          </tr>
+          <tr>
+            <td>&gt;&gt;Y[-2]</td>
+            <td>CenterNthSelector</td>
+            <td>2nd farthest vertex in the +Y dir</td>
+          </tr>
+          <tr>
+            <td>&lt;&lt;Y[0]</td>
+            <td>CenterNthSelector</td>
+            <td>1st closest vertex in the Y dir</td>
           </tr>
         </table>
       </div>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -41,6 +41,7 @@
     td {
       text-align: center;
       width: 5em;
+      padding: 3px 4px;
     }
     h1 {
       margin: 10px;
@@ -91,9 +92,14 @@
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.text">Workplane.text</a><br>(txt, fontsize, distance)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.revolve">Workplane.revolve</a><br>(angleDegrees)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">Workplane.intersect</a><br>(toIntersect)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.intersect">Workplane.intersect</a><br>(toIntersect)</td>
             </tr> 
-          </table>
+          <tr>
+            <td></td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.union">Workplane.union</a><br>(angleDegrees)</td>
+            <td></td>
+          </tr> 
+        </table>
       </div>
       <div class="section">
           <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#d-operations">2D Construction</a></h2>
@@ -119,8 +125,6 @@
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polyline">Workplane.polyline</a><br>(listOfXYTuple)</td>
             </tr>
           </table>
-      </div>
-      <div class="section">
           <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#sketch-initialization">Sketching</a></h2>
           <table>
             <tr>
@@ -206,9 +210,9 @@
         </table>
       </div>
       <div class="section">
-        <h2>Selector String Modifiers</h2><br />
-        <div class="section-subtitle">See <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/selectors.html">CadQuery String Selectors</a> for more information.<br />
-        Axis Strings are: X, Y, Z, XY, YZ, XZ</div>
+        <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/selectors.html">Selector String Modifiers</a></h2>
+        <h2></h2><br />
+        <div class="section-subtitle">Axis Strings are: X, Y, Z, XY, YZ, XZ</div>
         <table>
           <tr>
             <th style="width:10%;">Modifier</th>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -1,529 +1,656 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
-  <head>
-    <title>CadQuery Cheatsheet</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+	<head>
+		<title>CadQuery Cheatsheet</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <style type="text/css">
-    body {
-      width: 100vw;
-      margin: 0;
-      text-align: center;
-    }
-    #header {
-      background-color: #ddd; padding: 2px;
-      margin-bottom: 10px;
-    }
-    #section-container {
-      display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around; row-gap: 10px;
-      overflow: scroll;
-      width: 100%
-    }
-    .section {
-      margin: 0.5em;
-      padding: 0px 0.5em 0.5em;
-      background-color: #EBEBEB;
-      min-width: 340px;
-      max-width: min(50vw, 100%);
-      overflow-x: scroll;
-    }
-    .section-subtitle {
-      margin-bottom: 4px;
-    }
-    a, a:visited {
-      color: #1f4b8f;
-      font-weight: bold;
-      text-decoration: none;
-    }
-    table {
-      width: 100%;
-    }
-    tr {
-      background-color: #FFFFFF;
-    }
-    td {
-      text-align: center;
-      width: 5em;
-      padding: 3px 4px;
-    }
-    h1 {
-      margin: 10px;
-    }
-    h2 {
-      display: inline;
-    }
-    @media only screen and (max-width: 1000px) {
-      body{
-        font-size: 75%
-      }
-      .section {
-        max-width: 96%;
-      }
-    }
-    </style>
-  </head>
-  <body>
-    <div id="header">
-      <h1><img src="https://cadquery.readthedocs.io/en/latest/_static/cadquery_logo_dark.svg" alt="CadQuery Logo" height=30> Cheatsheet</h1>
-      <i>
-        A Quick Guide To The Most Commonly Used Functions! 
-        <br/>
-        <sub>
-          For the full API reference <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html">click here</a>.
-          For examples <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/examples.html">click here</a>.
-        </sub>
-      </i>
-    </div>
-    <div id="section-container">
-      <div class="section">
-        <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#id1">3D Construction</a></h2>
-          <table>
-            <thead>
-              <tr>
-                <th>Primitives</th>
-                <th>Additive</th>
-                <th>Subtractive</th>
-              </tr>
-            </thead>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.box">Workplane.box</a><br>(length, width, height)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">Workplane.extrude</a><br>(until)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cut">Workplane.cut</a><br>(toCut)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sphere">Workplane.sphere</a><br>(radius)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sweep">Workplane.sweep</a><br>(path)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">Workplane.cutThruAll</a><br>()</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cylinder">Workplane.cylinder</a><br>(height, radius)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.loft">Workplane.loft</a><br>(ruled, combine, clean)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutBlind">Workplane.cutBlind</a><br>(until)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.text">Workplane.text</a><br>(txt, fontsize, distance)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.revolve">Workplane.revolve</a><br>(angleDegrees)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hole">Workplane.hole</a><br>(diameter, depth)</td>
-            </tr> 
-          <tr>
-            <td></td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.union">Workplane.union</a><br>(angleDegrees)</td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.intersect">Workplane.intersect</a><br>(toIntersect)</td>
-          </tr> 
-        </table>
-      </div>
-      <div class="section">
-          <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#d-operations">2D Construction</a></h2>
-          <table>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.rect">Workplane.rect</a><br>(xLen, yLen)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.circle">Workplane.circle</a><br>(radius)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.ellipse">Workplane.ellipse</a><br>(x_radius, y_radius)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.center">Workplane.center</a><br>(x, y)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.moveTo">Workplane.moveTo</a><br>(x, y)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.move">Workplane.move</a><br>(xDist, yDist)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.lineTo">Workplane.lineTo</a><br>(x, y)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.line">Workplane.line</a><br>(xDist, yDist)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polarLine">Workplane.polarLine</a><br>(distance, angle)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vLine">Workplane.vLine</a><br>(distance)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hLine">Workplane.hLine</a><br>(distance)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polyline">Workplane.polyline</a><br>(listOfXYTuple)</td>
-            </tr>
-          </table>
-          <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#sketch-initialization">Sketching</a></h2>
-          <table>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.rect">Sketch.rect</a><br>(w, h)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.circle">Sketch.circle</a><br>(r)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.ellipse">Sketch.ellipse</a><br>(a1, a2)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.trapezoid">Sketch.trapezoid</a><br>(w, h, a1)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.regularPolygon">Sketch.regularPolygon</a><br>(r, n)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.polygon">Sketch.polygon</a><br>(pts)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.fillet">Sketch.fillet</a><br>(d)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.chamfer">Sketch.chamfer</a><br>(d)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.finalize">Sketch.finalize</a><br>()</td>
-            </tr>
-          </table>
-      </div>
-      <div style="display: flex; flex-direction: column;">
-        <div class="section">
-            <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#file-management-and-export">Import/Export</a></h2>
-            <table>
-              <tr>
-                <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#cadquery.importers.importDXF">importers.importDXF</a><br>(path, tol)</td>
-                <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#importing-step">importers.importStep</a><br>("path")</td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#exporting-stl">exporters.export</a><br>(solid, "path/solid.***")</td>
-                <td>Where *** can be: svg, step, stl, amf, vrml, json</td>
-              </tr>
-            </table>
-        </div>
-        <div class="section">
-          <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#assemblies">Assemblies</a></h2>
-          <table>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly">Assembly(</a><br>(obj)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.add">Assembly.add</a><br>(obj)</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/assy.html#constraints">Assembly.constrain</a><br>(***)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.solve">Assembly.solve</a><br>()</td>
-            </tr>
-            <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.save">Assembly.save</a><br>("path/assembly.***")</td>
-              <td>Where *** can be: step, xml, gltf, vtkjs, vrml</td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <div class="section" style="min-width: 300px;" hidden>
-        <h2>BREP Terminology</h2><br />
-        <table>
-          <tr>
-            <td style="width:10%;"><strong>vertex</strong></td>
-            <td style="width:90%;">A single point in space</td>
-          </tr>
-          <tr>
-            <td><strong>edge</strong></td>
-            <td>A connection between two or more vertices along a particular path (called a curve)</td>
-          </tr>
-          <tr>
-            <td><strong>wire</strong></td>
-            <td>A collection of edges that are connected together</td>
-          </tr>
-          <tr>
-            <td><strong>face</strong></td>
-            <td>A set of edges or wires that enclose a surface</td>
-          </tr>
-          <tr>
-            <td><strong>shell</strong></td>
-            <td>A collection of faces that are connected together along some of their edges</td>
-          </tr>
-          <tr>
-            <td><strong>solid</strong></td>
-            <td>A shell that has a closed interior</td>
-          </tr>
-          <tr>
-            <td><strong>compound</strong></td>
-            <td>A collection of solids</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section">
-        <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/selectors.html">Selector String Modifiers</a></h2>
-        <h2></h2><br />
-        <div class="section-subtitle">Axis Strings are: X, Y, Z, XY, YZ, XZ</div>
-        <table>
-          <tr>
-            <th style="width:10%;">Modifier</th>
-            <th style="width:90%;">Description</th>
-          </tr>
-          <tr>
-            <td>&#124;</td>
-            <td>Parallel to = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.ParallelDirSelector">ParallelDirSelector</a></td>
-          </tr>
-          <tr>
-            <td>&#35;</td>
-            <td>Perpendicular to = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.PerpendicularDirSelector">PerpendicularDirSelector</a></td>
-          </tr>
-          <tr>
-            <td>&#43;</td>
-            <td>Positive direction = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a></td>
-          </tr>
-          <tr>
-            <td>&#45;</td>
-            <td>Negative direction = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a></td>
-          </tr>
-          <tr>
-            <td>&gt;</td>
-            <td>Max = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(directionMax=True)</td>
-          </tr>
-          <tr>
-            <td>&lt;</td>
-            <td>Min = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(directionMax=False)</td>
-          </tr>
-          <tr>
-            <td>&#37;</td>
-            <td>Curve/surface type = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.TypeSelector">TypeSelector</a></td>
-          </tr>
-        </table>
-      </div>
-      <div class="section">
-        <h2>Selector Methods</h2><br />
-        <div class="section-subtitle">CadQuery selector strings and classes allow filtering to select objects.</div>
-        <table>
-          <tr>
-            <th style="width:40%;">Selector Methods</th>
-            <th style="width:60%;">Selector Classes
-            </th>
-          </tr>
-          <tr>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.faces">CQ.faces</a>(selector)</td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.NearestToPointSelector">NearestToPointSelector</a>(pnt)</td>
-          <tr>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.edges">CQ.edges</a>(selector)</td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.ParallelDirSelector">ParallelDirSelector</a>(vector)</td>
-          </tr>
-          <tr>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vertices">CQ.vertices</a>(selector)</td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionSelector">DirectionSelector</a>(vector)</td>
-          </tr>
-          <tr>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.solids">CQ.solids</a>(selector)</td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(vector)</td>
-          </tr>
-          <tr>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shells">CQ.shells</a>(selector)</td>
-            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.TypeSelector">TypeSelector</a>(typeString)</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section">
-        <h2>Named Planes</h2><br />
-        <div class="section-subtitle">Direction references refer to the global directions.</div>
-        <table>
-          <tr>
-            <th style="width:25%;">Name</th>
-            <th style="width:25%;">xDir</th>
-            <th style="width:25%;">yDir</th>
-            <th style="width:25%;">zDir</th>
-          </tr>
-          <tr>
-            <td>XY</td>
-            <td>+x</td>
-            <td>+y</td>
-            <td>+z</td>
-          </tr>
-          <tr>
-            <td>YZ</td>
-            <td>+y</td>
-            <td>+z</td>
-            <td>+x</td>
-          </tr>
-          <tr>
-            <td>XZ</td>
-            <td>+x</td>
-            <td>+z</td>
-            <td>-y</td>
-          </tr>
-          <tr>
-            <td>front</td>
-            <td>+x</td>
-            <td>+y</td>
-            <td>+z</td>
-          </tr>
-          <tr>
-            <td>back</td>
-            <td>-x</td>
-            <td>+y</td>
-            <td>-z</td>
-          </tr>
-          <tr>
-            <td>left</td>
-            <td>+z</td>
-            <td>+y</td>
-            <td>-x</td>
-          </tr>
-          <tr>
-            <td>right</td>
-            <td>-z</td>
-            <td>+y</td>
-            <td>+x</td>
-          </tr>
-          <tr>
-            <td>top</td>
-            <td>+x</td>
-            <td>-z</td>
-            <td>+y</td>
-          </tr>
-          <tr>
-            <td>bottom</td>
-            <td>+x</td>
-            <td>+z</td>
-            <td>-y</td>
-          </tr>
-        </table>
-      </div>
+		<style type="text/css">
+		body {
+			margin: 0;
+			text-align: center;
+		}
+		#header {
+			background-color: #ddd;
+			padding: 2px;
+			margin-bottom: 10px;
+		}
+		#section-container {
+			display: flex; 
+			flex-wrap: wrap; 
+			align-items: stretch; 
+			justify-content: center; 
+			row-gap: 10px;
+			overflow: auto;
+			width: 100%;
+		}
+		.section {
+			margin: 10px;
+			padding: 0px 0.5em 0.5em;
+			background-color: #EBEBEB;
+			min-width: 360px;
+			max-width: min(50vw, 100%);
+			overflow-x: auto;
+		}
+		.section-subtitle {
+			margin-bottom: 4px;
+		}
+		a, a:visited, .dark-icon {
+			color: #2664c2;
+			fill: #2664c2;
+			font-weight: bold;
+			text-decoration: none;
+		}
+		table {
+			width: 100%;
+		}
+		tr {
+			background-color: #FFFFFF;
+		}
+		td {
+			text-align: center;
+			width: 5em;
+			padding: 3px 4px;
+			line-height: 0.8;
+		}
+		h1 {
+			margin: 10px;
+		}
+		h2 {
+			display: inline;
+		}
+		small {
+			font-size: 75%;
+			font-family: monospace;
+		}
+		code {
+			background-color: #ddd;
+		}
+		@media only screen and (max-width: 1000px) {
+			body{
+				font-size: 75%
+			}
+			.section {
+				max-width: 96%;
+			}
+		}
+		.dark{
+			color: #ccc;
+			background-color: #222;
+		}
+		.dark #header{
+			background-color: #333;
+		}
+		.dark .section {
+			background-color: #444;
+		}
+		.dark tr {
+			background-color: #333;
+		}
+		.dark a, .dark a:visited, .dark h2, .dark .dark-icon {
+			color: #cce1ff;
+			fill: #cce1ff
+		}
+		.dark code {
+			background-color: #555;
+		}
+		.dark-icon {
+			width: 12px;
+			height: 12px;
+		}
+		.dark .dark-icon.moon {
+			display: none;	
+		}
+		body:not(.dark) .dark-icon.sun {
+			display: none;	
+		}
+		</style>
+	</head>
+	<body>
+		<div id="header">
+			<h1><img src="https://cadquery.readthedocs.io/en/latest/_static/cadquery_logo_dark.svg" alt="CadQuery Logo" height=30> Cheatsheet</h1>
+			<i>
+				A Quick Guide To The Most Commonly Used Functions! 
+				<br/>
+				<sub>
+					<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html">Full API reference</a>
+					&nbsp;|&nbsp;
+					<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/examples.html">Examples</a>
+					&nbsp;|&nbsp;
+					<a target="_blank" href="https://blog.jpoles1.com/2022/08/28/intro-to-cadquery-series-installing-cq-editor/">Install CQ-Editor</a>
+					&nbsp;|&nbsp;
+					<a href="#" onclick="toggleDark()">
+						<svg xmlns="http://www.w3.org/2000/svg" class="dark-icon sun" viewBox="0 0 512 512"><path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM352 256c0 53-43 96-96 96s-96-43-96-96s43-96 96-96s96 43 96 96zm32 0c0-70.7-57.3-128-128-128s-128 57.3-128 128s57.3 128 128 128s128-57.3 128-128z"/></svg>
+						<svg xmlns="http://www.w3.org/2000/svg" class="dark-icon moon" viewBox="0 0 384 512"><path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"/></svg>
+						Mode
+					</a>
+				</sub>
+			</i>
+		</div>
+		<div id="section-container">
+			<div class="section">
+				<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#id1">3D Construction</a></h2>
+					<table>
+						<thead>
+							<tr>
+								<th>Primitives</th>
+								<th>Additive</th>
+								<th>Subtractive</th>
+							</tr>
+						</thead>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.box">box</a><br><small>(length, width, height)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">extrude</a><br><small>(until)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutBlind">cutBlind</a><br><small>(until)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sphere">sphere</a><br><small>(radius)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.revolve">revolve</a><br><small>(angleDegrees)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">cutThruAll</a><br><small>()</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cylinder">cylinder</a><br><small>(height, radius)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.loft">loft</a><br><small>(ruled)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hole">hole</a><br><small>(diameter, depth)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.text">text</a><br><small>(txt, fontsize, distance)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sweep">sweep</a><br><small>(path, isFrenet, transitionMode)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shell">shell</a><br><small>(thickness)</small></td>
+						</tr> 
+					<tr>
+						<td rowspan="2"><small>^ quickly perform ^ <br> +/- boolean ops with<br><span style="white-space: nowrap;">(..., combine="a/s")</span><br>or use <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.union">union</a>/<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cut">cut</a>(shape)</small></td>
+						<td rowspan="1"></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.fillet">fillet</a><br><small>(radius)</small></td>
+					</tr> 
+					<tr>
+						<td></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.chamfer">chamfer</a><br><small>(length)</small></td>
+					</tr> 
+				</table>
+			</div>
+			<div class="section">
+					<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#d-operations">2D Construction</a></h2>
+					<table>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.rect">rect</a><br><small>(xLen, yLen)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.circle">circle</a><br><small>(radius)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.ellipse">ellipse</a><br><small>(x_radius, y_radius)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.center">center</a><br><small>(x, y)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.moveTo">moveTo</a><br><small>(x, y)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.move">move</a><br><small>(xDist, yDist)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.lineTo">lineTo</a><br><small>(x, y)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.line">line</a><br><small>(xDist, yDist)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polarLine">polarLine</a><br><small>(distance, angle)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vLine">vLine</a><br><small>(distance)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hLine">hLine</a><br><small>(distance)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polyline">polyline</a><br><small>(listOfXYTuple)</small></td>
+						</tr>
+					</table>
+					<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#sketch-initialization">Sketching</a></h2>
+					<table>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.rect">rect</a><br><small>(w, h)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.circle">circle</a><br><small>(r)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.ellipse">ellipse</a><br><small>(a1, a2)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.trapezoid">trapezoid</a><br><small>(w, h, a1)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.regularPolygon">regularPolygon</a><br><small>(r, n)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.polygon">polygon</a><br><small>(pts)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.fillet">fillet</a><br><small>(d)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.chamfer">chamfer</a><br><small>(d)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.finalize">finalize</a><br><small>()</small></td>
+						</tr>
+					</table>
+			</div>
+			<div style="display: flex; flex-direction: column;">
+				<div class="section">
+						<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#file-management-and-export">Import/Export</a></h2>
+						<table>
+							<tr>
+								<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#cadquery.importers.importDXF">importers.importDXF</a><br><small>(path, tol)</small></td>
+								<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#importing-step">importers.importStep</a><br><small>("path")</small></td>
+							</tr>
+							<tr>
+								<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#exporting-stl">exporters.export</a><br><small>(solid, "path/solid.***")</small></td>
+								<td><small>Where *** can be: svg, step, stl, amf, vrml, json</small></td>
+							</tr>
+						</table>
+				</div>
+				<div class="section">
+					<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#assemblies">Assemblies</a></h2>
+					<table>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly">Assembly</a><br><small>()</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.add">add</a><br><small>(obj, loc, color)</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/assy.html#constraints">constrain</a><br><small>(***)</small></td>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.solve">solve</a><br><small>()</small></td>
+						</tr>
+						<tr>
+							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.save">save</a><br><small>("path/assembly.***")</small></td>
+							<td><small>Where *** can be: step, xml, gltf, vtkjs, vrml</small></td>
+						</tr>
+					</table>
+				</div>
+			</div>
+			<div class="section" style="min-width: 300px;" hidden>
+				<h2>BREP Terminology</h2><br />
+				<table>
+					<tr>
+						<td style="width:10%;"><strong>vertex</strong></td>
+						<td style="width:90%;">A single point in space</td>
+					</tr>
+					<tr>
+						<td><strong>edge</strong></td>
+						<td>A connection between two or more vertices along a particular path (called a curve)</td>
+					</tr>
+					<tr>
+						<td><strong>wire</strong></td>
+						<td>A collection of edges that are connected together</td>
+					</tr>
+					<tr>
+						<td><strong>face</strong></td>
+						<td>A set of edges or wires that enclose a surface</td>
+					</tr>
+					<tr>
+						<td><strong>shell</strong></td>
+						<td>A collection of faces that are connected together along some of their edges</td>
+					</tr>
+					<tr>
+						<td><strong>solid</strong></td>
+						<td>A shell that has a closed interior</td>
+					</tr>
+					<tr>
+						<td><strong>compound</strong></td>
+						<td>A collection of solids</td>
+					</tr>
+				</table>
+			</div>
+			<div class="section">
+				<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/selectors.html">Selector String Modifiers</a></h2>
+				<h2></h2><br />
+				<div class="section-subtitle">Axis Strings are: X, Y, Z, XY, YZ, XZ</div>
+				<table>
+					<tr>
+						<th style="width:15%;">Mod</th>
+						<th style="width:85%;">Description</th>
+					</tr>
+					<tr>
+						<td>&#124;</td>
+						<td>Parallel to = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.ParallelDirSelector">ParallelDirSelector</a></td>
+					</tr>
+					<tr>
+						<td>&#35;</td>
+						<td>Perpendicular to = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.PerpendicularDirSelector">PerpendicularDirSelector</a></td>
+					</tr>
+					<tr>
+						<td>+/-</td>
+						<td>Pos/Neg direction = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionSelector">DirectionSelector</a></td>
+					</tr>
+					<tr>
+						<td>&gt;</td>
+						<td>Max = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(directionMax=True)</td>
+					</tr>
+					<tr>
+						<td>&lt;</td>
+						<td>Min = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(directionMax=False)</td>
+					</tr>
+					<tr>
+						<td>&#37;</td>
+						<td>Curve/surface type = <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.TypeSelector">TypeSelector</a></td>
+					</tr>
+					<tr>
+						<td colspan="2">
+							Eg: select the top face (> in Z direction) = 
+							<code>.faces(">Z")</code>
+						</td>
+					</tr>
+				</table>
+				
+			</div>
+			<div class="section">
+				<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#selector-classes">Selector Methods</a></h2><br />
+				<div class="section-subtitle">CadQuery selector strings and classes allow filtering to select objects.</div>
+				<table>
+					<tr>
+						<th style="width:40%;">Selector Methods</th>
+						<th style="width:60%;">Selector Classes
+						</th>
+					</tr>
+					<tr>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.faces">faces</a>(selector)</td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.NearestToPointSelector">NearestToPointSelector</a>(pnt)</td>
+					<tr>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.edges">edges</a>(selector)</td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.ParallelDirSelector">ParallelDirSelector</a>(vector)</td>
+					</tr>
+					<tr>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vertices">vertices</a>(selector)</td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.PerpendicularDirSelector">PerpendicularDirSelector</a>(vector)</td>
+					</tr>
+					<tr>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.solids">solids</a>(selector)</td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(vector)</td>
+					</tr>
+					<tr>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shells">shells</a>(selector)</td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.RadiusNthSelector">RadiusNthSelector</a>(n)</td>
+					</tr>
+					<tr>
+						<td></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.AndSelector">AndSelector</a>(selector, selector)</td>
+					</tr>
+					<tr>
+						<td></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.SumSelector">SumSelector</a>(selector, selector)</td>
+					</tr>
+					<tr>
+						<td></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.SubtractSelector">SubtractSelector</a>(selector, selector)</td>
+					</tr>
+					<tr>
+						<td></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.InverseSelector">InverseSelector</a>(selector)</td>
+					</tr>
+				</table>
+			</div>
+			<div class="section">
+				<h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#d-operations">Workplane Positioning</a></h2>
+				<table>
+					<tr>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.translate">translate</a><br><small>(Vector(x, y, z))</small></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.rotateAboutCenter">rotateAboutCenter</a><br><small>(Vector(x, y, z), angleDegrees)</small></td>
+						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.rotate">rotate</a><br><small>(Vector(x, y, z), Vector(x, y, z), angleDegrees)</small></td>
+					</tr>
+					<tr>
+						<td colspan="3">
+							<small>
+								Position a workplane relative to an existing feature with:
+								<br>
+								<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html?highlight=workplane#cadquery.Workplane.workplane">.workplane</a>(offset, origin)
+								<br>
+								sets the <code>offset</code> perpendicular to the current plane
+								<br>
+								sets the <code>origin</code> relative to (0,0) on the current plane
+							</small>
+						</td>
+					</tr>
+				</table>
+			</div>
+			<div class="section">
+				<h2>Named Planes</h2><br />
+				<div class="section-subtitle">Direction references refer to the global directions.</div>
+				<table>
+					<tr>
+						<th style="width:25%;">Name</th>
+						<th style="width:25%;">xDir</th>
+						<th style="width:25%;">yDir</th>
+						<th style="width:25%;">zDir</th>
+					</tr>
+					<tr>
+						<td>XY</td>
+						<td>+x</td>
+						<td>+y</td>
+						<td>+z</td>
+					</tr>
+					<tr>
+						<td>YZ</td>
+						<td>+y</td>
+						<td>+z</td>
+						<td>+x</td>
+					</tr>
+					<tr>
+						<td>XZ</td>
+						<td>+x</td>
+						<td>+z</td>
+						<td>-y</td>
+					</tr>
+					<tr>
+						<td>front</td>
+						<td>+x</td>
+						<td>+y</td>
+						<td>+z</td>
+					</tr>
+					<tr>
+						<td>back</td>
+						<td>-x</td>
+						<td>+y</td>
+						<td>-z</td>
+					</tr>
+					<tr>
+						<td>left</td>
+						<td>+z</td>
+						<td>+y</td>
+						<td>-x</td>
+					</tr>
+					<tr>
+						<td>right</td>
+						<td>-z</td>
+						<td>+y</td>
+						<td>+x</td>
+					</tr>
+					<tr>
+						<td>top</td>
+						<td>+x</td>
+						<td>-z</td>
+						<td>+y</td>
+					</tr>
+					<tr>
+						<td>bottom</td>
+						<td>+x</td>
+						<td>+z</td>
+						<td>-y</td>
+					</tr>
+				</table>
+			</div>
 
-      <div class="section" hidden>
-        <h2>Core Classes</h2><br />
-        <table>
-          <tr>
-            <th style="width:40%;">Class</th>
-            <th style="width:60%;">Description</th>
-          </tr>
-          <tr>
-            <td>CQ(obj)</td>
-            <td>Provides enhanced functionality for a wrapped CAD primitive.</td>
-          </tr>
-          <tr>
-            <td>Plane(origin, xDir, normal)</td>
-            <td>A 2d coordinate system in space, with the x-y axes on the a plane, and a particular point as the origin.</td>
-          </tr>
-          <tr>
-            <td>Workplane(inPlane[origin, obj])</td>
-            <td>Defines a coordinate system in space, in which 2D coordinates can be used.</td>
-          </tr>
-        </table>
-      </div>
+			<div class="section" hidden>
+				<h2>Core Classes</h2><br />
+				<table>
+					<tr>
+						<th style="width:40%;">Class</th>
+						<th style="width:60%;">Description</th>
+					</tr>
+					<tr>
+						<td>CQ(obj)</td>
+						<td>Provides enhanced functionality for a wrapped CAD primitive.</td>
+					</tr>
+					<tr>
+						<td>Plane(origin, xDir, normal)</td>
+						<td>A 2d coordinate system in space, with the x-y axes on the a plane, and a particular point as the origin.</td>
+					</tr>
+					<tr>
+						<td>Workplane(inPlane[origin, obj])</td>
+						<td>Defines a coordinate system in space, in which 2D coordinates can be used.</td>
+					</tr>
+				</table>
+			</div>
 
-      <div class="section" style="max-width: 600px">
-        <h2>Examples of Filtering Faces</h2><br />
-        <div class="section-subtitle">
-          All types of filters work on faces. In most cases, the selector refers to the direction of the normal vector of the face.
-          If a face is not planar, selectors are evaluated at the center of mass of the face. This can lead to results that are quite unexpected.
-        </div>
-        <table>
-          <tr>
-            <th style="width:10%;">Selector</th>
-            <th style="width:40%;">Selector Class</th>
-            <th style="width:40%;">Selects</th>
-            <th style="width:10%;"># Objects Returned</th>
-          </tr>
-          <tr>
-            <td>&#43;Z</td>
-            <td>DirectionSelector</td>
-            <td>Faces with normal in +z direction</td>
-            <td>0 or 1</td>
-          </tr>
-          <tr>
-            <td>&#124;Z</td>
-            <td>ParallelDirSelector</td>
-            <td>Faces parallel to xy plane</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#45;X</td>
-            <td>DirectionSelector</td>
-            <td>Faces with normal in neg x direction</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#35;Z</td>
-            <td>PerpendicularDirSelector</td>
-            <td>Faces perpendicular to z direction</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#37;Plane</td>
-            <td>TypeSelector</td>
-            <td>Faces of type plane</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&gt;Y</td>
-            <td>DirectionMinMaxSelector</td>
-            <td>Face farthest in the positive y dir</td>
-            <td>0 or 1</td>
-          </tr>
-          <tr>
-            <td>&lt;Y</td>
-            <td>DirectionMinMaxSelector</td>
-            <td>Face farthest in the negative y dir</td>
-            <td>0 or 1</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section" style="max-width: 600px">
-        <h2>Examples of Filtering Edges</h2><br />
-        <div class="section-subtitle">
-          Some filter types are not supported for edges. The selector usually refers to the direction of the edge.
-          Non-linear edges are not selected for any selectors except type (%). Non-linear edges are never returned when these filters are applied.
-        </div>
-        <table>
-          <tr>
-            <th style="width:10%;">Selector</th>
-            <th style="width:40%;">Selector Class</th>
-            <th style="width:40%;">Selects</th>
-            <th style="width:10%;"># Objects Returned</th>
-          </tr>
-          <tr>
-            <td>&#43;Z</td>
-            <td>DirectionSelector</td>
-            <td>Edges aligned in the Z direction</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#124;Z</td>
-            <td>ParallelDirSelector</td>
-            <td>Edges parallel to z direction</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#45;X</td>
-            <td>DirectionSelector</td>
-            <td>Edges aligned in neg x direction</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#35;Z</td>
-            <td>PerpendicularDirSelector</td>
-            <td>Edges perpendicular to z direction</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&#37;Plane</td>
-            <td>TypeSelector</td>
-            <td>Edges type line</td>
-            <td>0..many</td>
-          </tr>
-          <tr>
-            <td>&gt;Y</td>
-            <td>DirectionMinMaxSelector</td>
-            <td>Edges farthest in the positive y dir</td>
-            <td>0 or 1</td>
-          </tr>
-          <tr>
-            <td>&lt;Y</td>
-            <td>DirectionMinMaxSelector</td>
-            <td>Edges farthest in the negative y dir</td>
-            <td>0 or 1</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section" style="max-width: 600px">
-        <h2>Examples of Filtering Vertices</h2><br />
-        <div class="section-subtitle">Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter.</div>
-        <table>
-          <tr>
-            <th style="width:10%;">Selector</th>
-            <th style="width:40%;">Selector Class</th>
-            <th style="width:40%;">Selects</th>
-          </tr>
-          <tr>
-            <td>&gt;Y</td>
-            <td>DirectionMinMaxSelector</td>
-            <td>Vertices farthest in the +Y dir</td>
-          </tr>
-          <tr>
-            <td>&lt;Y</td>
-            <td>DirectionMinMaxSelector</td>
-            <td>Vertices farthest in the -Y dir</td>
-          </tr>
-          <tr>
-            <td>&gt;&gt;Y[-2]</td>
-            <td>CenterNthSelector</td>
-            <td>2nd farthest vertex in the +Y dir</td>
-          </tr>
-          <tr>
-            <td>&lt;&lt;Y[0]</td>
-            <td>CenterNthSelector</td>
-            <td>1st closest vertex in the Y dir</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-  </body>
+			<div class="section" style="max-width: 600px">
+				<h2>Examples of Filtering Faces</h2><br />
+				<div class="section-subtitle">
+					All types of filters work on faces. In most cases, the selector refers to the direction of the normal vector of the face.
+					If a face is not planar, selectors are evaluated at the center of mass of the face. This can lead to results that are quite unexpected.
+				</div>
+				<table>
+					<tr>
+						<th style="width:10%;">Selector</th>
+						<th style="width:40%;">Selector Class</th>
+						<th style="width:40%;">Selects</th>
+						<th style="width:10%;"># Objects Returned</th>
+					</tr>
+					<tr>
+						<td>&#43;Z</td>
+						<td>DirectionSelector</td>
+						<td>Faces with normal in +z direction</td>
+						<td>0 or 1</td>
+					</tr>
+					<tr>
+						<td>&#124;Z</td>
+						<td>ParallelDirSelector</td>
+						<td>Faces parallel to xy plane</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#45;X</td>
+						<td>DirectionSelector</td>
+						<td>Faces with normal in neg x direction</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#35;Z</td>
+						<td>PerpendicularDirSelector</td>
+						<td>Faces perpendicular to z direction</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#37;Plane</td>
+						<td>TypeSelector</td>
+						<td>Faces of type plane</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&gt;Y</td>
+						<td>DirectionMinMaxSelector</td>
+						<td>Face farthest in the positive y dir</td>
+						<td>0 or 1</td>
+					</tr>
+					<tr>
+						<td>&lt;Y</td>
+						<td>DirectionMinMaxSelector</td>
+						<td>Face farthest in the negative y dir</td>
+						<td>0 or 1</td>
+					</tr>
+				</table>
+			</div>
+			<div class="section" style="max-width: 600px">
+				<h2>Examples of Filtering Edges</h2><br />
+				<div class="section-subtitle">
+					Some filter types are not supported for edges. The selector usually refers to the direction of the edge.
+					Non-linear edges are not selected for any selectors except type (%). Non-linear edges are never returned when these filters are applied.
+				</div>
+				<table>
+					<tr>
+						<th style="width:10%;">Selector</th>
+						<th style="width:40%;">Selector Class</th>
+						<th style="width:40%;">Selects</th>
+						<th style="width:10%;"># Objects Returned</th>
+					</tr>
+					<tr>
+						<td>&#43;Z</td>
+						<td>DirectionSelector</td>
+						<td>Edges aligned in the Z direction</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#124;Z</td>
+						<td>ParallelDirSelector</td>
+						<td>Edges parallel to z direction</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#45;X</td>
+						<td>DirectionSelector</td>
+						<td>Edges aligned in neg x direction</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#35;Z</td>
+						<td>PerpendicularDirSelector</td>
+						<td>Edges perpendicular to z direction</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&#37;Plane</td>
+						<td>TypeSelector</td>
+						<td>Edges type line</td>
+						<td>0..many</td>
+					</tr>
+					<tr>
+						<td>&gt;Y</td>
+						<td>DirectionMinMaxSelector</td>
+						<td>Edges farthest in the positive y dir</td>
+						<td>0 or 1</td>
+					</tr>
+					<tr>
+						<td>&lt;Y</td>
+						<td>DirectionMinMaxSelector</td>
+						<td>Edges farthest in the negative y dir</td>
+						<td>0 or 1</td>
+					</tr>
+				</table>
+			</div>
+			<div class="section" style="max-width: 600px">
+				<h2>Examples of Filtering Vertices</h2><br />
+				<div class="section-subtitle">Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter.</div>
+				<table>
+					<tr>
+						<th style="width:10%;">Selector</th>
+						<th style="width:40%;">Selector Class</th>
+						<th style="width:40%;">Selects</th>
+					</tr>
+					<tr>
+						<td>&gt;Y</td>
+						<td>DirectionMinMaxSelector</td>
+						<td>Vertices farthest in the +Y dir</td>
+					</tr>
+					<tr>
+						<td>&lt;Y</td>
+						<td>DirectionMinMaxSelector</td>
+						<td>Vertices farthest in the -Y dir</td>
+					</tr>
+					<tr>
+						<td>&gt;&gt;Y[-2]</td>
+						<td>CenterNthSelector</td>
+						<td>2nd farthest vertex in the +Y dir</td>
+					</tr>
+					<tr>
+						<td>&lt;&lt;Y[0]</td>
+						<td>CenterNthSelector</td>
+						<td>1st closest vertex in the Y dir</td>
+					</tr>
+				</table>
+			</div>
+		</div>
+	</body>
 </html>
+
+<script type="text/javascript">
+	function getCookie(name) {
+		var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+		return v ? v[2] : null;
+	}
+	function enableDark() {
+		document.querySelector("body").classList.add("dark")
+		document.cookie="dark=1;"
+	}
+	function disableDark() {
+		document.querySelector("body").classList.remove("dark")
+		document.cookie="dark=0;"
+	}
+	function toggleDark() {
+		elem = document.querySelector("body")
+		if(elem.classList.contains("dark")) {
+			disableDark()
+		} else {
+			enableDark()
+		}
+	}
+
+	window.onload = () => {	
+		if(getCookie("dark") == "1") {
+			enableDark()
+		}
+	}
+</script>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -140,6 +140,38 @@
             </tr>
           </table>
       </div>
+      <div style="display: flex; flex-direction: column;">
+        <div class="section">
+            <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#file-management-and-export">Import/Export</a></h2>
+            <table>
+              <tr>
+                <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#cadquery.importers.importDXF">importers.importDXF</a><br>(path, tol)</td>
+                <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#importing-step">importers.importStep</a><br>("path")</td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/importexport.html#exporting-stl">exporters.export</a><br>(solid, "path/solid.***")</td>
+                <td>Where *** can be: svg, step, stl, amf, vrml, json</td>
+              </tr>
+            </table>
+        </div>
+        <div class="section">
+          <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#assemblies">Assemblies</a></h2>
+          <table>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly">Assembly(</a><br>(obj)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.add">Assembly.add</a><br>(obj)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/assy.html#constraints">Assembly.constrain</a><br>(***)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.solve">Assembly.solve</a><br>()</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Assembly.save">Assembly.save</a><br>("path/assembly.***")</td>
+              <td>Where *** can be: step, xml, gltf, vtkjs, vrml</td>
+            </tr>
+          </table>
+        </div>
+      </div>
       <div class="section" style="min-width: 300px;" hidden>
         <h2>BREP Terminology</h2><br />
         <table>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -82,22 +82,22 @@
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sphere">Workplane.sphere</a><br>(radius)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sweep">Workplane.sweep</a><br>(path)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">Workplane.cutThruAll</a><br>(until)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">Workplane.cutThruAll</a><br>()</td>
             </tr>
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cylinder">Workplane.sphere</a><br>(height, radius)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.loft">Workplane.loft</a><br>(ruled, combine, clean)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">Workplane.hole</a><br>(diameter, depth)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutBlind">Workplane.cutBlind</a><br>(until)</td>
             </tr>
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.text">Workplane.text</a><br>(txt, fontsize, distance)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.revolve">Workplane.revolve</a><br>(angleDegrees)</td>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.intersect">Workplane.intersect</a><br>(toIntersect)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hole">Workplane.hole</a><br>(diameter, depth)</td>
             </tr> 
           <tr>
             <td></td>
             <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.union">Workplane.union</a><br>(angleDegrees)</td>
-            <td></td>
+            <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.intersect">Workplane.intersect</a><br>(toIntersect)</td>
           </tr> 
         </table>
       </div>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -9,10 +9,20 @@
       margin: 0.5em;
       padding: 0px 0.5em 0.5em;
       background-color: #EBEBEB;
+      min-width: 300px;
+      max-width: 30vw;
+    }
+     {
+
+    }
+    h2 a, h2 a:visited, .section a,.section a:visited {
+      color: #1f4b8f;
+      font-weight: bold;
+      text-decoration: none;
+
     }
     .column {
       float: left;
-      width: 375px;
     }
     tr {
       background-color: #FFFFFF;
@@ -26,9 +36,15 @@
     }
     </style>
   </head>
-  <body>
-    <div class="column" style="width:475px;">
-      <div class="section">
+  <body style="text-align: center">
+    <div style="background-color: #ddd; padding: 2px;">
+      <h1><img src="https://cadquery.readthedocs.io/en/latest/_static/cadquery_logo_dark.svg" height=30> Cheatsheet</h1>
+      <i>A Quick Guide To The Most Commonly Used Functions! 
+      <br/>
+      <sub>For the full API ref <a href="https://cadquery.readthedocs.io/en/latest/apireference.html" target="_blank">click here!</a></sub></i>
+    </div>
+    <div style="display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around;">
+      <div class="section" hidden>
         <h2>Documentation</h2>
         <ul style="background-color:#ffffff;margin-bottom:0px;margin-top:0px;">
           <li><a href="https://cadquery.readthedocs.io/en/latest/">CadQuery Documentation</a></li>
@@ -38,6 +54,81 @@
         </ul>
       </div>
       <div class="section">
+        <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#id1">3D Construction</a></h2>
+          <table style="width:100%;">
+            <thead>
+              <th>Primitives</th>
+              <th>Additive</th>
+              <th>Subtractive</th>
+            </thead>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.box">Workplane.box</a><br>(length, width, height)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">Workplane.extrude</a><br>(until)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cut">Workplane.cut</a><br>(toCut)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sphere">Workplane.sphere</a><br>(radius)</li></td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sweep">Workplane.sweep</a><br>(path)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">Workplane.cutThruAll</a><br>(until)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cylinder">Workplane.sphere</a><br>(height, radius)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.loft">Workplane.loft</a><br>(ruled, combine, clean)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">Workplane.hole</a><br>(diameter, depth)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.text">Workplane.text</a><br>(txt, fontsize, distance)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.revolve">Workplane.revolve</a><br>(angleDegrees)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.extrude">Workplane.intersect</a><br>(toIntersect)</td>
+            </tr> 
+          </table>
+      </div>
+      <div class="section">
+          <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#d-operations">2D Construction</a></h2>
+          <table style="width:100%;">
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.rect">Workplane.rect</a><br>(xLen, yLen)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.circle">Workplane.circle</a><br>(radius)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.ellipse">Workplane.ellipse</a><br>(x_radius, y_radius)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.center">Workplane.center</a><br>(x, y)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.moveTo">Workplane.moveTo</a><br>(x, y)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.move">Workplane.move</a><br>(xDist, yDist)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.lineTo">Workplane.lineTo</a><br>(x, y)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.line">Workplane.line</a><br>(xDist, yDist)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polarLine">Workplane.polarLine</a><br>(distance, angle)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vLine">Workplane.vLine</a><br>(distance)</li></td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hLine">Workplane.hLine</a><br>(distance)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polyline">Workplane.polyline</a><br>(listOfXYTuple)</td>
+            </tr>
+          </table>
+      </div>
+      <div class="section">
+          <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#sketch-initialization">Sketching</a></h2>
+          <table style="width:100%;">
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.rect">Sketch.rect</a><br>(w, h)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.circle">Sketch.circle</a><br>(r)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.ellipse">Sketch.ellipse</a><br>(a1, a2)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.trapezoid">Sketch.trapezoid</a><br>(w, h, a1)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.regularPolygon">Sketch.regularPolygon</a><br>(r, n)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.polygon">Sketch.polygon</a><br>(pts)</td>
+            </tr>
+            <tr>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.fillet">Sketch.fillet</a><br>(d)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.chamfer">Sketch.chamfer</a><br>(d)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.clean">Sketch.clean</a><br>()</td>
+            </tr>
+          </table>
+      </div>
+      <div class="section" style="min-width: 300px;" hidden>
         <h2>BREP Terminology</h2><br />
         <table style="width:100%;">
           <tr>
@@ -72,7 +163,7 @@
       </div>
       <div class="section">
         <h2>Named Planes</h2><br />
-        Available named planes are as follows. Direction references refer to the global directions.
+        <i></i>Direction references refer to the global directions.</i>
         <table style="width:100%;">
           <tr>
             <th style="width:25%;">Name</th>
@@ -136,7 +227,7 @@
           </tr>
         </table>
       </div>
-      <div class="section">
+      <div class="section" hidden>
         <h2>Core Classes</h2><br />
         <table style="width:100%;">
           <tr>
@@ -154,75 +245,6 @@
           <tr>
             <td>Workplane(inPlane[origin, obj])</td>
             <td>Defines a coordinate system in space, in which 2D coordinates can be used.</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="column" style="width:600px;">
-      <div class="section">
-        <h2>Selector Methods</h2><br />
-        CadQuery selector strings allow filtering various types of object lists.
-        Most commonly, Edges, Faces, and Vertices are used, but all objects types can be filtered.<br />
-        <table style="width:100%;">
-          <tr>
-            <th style="width:40%;">Selector Method</th>
-            <th style="width:60%;">Description</th>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.faces">CQ.faces(selector=None)</a></td>
-            <td>Select the faces of objects on the stack, optionally filtering the selection.</td>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.edges">CQ.edges(selector=None)</a></td>
-            <td>Select the edges of objects on the stack, optionally filtering the selection.</td>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vertices">CQ.vertices(selector=None)</a></td>
-            <td>Select the vertices of objects on the stack, optionally filtering the selection.</td>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.solids">CQ.solids(selector=None)</a></td>
-            <td>Select the solids of objects on the stack, optionally filtering the selection.</td>
-          </tr>
-          <tr>
-            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shells">CQ.shells(selector=None)</a></td>
-            <td>Select the shells of objects on the stack, optionally filtering the selection.</td>
-          </tr>
-        </table>
-      </div>
-      <div class="section">
-        <h2>Selector Classes</h2><br />
-        <table style="width:100%;">
-          <tr>
-            <th style="width:40%;">Class</th>
-            <th style="width:60%;">Description</th>
-          </tr>
-          <tr>
-            <td>NearestToPointSelector(pnt)</td>
-            <td>Selects object nearest the provided point.</td>
-          </tr>
-          <tr>
-            <td>ParallelDirSelector(vector[tolerance])</td>
-            <td>Selects objects parallel with the provided direction.</td>
-          </tr>
-          <tr>
-            <td>DirectionSelector(vector[tolerance])</td>
-            <td>Selects objects aligned with the provided direction.</td>
-          </tr>
-          <tr>
-            <td>PerpendicularDirSelector(vector[tolerance])</td>
-            <td>Selects objects perpendicular with the provided direction.</td>
-          </tr>
-          <tr>
-            <td>TypeSelector(typeString)</td>
-            <td>Selects objects of the prescribed topological type.</td>
-          </tr>
-          <tr>
-            <td>DirectionMinMaxSelector(vector[directionMax])</td>
-            <td>Selects objects closest or farthest in the specified direction.</td>
-          </tr>
-          <tr>
-            <td>StringSyntaxSelector(selectorString)</td>
-            <td>Filter lists objects using a simple string syntax.</td>
           </tr>
         </table>
       </div>
@@ -262,6 +284,37 @@
           <tr>
             <td>&#37;</td>
             <td>Curve/surface type (same as <a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.TypeSelector">TypeSelector</a>)</td>
+          </tr>
+        </table>
+      </div>
+      <div class="section">
+        <h2>Selector Methods</h2><br />
+        CadQuery selector strings allow filtering various types of object lists.
+        Most commonly, Edges, Faces, and Vertices are used, but all objects types can be filtered.<br />
+        <table style="width:100%;">
+          <tr>
+            <th style="width:40%;">Selector Methods</th>
+            <th style="width:60%;">Selector Classes
+            </th>
+          </tr>
+          <tr>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.faces">CQ.faces</a>(selector)</td>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.NearestToPointSelector">NearestToPointSelector</a>(pnt)</td>
+          <tr>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.edges">CQ.edges</a>(selector)</td>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.ParallelDirSelector">ParallelDirSelector</a>(vector)</td>
+          </tr>
+          <tr>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vertices">CQ.vertices</a>(selector)</td>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionSelector">DirectionSelector</a>(vector)</td>
+          </tr>
+          <tr>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.solids">CQ.solids</a>(selector)</td>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.DirectionMinMaxSelector">DirectionMinMaxSelector</a>(vector)</td>
+          </tr>
+          <tr>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shells">CQ.shells</a>(selector)</td>
+            <td><a href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.selectors.TypeSelector">TypeSelector</a>(typeString)</td>
           </tr>
         </table>
       </div>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -85,7 +85,7 @@
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">Workplane.cutThruAll</a><br>()</td>
             </tr>
             <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cylinder">Workplane.sphere</a><br>(height, radius)</td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cylinder">Workplane.cylinder</a><br>(height, radius)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.loft">Workplane.loft</a><br>(ruled, combine, clean)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutBlind">Workplane.cutBlind</a><br>(until)</td>
             </tr>

--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -1,11 +1,22 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html>
+<html lang="en">
   <head>
     <title>CadQuery Cheatsheet</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style type="text/css">
+    body {
+      margin: 0;
+      text-align: center;
+    }
+    #header {
+      background-color: #ddd; padding: 2px;
+      margin-bottom: 10px;
+    }
+    #section-container {
+      display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around; row-gap: 10px;
+    }
     .section {
       margin: 0.5em;
       padding: 0px 0.5em 0.5em;
@@ -16,14 +27,13 @@
     .section-subtitle {
       margin-bottom: 4px;
     }
-    h2 a, h2 a:visited, .section a,.section a:visited {
+    a, a:visited {
       color: #1f4b8f;
       font-weight: bold;
       text-decoration: none;
-
     }
-    .column {
-      float: left;
+    table {
+      width: 100%;
     }
     tr {
       background-color: #FFFFFF;
@@ -32,35 +42,36 @@
       text-align: center;
       width: 5em;
     }
+    h1 {
+      margin: 10px;
+    }
     h2 {
       display: inline;
     }
     </style>
   </head>
-  <body style="text-align: center">
-    <div style="background-color: #ddd; padding: 2px;">
-      <h1><img src="https://cadquery.readthedocs.io/en/latest/_static/cadquery_logo_dark.svg" height=30> Cheatsheet</h1>
-      <i>A Quick Guide To The Most Commonly Used Functions! 
-      <br/>
-      <sub>For the full API ref <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html" target="_blank">click here!</a></sub></i>
+  <body>
+    <div id="header">
+      <h1><img src="https://cadquery.readthedocs.io/en/latest/_static/cadquery_logo_dark.svg" alt="CadQuery Logo" height=30> Cheatsheet</h1>
+      <i>
+        A Quick Guide To The Most Commonly Used Functions! 
+        <br/>
+        <sub>
+          For the full API reference <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html">click here</a>.
+          For examples <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/examples.html">click here</a>.
+        </sub>
+      </i>
     </div>
-    <div style="display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-around; row-gap: 10px;">
-      <div class="section" hidden>
-        <h2>Documentation</h2>
-        <ul style="background-color:#ffffff;margin-bottom:0px;margin-top:0px;">
-          <li><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/">CadQuery Documentation</a></li>
-          <li><a target="_blank" href="https://github.com/CadQuery/cadquery/blob/master/README.md">CadQuery Readme</a></li>
-          <li><a target="_blank" href="https://github.com/CadQuery/cadquery/tree/master/examples">CadQuery Examples</a></li>
-          <li><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html">CadQuery API Reference</a></li>
-        </ul>
-      </div>
+    <div id="section-container">
       <div class="section">
         <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#id1">3D Construction</a></h2>
-          <table style="width:100%;">
+          <table>
             <thead>
-              <th>Primitives</th>
-              <th>Additive</th>
-              <th>Subtractive</th>
+              <tr>
+                <th>Primitives</th>
+                <th>Additive</th>
+                <th>Subtractive</th>
+              </tr>
             </thead>
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.box">Workplane.box</a><br>(length, width, height)</td>
@@ -68,7 +79,7 @@
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cut">Workplane.cut</a><br>(toCut)</td>
             </tr>
             <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sphere">Workplane.sphere</a><br>(radius)</li></td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sphere">Workplane.sphere</a><br>(radius)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.sweep">Workplane.sweep</a><br>(path)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cutThruAll">Workplane.cutThruAll</a><br>(until)</td>
             </tr>
@@ -86,7 +97,7 @@
       </div>
       <div class="section">
           <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#d-operations">2D Construction</a></h2>
-          <table style="width:100%;">
+          <table>
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.rect">Workplane.rect</a><br>(xLen, yLen)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.circle">Workplane.circle</a><br>(radius)</td>
@@ -103,7 +114,7 @@
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polarLine">Workplane.polarLine</a><br>(distance, angle)</td>
             </tr>
             <tr>
-              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vLine">Workplane.vLine</a><br>(distance)</li></td>
+              <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.vLine">Workplane.vLine</a><br>(distance)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.hLine">Workplane.hLine</a><br>(distance)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.polyline">Workplane.polyline</a><br>(listOfXYTuple)</td>
             </tr>
@@ -111,7 +122,7 @@
       </div>
       <div class="section">
           <h2><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/apireference.html#sketch-initialization">Sketching</a></h2>
-          <table style="width:100%;">
+          <table>
             <tr>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.rect">Sketch.rect</a><br>(w, h)</td>
               <td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Sketch.circle">Sketch.circle</a><br>(r)</td>
@@ -131,7 +142,7 @@
       </div>
       <div class="section" style="min-width: 300px;" hidden>
         <h2>BREP Terminology</h2><br />
-        <table style="width:100%;">
+        <table>
           <tr>
             <td style="width:10%;"><strong>vertex</strong></td>
             <td style="width:90%;">A single point in space</td>
@@ -166,7 +177,7 @@
         <h2>Selector String Modifiers</h2><br />
         <div class="section-subtitle">See <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/selectors.html">CadQuery String Selectors</a> for more information.<br />
         Axis Strings are: X, Y, Z, XY, YZ, XZ</div>
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:10%;">Modifier</th>
             <th style="width:90%;">Description</th>
@@ -204,7 +215,7 @@
       <div class="section">
         <h2>Selector Methods</h2><br />
         <div class="section-subtitle">CadQuery selector strings and classes allow filtering to select objects.</div>
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:40%;">Selector Methods</th>
             <th style="width:60%;">Selector Classes
@@ -234,7 +245,7 @@
       <div class="section">
         <h2>Named Planes</h2><br />
         <div class="section-subtitle">Direction references refer to the global directions.</div>
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:25%;">Name</th>
             <th style="width:25%;">xDir</th>
@@ -300,7 +311,7 @@
 
       <div class="section" hidden>
         <h2>Core Classes</h2><br />
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:40%;">Class</th>
             <th style="width:60%;">Description</th>
@@ -326,7 +337,7 @@
           All types of filters work on faces. In most cases, the selector refers to the direction of the normal vector of the face.
           If a face is not planar, selectors are evaluated at the center of mass of the face. This can lead to results that are quite unexpected.
         </div>
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:10%;">Selector</th>
             <th style="width:40%;">Selector Class</th>
@@ -383,7 +394,7 @@
           Some filter types are not supported for edges. The selector usually refers to the direction of the edge.
           Non-linear edges are not selected for any selectors except type (%). Non-linear edges are never returned when these filters are applied.
         </div>
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:10%;">Selector</th>
             <th style="width:40%;">Selector Class</th>
@@ -437,7 +448,7 @@
       <div class="section" style="max-width: 600px">
         <h2>Examples of Filtering Vertices</h2><br />
         <div class="section-subtitle">Only a few of the filter types apply to vertices. The location of the vertex is the subject of the filter.</div>
-        <table style="width:100%;">
+        <table>
           <tr>
             <th style="width:10%;">Selector</th>
             <th style="width:40%;">Selector Class</th>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,6 +43,7 @@ Table Of Contents
     fileformat.rst
     examples.rst
     apireference.rst
+    API Cheatsheet <https://cadquery.readthedocs.io/en/latest/_static/cadquery_cheatsheet.html>
     selectors.rst
     classreference.rst
     importexport.rst


### PR DESCRIPTION
This PR includes a revamped cheatsheet. It includes more information on the most common commands. Some commands have been excluded from this first draft at rewriting the cheatsheet, any important ones I missed can certainly be added, just let me know.  Addresses issue #1128.

I've also made some changes to the README to link to the documentation more clearly under the "Getting Started" header, including a link to the cheatsheet.

Finally, made a few stylistic fixes to that part of the README, added a link to a VSCode extension. This part is more optional, but figured I'd include it, no worries if we need to drop it.