### PR TITLE
Added --pre option to pip install line to make it explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ NB: CadQuery has only recently returned to PyPI, and a full release has not happ
 
 It is also possible to install the very latest changes directly from CadQuery's GitHub repository, with the understanding that sometimes breaking changes can occur. To install from the git repository, run the following command line.
 ```
-pip install git+https://github.com/CadQuery/cadquery.git
+pip install --pre git+https://github.com/CadQuery/cadquery.git
 ```
 
 You should now have a working CadQuery installation, but developers or users who want to use CadQuery with IPython/Jupyter or to set up a developer environment can read the rest of this section.


### PR DESCRIPTION
Not having this option caused a problem on a Windows install because the `--pre` wasn't assumed by pip when installing from git.