### PR TITLE
Option to control verbosity of assembly solver

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -346,7 +346,7 @@ class Assembly(object):
 
         return self
 
-    def solve(self) -> "Assembly":
+    def solve(self, verbosity: int = 0) -> "Assembly":
         """
         Solve the constraints.
         """
@@ -412,7 +412,7 @@ class Assembly(object):
         solver = ConstraintSolver(locs, constraints, locked=locked, scale=scale)
 
         # solve
-        locs_new, self._solve_result = solver.solve()
+        locs_new, self._solve_result = solver.solve(verbosity)
 
         # update positions
 

--- a/cadquery/occ_impl/solver.py
+++ b/cadquery/occ_impl/solver.py
@@ -659,7 +659,7 @@ class ConstraintSolver(object):
 
     def solve(self, verbosity: int = 0) -> Tuple[List[Location], Dict[str, Any]]:
 
-        suppress_banner = ("yes" if verbosity == 0 else "no")
+        suppress_banner = "yes" if verbosity == 0 else "no"
 
         opti = self.opti
 

--- a/cadquery/occ_impl/solver.py
+++ b/cadquery/occ_impl/solver.py
@@ -657,7 +657,12 @@ class ConstraintSolver(object):
 
         return rv
 
-    def solve(self) -> Tuple[List[Location], Dict[str, Any]]:
+    def solve(self, verbosity: int = 0) -> Tuple[List[Location], Dict[str, Any]]:
+
+        if verbosity == 0:
+            suppress_banner = "yes"
+        else:
+            suppress_banner = "no"
 
         opti = self.opti
 
@@ -709,7 +714,8 @@ class ConstraintSolver(object):
                 "nlp_scaling_method": "none",
                 "honor_original_bounds": "yes",
                 "bound_relax_factor": 0,
-                "print_level": 5,
+                "print_level": verbosity,
+                "sb": suppress_banner,
                 "print_timing_statistics": "no",
                 "linear_solver": "mumps",
             },

--- a/cadquery/occ_impl/solver.py
+++ b/cadquery/occ_impl/solver.py
@@ -659,10 +659,7 @@ class ConstraintSolver(object):
 
     def solve(self, verbosity: int = 0) -> Tuple[List[Location], Dict[str, Any]]:
 
-        if verbosity == 0:
-            suppress_banner = "yes"
-        else:
-            suppress_banner = "no"
+        suppress_banner = ("yes" if verbosity == 0 else "no")
 
         opti = self.opti
 


### PR DESCRIPTION
Proposed method signature for `cadquery.assembly.Assembly.solve`:

```python
def solve(self, verbosity: int = 0) -> "Assembly":
```

When verbosity == 0 there is no output. Values of 1 and greater have increasing levels of verbosity printed to stdout.

Closes #1191