### PR TITLE
fix incorrect coordinate system of glTF exports

### DIFF
--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -83,6 +83,10 @@ class AssemblyProtocol(Protocol):
     def loc(self) -> Location:
         ...
 
+    @loc.setter
+    def loc(self, value: Location) -> None:
+        ...
+
     @property
     def name(self) -> str:
         ...

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -164,8 +164,8 @@ def exportGLTF(
 
     # map from CadQuery's right-handed +Z up coordinate system to glTF's right-handed +Y up coordinate system
     # https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units
-    coordinate_system_relation = Location((0, 0, 0), (1, 0, 0), -90)
-    assy.loc *= coordinate_system_relation
+    orig_loc = assy.loc
+    assy.loc *= Location((0, 0, 0), (1, 0, 0), -90)
 
     # mesh all the shapes
     for _, el in assy.traverse():
@@ -180,6 +180,6 @@ def exportGLTF(
     )
 
     # restore coordinate system after exporting
-    assy.loc *= coordinate_system_relation.inverse
+    assy.loc = orig_loc
 
     return result

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -26,6 +26,7 @@ from OCP.Interface import Interface_Static
 from ..assembly import AssemblyProtocol, toCAF, toVTK
 from ..geom import Location
 
+
 def exportAssembly(assy: AssemblyProtocol, path: str, **kwargs) -> bool:
     """
     Export an assembly to a STEP file.
@@ -162,7 +163,7 @@ def exportGLTF(
     """
 
     # map from CadQuery's right-handed +Z up coordinate system to glTF's right-handed +Y up coordinate system
-    # https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units 
+    # https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units
     coordinate_system_relation = Location((0, 0, 0), (1, 0, 0), -90)
     assy.loc *= coordinate_system_relation
 
@@ -174,7 +175,7 @@ def exportGLTF(
     _, doc = toCAF(assy, True)
 
     writer = RWGltf_CafWriter(TCollection_AsciiString(path), binary)
-    result =  writer.Perform(
+    result = writer.Perform(
         doc, TColStd_IndexedDataMapOfStringString(), Message_ProgressRange()
     )
 

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -24,7 +24,7 @@ from OCP.Message import Message_ProgressRange
 from OCP.Interface import Interface_Static
 
 from ..assembly import AssemblyProtocol, toCAF, toVTK
-
+from ..geom import Location
 
 def exportAssembly(assy: AssemblyProtocol, path: str, **kwargs) -> bool:
     """
@@ -161,6 +161,11 @@ def exportGLTF(
     Export an assembly to a gltf file.
     """
 
+    # map from CadQuery's right-handed +Z up coordinate system to glTF's right-handed +Y up coordinate system
+    # https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units 
+    coordinate_system_relation = Location((0, 0, 0), (1, 0, 0), -90)
+    assy.loc *= coordinate_system_relation
+
     # mesh all the shapes
     for _, el in assy.traverse():
         for s in el.shapes:
@@ -169,6 +174,11 @@ def exportGLTF(
     _, doc = toCAF(assy, True)
 
     writer = RWGltf_CafWriter(TCollection_AsciiString(path), binary)
-    return writer.Perform(
+    result =  writer.Perform(
         doc, TColStd_IndexedDataMapOfStringString(), Message_ProgressRange()
     )
+
+    # restore coordinate system after exporting
+    assy.loc *= coordinate_system_relation.inverse
+
+    return result


### PR DESCRIPTION
correctly exports glTF in right-handed +Y up coordinate space as defined in the [glTF specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units)

before:
![before](https://user-images.githubusercontent.com/7185241/209367117-176fe1b9-0c86-4715-aeef-434b7b712e2c.png)

after:
![after](https://user-images.githubusercontent.com/7185241/209367122-da7843c0-17c4-4dd0-ba67-7e9a9291133f.png)
