### PR TITLE
Update cadquery-ocp pip requirement to 7.6.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ is_azure = "CONDA_PY" in os.environ
 # Only include the installation dependencies if we are not running on RTD or AppVeyor
 if not is_rtd and not is_appveyor and not is_azure:
     reqs = [
-        "cadquery-ocp>=7.5,<7.6",
+        "cadquery-ocp>=7.6,<7.7",
         "ezdxf",
         "multimethod>=1.7,<2.0",
         "nlopt",


### PR DESCRIPTION
cadquery-ocp wheels are available for ocp 7.6.3.alpha and vtk 9.1 at https://pypi.org/project/cadquery-ocp/7.6.3a0/﻿ so update the requirement to enable:

```sh
pip install --pre git+https://github.com/cadquery/cadquery
```

