### PR TITLE
Improve style of quick start docs

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -84,8 +84,9 @@ This modification will do the trick:
     diameter = 22.0
 
     # make the base
-    result = cq.Workplane("XY").box(height, width, thickness)\
+    result = (cq.Workplane("XY").box(height, width, thickness)
         .faces(">Z").workplane().hole(diameter)
+    )
 
     # Render the solid
     show_object(result)
@@ -138,13 +139,14 @@ Good news!-- we can get the job done with just a few lines of code. Here's the c
     padding = 12.0
 
     # make the base
-    result = cq.Workplane("XY").box(height, width, thickness)\
-        .faces(">Z").workplane().hole(diameter)\
-        .faces(">Z").workplane() \
-        .rect(height - padding,width - padding,forConstruction=True)\
-        .vertices()\
+    result = (cq.Workplane("XY")
+        .box(height, width, thickness)
+        .faces(">Z").workplane().hole(diameter)
+        .faces(">Z").workplane()
+        .rect(height - padding,width - padding,forConstruction=True)
+        .vertices()
         .cboreHole(2.4, 4.4, 2.1)
-
+    )
     # Render the solid
     show_object(result)
 
@@ -203,12 +205,14 @@ We can do that using the preset dictionaries in the parameter definition:
     padding = 12.0
 
     # make the base
-    result = cq.Workplane("XY").box(height, width, thickness)\
-        .faces(">Z").workplane().hole(diameter)\
-        .faces(">Z").workplane() \
-        .rect(height - padding, width - padding, forConstruction=True)\
-        .vertices().cboreHole(2.4, 4.4, 2.1)\
+    result = (cq.Workplane("XY")
+        .box(height, width, thickness)
+        .faces(">Z").workplane().hole(diameter)
+        .faces(">Z").workplane()
+        .rect(height - padding, width - padding, forConstruction=True)
+        .vertices().cboreHole(2.4, 4.4, 2.1)
         .edges("|Z").fillet(2.0)
+    )
 
     # Render the solid
     show_object(result)
@@ -240,12 +244,14 @@ This can be easily accomplished using the :py:meth:`cadquery.exporters.export` f
     padding = 12.0
 
     # make the base
-    result = cq.Workplane("XY").box(height, width, thickness)\
-        .faces(">Z").workplane().hole(diameter)\
-        .faces(">Z").workplane() \
-        .rect(height - padding, width - padding, forConstruction=True)\
-        .vertices().cboreHole(2.4, 4.4, 2.1)\
+    result = (cq.Workplane("XY")
+        .box(height, width, thickness)
+        .faces(">Z").workplane().hole(diameter)
+        .faces(">Z").workplane()
+        .rect(height - padding, width - padding, forConstruction=True)
+        .vertices().cboreHole(2.4, 4.4, 2.1)
         .edges("|Z").fillet(2.0)
+    )
 
     # Render the solid
     show_object(result)


### PR DESCRIPTION
Remove line-break slashes and replace with parentheses per psf/black formatter guidelines. This also makes the quick start page more consistent with the other examples that are already in the documentation.