### PR TITLE
Attempting to Fix RTD Doc Builds with mock

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,6 +13,7 @@
 
 import sys, os, re
 import os.path
+import mock
 
 # print "working path is %s" % os.getcwd()
 # sys.path.append("../cadquery")


### PR DESCRIPTION
RTD is failing due to a memory consumption error, which hopefully can be fixed by using mock. Do not merge until this fix is verified.