### PR TITLE
show deprecation warning only when required

### DIFF
--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -59,9 +59,7 @@ class deprecate_kwarg_name:
         @wraps(f)
         def wrapped(*args, **kwargs):
 
-            f_sig_params = signature(f).parameters
-
-            if f_sig_params[self.name]:
+            if self.name in kwargs:
                 warn(
                     f"Kwarg <{self.name}> will be removed. Please use <{self.new_name}>",
                     FutureWarning,


### PR DESCRIPTION
Show the deprecation warning (used in workplane.text) only when the argument is actually used in the function call.