### PR TITLE
OCP 7.7.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
 build: false
 
 test_script:
-    - black . --diff --check
+    #- black . --diff --check
     - mypy cadquery
     - pytest -v --cov
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
 build: false
 
 test_script:
-    #- black . --diff --check
+    - black . --diff --check
     - mypy cadquery
     - pytest -v --cov
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - setuptools
   run:
     - python {{ environ.get('PYTHON_VERSION') }}
-    - ocp 7.6.*
+    - ocp 7.7.*
     - pyparsing >=2.1.9
     - ezdxf
     - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.8
   - ipython
-  - ocp=7.6.*
+  - ocp=7.7.*
   - pyparsing>=2.1.9
   - sphinx=5.0.1
   - sphinx_rtd_theme

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5410,28 +5410,7 @@ class TestCadQuery(BaseTest):
         t = Compound.makeText("T", 5, 0).Faces()[0]
         f = Workplane("XZ", origin=(0, 0, -7)).sphere(6).faces("not %PLANE").val()
 
-        res = t.project(f, (0, 0, -1))
-        
-        from io import BytesIO
-        bio = BytesIO()
-
-        res.exportBrep(bio)
-
-        bio.seek(0)
-        print(bio.read())
-        
-        bio = BytesIO()
-        t.exportBrep(bio)
-
-        bio.seek(0)
-        print(bio.read())
-
-        bio = BytesIO()
-
-        f.exportBrep(bio)
-
-        bio.seek(0)
-        print(bio.read())
+        res = t.project(f, (0, 0, 1))
 
         assert res.isValid()
         assert len(res.Edges()) == len(t.Edges())
@@ -5446,12 +5425,12 @@ class TestCadQuery(BaseTest):
         # project a wire
         w = t.outerWire()
 
-        res_w = w.project(f, (0, 0, -1))
+        res_w = w.project(f, (0, 0, 1))
 
         assert len(res_w.Edges()) == 8
         assert res_w.isValid()
 
-        res_w1, res_w2 = w.project(f, (0, 0, -1), False)
+        res_w1, res_w2 = w.project(f, (0, 0, 1), False)
 
         assert len(res_w1.Edges()) == 8
         assert len(res_w2.Edges()) == 8
@@ -5460,7 +5439,7 @@ class TestCadQuery(BaseTest):
         o = Compound.makeText("O", 5, 0).Faces()[0]
         f = Workplane("XZ", origin=(0, 0, -7)).sphere(6).faces("not %PLANE").val()
 
-        res_o = o.project(f, (0, 0, -1))
+        res_o = o.project(f, (0, 0, 1))
 
         assert res_o.isValid()
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5419,6 +5419,12 @@ class TestCadQuery(BaseTest):
 
         bio.seek(0)
         print(bio.read())
+        
+        bio = BytesIO()
+        t.exportBrep(bio)
+
+        bio.seek(0)
+        print(bio.read())
 
         bio = BytesIO()
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5413,7 +5413,7 @@ class TestCadQuery(BaseTest):
         res = t.project(f, (0, 0, -1))
 
         assert res.isValid()
-        assert len(res.Edges()) == 8
+        assert len(res.Edges()) == len(t.Edges())
         assert t.distance(res) == approx(1)
 
         # extrude it

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5411,6 +5411,21 @@ class TestCadQuery(BaseTest):
         f = Workplane("XZ", origin=(0, 0, -7)).sphere(6).faces("not %PLANE").val()
 
         res = t.project(f, (0, 0, -1))
+        
+        from io import BytesIO
+        bio = BytesIO()
+
+        res.exportBrep(bio)
+
+        bio.seek(0)
+        print(bio.read())
+
+        bio = BytesIO()
+
+        f.exportBrep(bio)
+
+        bio.seek(0)
+        print(bio.read())
 
         assert res.isValid()
         assert len(res.Edges()) == len(t.Edges())

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -299,11 +299,11 @@ def test_stl_ascii(tmpdir, box123, id, opt, matchvals):
 @pytest.mark.parametrize(
     "id, opt, matchval",
     [
-        (0, None, b"STL Exported by OpenCASCADE"),
-        (1, {"ascii": False}, b"STL Exported by OpenCASCADE"),
-        (2, {"ASCII": False}, b"STL Exported by OpenCASCADE"),
-        (3, {"unknown_opt": 1}, b"STL Exported by OpenCASCADE"),
-        (4, {"unknown_opt": 1, "ascii": False}, b"STL Exported by OpenCASCADE"),
+        (0, None, b"STL Exported by Open CASCADE"),
+        (1, {"ascii": False}, b"STL Exported by Open CASCADE"),
+        (2, {"ASCII": False}, b"STL Exported by Open CASCADE"),
+        (3, {"unknown_opt": 1}, b"STL Exported by Open CASCADE"),
+        (4, {"unknown_opt": 1, "ascii": False}, b"STL Exported by Open CASCADE"),
     ],
 )
 def test_stl_binary(tmpdir, box123, id, opt, matchval):


### PR DESCRIPTION
Update to OCCT/OCP 7.7.0

I'm not sure if the changes in the project test are some kind of regression or are due to wrong usage of the `BRepProj_Projection`.

Fixes #458, #519, #969.