### PR TITLE
Format documentation code blocks with Black

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -121,8 +121,8 @@ class Assembly(object):
 
         To create one constraint a root object::
 
-            b = Workplane().box(1,1,1)
-            assy = Assembly(b, Location(Vector(0,0,1)), name="root")
+            b = Workplane().box(1, 1, 1)
+            assy = Assembly(b, Location(Vector(0, 0, 1)), name="root")
 
         """
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2582,9 +2582,7 @@ class Workplane(object):
         the center of mass (equals center for next shape) is shifted. To create concentric ellipses
         use::
 
-            Workplane("XY")
-            .center(10, 20).ellipse(100,10)
-            .center(0, 0).ellipse(50, 5)
+            Workplane("XY").center(10, 20).ellipse(100,10).center(0, 0).ellipse(50, 5)
         """
 
         e = Wire.makeEllipse(

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -288,7 +288,7 @@ class Workplane(object):
         a split bushing::
 
             # drill a hole in the side
-            c = Workplane().box(1,1,1).faces(">Z").workplane().circle(0.25).cutThruAll()
+            c = Workplane().box(1, 1, 1).faces(">Z").workplane().circle(0.25).cutThruAll()
 
             # now cut it in half sideways
             c = c.faces(">Y").workplane(-0.5).split(keepTop=True)
@@ -1248,7 +1248,7 @@ class Workplane(object):
 
         This example will create a unit cube, with the top edges filleted::
 
-            s = Workplane().box(1,1,1).faces("+Z").edges().fillet(0.1)
+            s = Workplane().box(1, 1, 1).faces("+Z").edges().fillet(0.1)
         """
         # TODO: ensure that edges selected actually belong to the solid in the chain, otherwise,
         # TODO: we segfault
@@ -1282,11 +1282,11 @@ class Workplane(object):
 
         This example will create a unit cube, with the top edges chamfered::
 
-            s = Workplane("XY").box(1,1,1).faces("+Z").chamfer(0.1)
+            s = Workplane("XY").box(1, 1, 1).faces("+Z").chamfer(0.1)
 
         This example will create chamfers longer on the sides::
 
-            s = Workplane("XY").box(1,1,1).faces("+Z").chamfer(0.2, 0.1)
+            s = Workplane("XY").box(1, 1, 1).faces("+Z").chamfer(0.2, 0.1)
         """
         solid = self.findSolid()
 
@@ -1515,8 +1515,13 @@ class Workplane(object):
         circles or holes. This example creates a cube, and then drills three holes through it,
         based on three points::
 
-            s = Workplane().box(1,1,1).faces(">Z").workplane().\
-                pushPoints([(-0.3,0.3),(0.3,0.3),(0,0)])
+            s = (
+                Workplane()
+                .box(1, 1, 1)
+                .faces(">Z")
+                .workplane()
+                .pushPoints([(-0.3, 0.3), (0.3, 0.3), (0, 0)])
+            )
             body = s.circle(0.05).cutThruAll()
 
         Here the circle function operates on all three points, and is then extruded to create three
@@ -1547,12 +1552,12 @@ class Workplane(object):
         In this example, we adjust the workplane center to be at the corner of a cube, instead of
         the center of a face, which is the default::
 
-            #this workplane is centered at x=0.5,y=0.5, the center of the upper face
-            s = Workplane().box(1,1,1).faces(">Z").workplane()
+            # this workplane is centered at x=0.5,y=0.5, the center of the upper face
+            s = Workplane().box(1, 1, 1).faces(">Z").workplane()
 
-            s = s.center(-0.5,-0.5) # move the center to the corner
+            s = s.center(-0.5, -0.5)  # move the center to the corner
             t = s.circle(0.25).extrude(0.2)
-            assert ( t.faces().size() == 9 ) # a cube with a cylindrical nub at the top right corner
+            assert t.faces().size() == 9  # a cube with a cylindrical nub at the top right corner
 
         The result is a cube with a round boss on the corner
         """
@@ -1822,15 +1827,15 @@ class Workplane(object):
 
             s = Workplane(Plane.XY())
             sPnts = [
-                (2.75,1.5),
-                (2.5,1.75),
-                (2.0,1.5),
-                (1.5,1.0),
-                (1.0,1.25),
-                (0.5,1.0),
-                (0,1.0)
+                (2.75, 1.5),
+                (2.5, 1.75),
+                (2.0, 1.5),
+                (1.5, 1.0),
+                (1.0, 1.25),
+                (0.5, 1.0),
+                (0, 1.0),
             ]
-            r = s.lineTo(3.0,0).lineTo(3.0,1.0).spline(sPnts).close()
+            r = s.lineTo(3.0, 0).lineTo(3.0, 1.0).spline(sPnts).close()
             r = r.extrude(0.5)
 
         *WARNING*  It is fairly easy to create a list of points
@@ -2207,7 +2212,7 @@ class Workplane(object):
 
         Typically used to make creating wires with symmetry easier. This line of code::
 
-             s = Workplane().lineTo(2,2).threePointArc((3,1),(2,0)).mirrorX().extrude(0.25)
+             s = Workplane().lineTo(2, 2).threePointArc((3, 1), (2, 0)).mirrorX().extrude(0.25)
 
         Produces a flat, heart shaped object
         """
@@ -2488,7 +2493,7 @@ class Workplane(object):
         A common use case is to use a for-construction rectangle to define the centers of a hole
         pattern::
 
-            s = Workplane().rect(4.0,4.0,forConstruction=True).vertices().circle(0.25)
+            s = Workplane().rect(4.0, 4.0, forConstruction=True).vertices().circle(0.25)
 
         Creates 4 circles at the corners of a square centered on the origin.
 
@@ -2538,7 +2543,7 @@ class Workplane(object):
         A common use case is to use a for-construction rectangle to define the centers of a
         hole pattern::
 
-            s = Workplane().rect(4.0,4.0,forConstruction=True).vertices().circle(0.25)
+            s = Workplane().rect(4.0, 4.0, forConstruction=True).vertices().circle(0.25)
 
         Creates 4 circles at the corners of a square centered on the origin. Another common case is
         to use successive circle() calls to create concentric circles.  This works because the
@@ -2582,7 +2587,7 @@ class Workplane(object):
         the center of mass (equals center for next shape) is shifted. To create concentric ellipses
         use::
 
-            Workplane("XY").center(10, 20).ellipse(100,10).center(0, 0).ellipse(50, 5)
+            Workplane("XY").center(10, 20).ellipse(100, 10).center(0, 0).ellipse(50, 5)
         """
 
         e = Wire.makeEllipse(
@@ -2697,7 +2702,7 @@ class Workplane(object):
         the group of edges into a wire. This example builds a simple triangular
         prism::
 
-            s = Workplane().lineTo(1,0).lineTo(1,1).close().extrude(0.2)
+            s = Workplane().lineTo(1, 0).lineTo(1, 1).close().extrude(0.2)
         """
         endPoint = self._findFromPoint(True)
 
@@ -3880,11 +3885,11 @@ class Workplane(object):
 
             # create 4 small square bumps on a larger base plate:
             s = (
-                Workplane().
-                box(4, 4, 0.5).
-                faces(">Z").
-                workplane().
-                rect(3, 3, forConstruction=True)
+                Workplane()
+                .box(4, 4, 0.5)
+                .faces(">Z")
+                .workplane()
+                .rect(3, 3, forConstruction=True)
                 .vertices()
                 .box(0.25, 0.25, 0.25, combine=True)
             )

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -94,7 +94,7 @@ class NearestToPointSelector(Selector):
 
     Example::
 
-       CQ(aCube).vertices(NearestToPointSelector((0,1,0))
+       CQ(aCube).vertices(NearestToPointSelector((0, 1, 0)))
 
     returns the vertex of the unit cube closest to the point x=0,y=1,z=0
 
@@ -126,7 +126,7 @@ class BoxSelector(Selector):
 
     Example::
 
-        CQ(aCube).edges(BoxSelector((0,1,0), (1,2,1))
+        CQ(aCube).edges(BoxSelector((0, 1, 0), (1, 2, 1)))
     """
 
     def __init__(self, point0, point1, boundingbox=False):
@@ -213,7 +213,7 @@ class ParallelDirSelector(BaseDirSelector):
 
     Example::
 
-        CQ(aCube).faces(ParallelDirSelector((0, 0, 1))
+        CQ(aCube).faces(ParallelDirSelector((0, 0, 1)))
 
     selects faces with the normal parallel to the z direction, and is equivalent to::
 
@@ -236,7 +236,7 @@ class DirectionSelector(BaseDirSelector):
 
     Example::
 
-        CQ(aCube).faces(DirectionSelector((0, 0, 1))
+        CQ(aCube).faces(DirectionSelector((0, 0, 1)))
 
     selects faces with the normal in the z direction, and is equivalent to::
 
@@ -260,7 +260,7 @@ class PerpendicularDirSelector(BaseDirSelector):
 
     Example::
 
-        CQ(aCube).faces(PerpendicularDirSelector((0, 0, 1))
+        CQ(aCube).faces(PerpendicularDirSelector((0, 0, 1)))
 
     selects faces with the normal perpendicular to the z direction, and is equivalent to::
 
@@ -418,7 +418,7 @@ class DirectionMinMaxSelector(CenterNthSelector):
 
     For example this::
 
-        CQ(aCube).faces(DirectionMinMaxSelector((0, 0, 1), True)
+        CQ(aCube).faces(DirectionMinMaxSelector((0, 0, 1), True))
 
     Means to select the face having the center of mass farthest in the positive
     z direction, and is the same as::

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -281,11 +281,11 @@ class TypeSelector(Selector):
 
     You can use the string selector syntax. For example this::
 
-        CQ(aCube).faces ( TypeSelector("PLANE") )
+        CQ(aCube).faces(TypeSelector("PLANE"))
 
     will select 6 faces, and is equivalent to::
 
-        CQ(aCube).faces( "%PLANE" )
+        CQ(aCube).faces("%PLANE")
 
     """
 

--- a/doc/assy.rst
+++ b/doc/assy.rst
@@ -187,15 +187,15 @@ Should you need to do something unusual that is not possible with the string
 based selectors (e.g. use :py:class:`cadquery.selectors.BoxSelector` or a user-defined selector class),
 it is possible to pass :py:class:`cadquery.Shape` objects to the :py:meth:`cadquery.Assembly.constrain` method directly. For example, the above
 
-.. code-block:: python
+.. code-block::
 
-    .constrain('part1@faces@>Z','part3@faces@<Z','Axis')
+    .constrain("part1@faces@>Z", "part3@faces@<Z", "Axis")
 
 is equivalent to
 
-.. code-block:: python
+.. code-block::
 
-    .constrain('part1',part1.faces('>z').val(),'part3',part3.faces('<Z').val(),'Axis')
+    .constrain("part1", part1.faces(">z").val(), "part3", part3.faces("<Z").val(), "Axis")
 
 This method requires a :py:class:`cadquery.Shape` object, so remember to use the :py:meth:`cadquery.Workplane.val`
 method to pass a single :py:class:`cadquery.Shape` and not the whole :py:class:`cadquery.Workplane` object.

--- a/doc/assy.rst
+++ b/doc/assy.rst
@@ -19,21 +19,21 @@ We want to start with defining the model parameters to allow for easy dimension 
 .. code-block:: python
 
     import cadquery as cq
-    
+
     # Parameters
     H = 400
     W = 200
     D = 350
-    
+
     PROFILE = cq.importers.importDXF("vslot-2020_1.dxf").wires()
-    
+
     SLOT_D = 5
     PANEL_T = 3
-    
+
     HANDLE_D = 20
     HANDLE_L = 50
     HANDLE_W = 4
-    
+
 It is interesting to note that the v-slot profile is imported from a DXF file.
 This way it is very easy to change to other aluminum extrusion type, e.g. Item or Bosch.
 Vendors usually provide DXF files.
@@ -46,12 +46,10 @@ Next we want to define functions generating the assembly components based on the
 .. code-block:: python
 
     def make_vslot(l):
-    
         return PROFILE.toPending().extrude(l)
-    
-    
+
+
     def make_connector():
-    
         rv = (
             cq.Workplane()
             .box(20, 20, 20)
@@ -62,43 +60,41 @@ Next we want to define functions generating the assembly components based on the
             .workplane(centerOption="CenterOfMass")
             .cboreHole(6, 15, 18)
         )
-    
+
         # tag mating faces
         rv.faces(">X").tag("X").end()
         rv.faces(">Z").tag("Z").end()
-    
+
         return rv
-    
-    
+
+
     def make_panel(w, h, t, cutout):
-    
         rv = (
             cq.Workplane("XZ")
             .rect(w, h)
             .extrude(t)
             .faces(">Y")
             .vertices()
-            .rect(2*cutout,2*cutout)
+            .rect(2 * cutout, 2 * cutout)
             .cutThruAll()
             .faces("<Y")
             .workplane()
             .pushPoints([(-w / 3, HANDLE_L / 2), (-w / 3, -HANDLE_L / 2)])
             .hole(3)
         )
-    
+
         # tag mating edges
         rv.faces(">Y").edges("%CIRCLE").edges(">Z").tag("hole1")
         rv.faces(">Y").edges("%CIRCLE").edges("<Z").tag("hole2")
-    
+
         return rv
-    
-    
+
+
     def make_handle(w, h, r):
-    
         pts = ((0, 0), (w, 0), (w, h), (0, h))
-    
+
         path = cq.Workplane().polyline(pts)
-    
+
         rv = (
             cq.Workplane("YZ")
             .rect(r, r)
@@ -109,43 +105,43 @@ Next we want to define functions generating the assembly components based on the
             .faces("<X", tag="solid")
             .hole(r / 1.5)
         )
-        
+
         # tag mating faces
         rv.faces("<X").faces(">Y").tag("mate1")
         rv.faces("<X").faces("<Y").tag("mate2")
-    
+
         return rv
-        
+
 Initial assembly
 ================
 
 Next we want to instantiate all the components and add them to the assembly.
 
 .. code-block:: python
-   
-    # define the elements
-    door = (
-        cq.Assembly()
-        .add(make_vslot(H), name="left")
-        .add(make_vslot(H), name="right")
-        .add(make_vslot(W), name="top")
-        .add(make_vslot(W), name="bottom")
-        .add(make_connector(), name="con_tl", color=cq.Color("black"))
-        .add(make_connector(), name="con_tr", color=cq.Color("black"))
-        .add(make_connector(), name="con_bl", color=cq.Color("black"))
-        .add(make_connector(), name="con_br", color=cq.Color("black"))
-        .add(
-            make_panel(W + SLOT_D, H + SLOT_D, PANEL_T, SLOT_D),
-            name="panel",
-            color=cq.Color(0, 0, 1, 0.2),
-        )
-        .add(
-            make_handle(HANDLE_D, HANDLE_L, HANDLE_W),
-            name="handle",
-            color=cq.Color("yellow"),
-        )
-    )
-    
+
+   # define the elements
+   door = (
+       cq.Assembly()
+       .add(make_vslot(H), name="left")
+       .add(make_vslot(H), name="right")
+       .add(make_vslot(W), name="top")
+       .add(make_vslot(W), name="bottom")
+       .add(make_connector(), name="con_tl", color=cq.Color("black"))
+       .add(make_connector(), name="con_tr", color=cq.Color("black"))
+       .add(make_connector(), name="con_bl", color=cq.Color("black"))
+       .add(make_connector(), name="con_br", color=cq.Color("black"))
+       .add(
+           make_panel(W + SLOT_D, H + SLOT_D, PANEL_T, SLOT_D),
+           name="panel",
+           color=cq.Color(0, 0, 1, 0.2),
+       )
+       .add(
+           make_handle(HANDLE_D, HANDLE_L, HANDLE_W),
+           name="handle",
+           color=cq.Color("yellow"),
+       )
+   )
+
 Constraints definition
 ======================
 
@@ -182,7 +178,7 @@ Then we want to define all the constraints
         .constrain("panel?hole1", "handle?mate1", "Plane")
         .constrain("panel?hole2", "handle?mate2", "Point")
     )
-    
+
 Should you need to do something unusual that is not possible with the string
 based selectors (e.g. use :py:class:`cadquery.selectors.BoxSelector` or a user-defined selector class),
 it is possible to pass :py:class:`cadquery.Shape` objects to the :py:meth:`cadquery.Assembly.constrain` method directly. For example, the above
@@ -367,9 +363,8 @@ STEP can be loaded in all CAD tool, e.g. in FreeCAD and the XML be used in other
 .. code-block:: python
    :linenos:
 
-    door.save('door.step')
-    door.save('door.xml')
-    
+    door.save("door.step")
+    door.save("door.xml")
 ..  image:: _static/door_assy_freecad.png
 
 

--- a/doc/assy.rst
+++ b/doc/assy.rst
@@ -205,29 +205,27 @@ Below is the complete code including the final solve step.
     :height: 600px
 
     import cadquery as cq
-    
+
     # Parameters
     H = 400
     W = 200
     D = 350
-    
+
     PROFILE = cq.importers.importDXF("vslot-2020_1.dxf").wires()
-    
+
     SLOT_D = 6
     PANEL_T = 3
-    
+
     HANDLE_D = 20
     HANDLE_L = 50
     HANDLE_W = 4
-    
-    
+
+
     def make_vslot(l):
-    
         return PROFILE.toPending().extrude(l)
-    
-    
+
+
     def make_connector():
-    
         rv = (
             cq.Workplane()
             .box(20, 20, 20)
@@ -238,43 +236,41 @@ Below is the complete code including the final solve step.
             .workplane(centerOption="CenterOfMass")
             .cboreHole(6, 15, 18)
         )
-    
+
         # tag mating faces
         rv.faces(">X").tag("X").end()
         rv.faces(">Z").tag("Z").end()
-    
+
         return rv
-    
-    
+
+
     def make_panel(w, h, t, cutout):
-    
         rv = (
             cq.Workplane("XZ")
             .rect(w, h)
             .extrude(t)
             .faces(">Y")
             .vertices()
-            .rect(2*cutout,2*cutout)
+            .rect(2 * cutout, 2 * cutout)
             .cutThruAll()
             .faces("<Y")
             .workplane()
             .pushPoints([(-w / 3, HANDLE_L / 2), (-w / 3, -HANDLE_L / 2)])
             .hole(3)
         )
-    
+
         # tag mating edges
         rv.faces(">Y").edges("%CIRCLE").edges(">Z").tag("hole1")
         rv.faces(">Y").edges("%CIRCLE").edges("<Z").tag("hole2")
-    
+
         return rv
-    
-    
+
+
     def make_handle(w, h, r):
-    
         pts = ((0, 0), (w, 0), (w, h), (0, h))
-    
+
         path = cq.Workplane().polyline(pts)
-    
+
         rv = (
             cq.Workplane("YZ")
             .rect(r, r)
@@ -285,14 +281,14 @@ Below is the complete code including the final solve step.
             .faces("<X", tag="solid")
             .hole(r / 1.5)
         )
-        
+
         # tag mating faces
         rv.faces("<X").faces(">Y").tag("mate1")
         rv.faces("<X").faces("<Y").tag("mate2")
-    
+
         return rv
-    
-    
+
+
     # define the elements
     door = (
         cq.Assembly()
@@ -305,7 +301,7 @@ Below is the complete code including the final solve step.
         .add(make_connector(), name="con_bl", color=cq.Color("black"))
         .add(make_connector(), name="con_br", color=cq.Color("black"))
         .add(
-            make_panel(W + 2*SLOT_D, H + 2*SLOT_D, PANEL_T, SLOT_D),
+            make_panel(W + 2 * SLOT_D, H + 2 * SLOT_D, PANEL_T, SLOT_D),
             name="panel",
             color=cq.Color(0, 0, 1, 0.2),
         )
@@ -315,7 +311,7 @@ Below is the complete code including the final solve step.
             color=cq.Color("yellow"),
         )
     )
-    
+
     # define the constraints
     (
         door
@@ -345,11 +341,11 @@ Below is the complete code including the final solve step.
         .constrain("panel?hole1", "handle?mate1", "Plane")
         .constrain("panel?hole2", "handle?mate2", "Point")
     )
-    
+
     # solve
     door.solve()
-    
-    show_object(door,name='door')
+
+    show_object(door, name="door")
 
 
 Data export
@@ -457,18 +453,22 @@ argument. Hence it will work with all subclasses of :class:`~cadquery.Shape`.
 
     assy = cq.Assembly()
     assy.add(line, name="line")
-    
+
     # position the red box on the center of the arc
     assy.add(box, name="box0", color=cq.Color("red"))
     assy.constrain("line", "box0", "Point")
-    
+
     # position the green box at a normalized distance of 0.8 along the arc
     position0 = line.positionAt(0.8)
     assy.add(box, name="box1", color=cq.Color("green"))
     assy.constrain(
-        "line", cq.Vertex.makeVertex(*position0.toTuple()), "box1", box.val(), "Point",
+        "line",
+        cq.Vertex.makeVertex(*position0.toTuple()),
+        "box1",
+        box.val(),
+        "Point",
     )
-    
+
     # position the orange box 2 units in any direction from the green box
     assy.add(box, name="box2", color=cq.Color("orange"))
     assy.constrain(
@@ -484,9 +484,13 @@ argument. Hence it will work with all subclasses of :class:`~cadquery.Shape`.
     position1 = position0 + cq.Vector(2, 0, 0)
     assy.add(box, name="box3", color=cq.Color("blue"))
     assy.constrain(
-        "line", cq.Vertex.makeVertex(*position1.toTuple()), "box3", box.val(), "Point",
+        "line",
+        cq.Vertex.makeVertex(*position1.toTuple()),
+        "box3",
+        box.val(),
+        "Point",
     )
-    
+
     assy.solve()
     show_object(assy)
 
@@ -527,7 +531,7 @@ of two objects touch.
     assy.add(cone, name="cone0", color=cq.Color("green"))
     assy.add(cone, name="cone1", color=cq.Color("blue"))
     assy.constrain("cone0@faces@<Z", "cone1@faces@<Z", "Axis")
-    
+
     assy.solve()
     show_object(assy)
 
@@ -542,16 +546,16 @@ This is often used when one object goes through another, such as a pin going int
 
     plate = cq.Workplane().box(10, 10, 1).faces(">Z").workplane().hole(2)
     cone = cq.Solid.makeCone(0.8, 0, 4)
-    
+
     assy = cq.Assembly()
     assy.add(plate, name="plate", color=cq.Color("green"))
     assy.add(cone, name="cone", color=cq.Color("blue"))
     # place the center of the flat face of the cone in the center of the upper face of the plate
     assy.constrain("plate@faces@>Z", "cone@faces@<Z", "Point")
-    
+
     # set both the flat face of the cone and the upper face of the plate to point in the same direction
     assy.constrain("plate@faces@>Z", "cone@faces@<Z", "Axis", param=0)
-    
+
     assy.solve()
     show_object(assy)
 
@@ -657,7 +661,7 @@ Where:
 - :math:`\operatorname{dist}( \vec{ a }, b)` is the distance between point :math:`\vec{ a }` and
   plane :math:`b`.
 
-    
+
 .. cadquery::
 
     import cadquery as cq

--- a/doc/cqgi.rst
+++ b/doc/cqgi.rst
@@ -133,7 +133,7 @@ You can list the variables defined in the model by using the return value of the
 
        model = cqgi.parse(user_script)
 
-       //a dictionary of InputParameter objects
+       # a dictionary of InputParameter objects
        parameters = model.metadata.parameters
 
 The key of the dictionary is a string , and the value is a :py:class:`cadquery.cqgi.InputParameter` object

--- a/doc/cqgi.rst
+++ b/doc/cqgi.rst
@@ -37,15 +37,20 @@ the container.  An error will occur if the script does not return an object usin
 
 This CQGI compliant script produces a cube with a circle on top, and displays a workplane as well as an intermediate circle as debug output::
 
-    base_cube = cq.Workplane('XY').rect(1.0,1.0).extrude(1.0)
+    base_cube = cq.Workplane("XY").rect(1.0, 1.0).extrude(1.0)
     top_of_cube_plane = base_cube.faces(">Z").workplane()
-    debug(top_of_cube_plane, { 'color': 'yellow', } )
-    debug(top_of_cube_plane.center, { 'color' : 'blue' } )
+    debug(
+        top_of_cube_plane,
+        {
+            "color": "yellow",
+        },
+    )
+    debug(top_of_cube_plane.center, {"color": "blue"})
 
-    circle=top_of_cube_plane.circle(0.5)
-    debug(circle, { 'color': 'red' } )
+    circle = top_of_cube_plane.circle(0.5)
+    debug(circle, {"color": "red"})
 
-    show_object( circle.extrude(1.0) )
+    show_object(circle.extrude(1.0))
 
 Note that importing cadquery is not required. 
 At the end of this script, one object will be displayed, in addition to a workplane, a point, and a circle
@@ -73,7 +78,6 @@ user parameters available. This is useful if the execution environment would lik
 model parameters.  Typically, after collecting new values, the environment will supply them in the build() method.
 
 This code will return a dictionary of parameter values in the model text SCRIPT::
-     
      parameters = cqgi.parse(SCRIPT).metadata.parameters
 
 The dictionary you get back is a map where key is the parameter name, and value is an InputParameter object, 
@@ -100,7 +104,9 @@ with new values::
     from cadquery import cqgi
 
     user_script = ...
-    build_result = cqgi.parse(user_script).build(build_parameters={ 'param': 2 }, build_options={} )
+    build_result = cqgi.parse(user_script).build(
+        build_parameters={"param": 2}, build_options={}
+    )
 
 If a parameter called 'param' is defined in the model, it will be assigned the value 2 before the script runs.
 An error will occur if a value is provided that is not defined in the model, or if the value provided cannot
@@ -122,7 +128,8 @@ For example, in the following script::
 
       h = 1.0
       w = 2.0
-      foo = 'bar'
+      foo = "bar"
+
 
       def some_function():
           x = 1
@@ -150,13 +157,13 @@ The below Python script demonstrates how to open, process, and export an STL fil
       # Load CQGI
       import cadquery.cqgi as cqgi
       import cadquery as cq
-      
+
       # load the cadquery script
       model = cqgi.parse(open("example.py").read())
-      
+
       # run the script and store the result (from the show_object call in the script)
       build_result = model.build()
-      
+
       # test to ensure the process worked.
       if build_result.success:
           # loop through all the shapes returned and export to STL

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -70,8 +70,13 @@ projection is at the center of the face. The default hole depth is through the e
         center_hole_dia = 22.0
 
         # Create a box based on the dimensions above and add a 22mm center hole
-        result = (cq.Workplane("XY").box(length, height, thickness)
-            .faces(">Z").workplane().hole(center_hole_dia))
+        result = (
+            cq.Workplane("XY")
+            .box(length, height, thickness)
+            .faces(">Z")
+            .workplane()
+            .hole(center_hole_dia)
+        )
 
 .. topic:: Api References
 
@@ -117,8 +122,14 @@ closed curve.
 
 .. cadquery::
 
-    result = (cq.Workplane("front").lineTo(2.0, 0).lineTo(2.0, 1.0).threePointArc((1.0, 1.5), (0.0, 1.0))
-        .close().extrude(0.25))
+    result = (
+        cq.Workplane("front")
+        .lineTo(2.0, 0)
+        .lineTo(2.0, 1.0)
+        .threePointArc((1.0, 1.5), (0.0, 1.0))
+        .close()
+        .extrude(0.25)
+    )
 
 
 .. topic:: Api References
@@ -143,7 +154,9 @@ A new work plane center can be established at any point.
 
 .. cadquery::
 
-    result = cq.Workplane("front").circle(3.0)  # current point is the center of the circle, at (0, 0)
+    result = cq.Workplane("front").circle(
+        3.0
+    )  # current point is the center of the circle, at (0, 0)
     result = result.center(1.5, 0.0).rect(0.5, 0.5)  # new work center is (1.5, 0.0)
 
     result = result.center(-1.5, 1.5).circle(0.25)  # new work center is (0.0, 1.5).
@@ -174,10 +187,12 @@ like :py:meth:`Workplane.circle` and :py:meth:`Workplane.rect`, will operate on 
 
 .. cadquery::
 
-   r = cq.Workplane("front").circle(2.0)                           # make base
-   r = r.pushPoints([(1.5, 0), (0, 1.5), (-1.5, 0), (0, -1.5)])    # now four points are on the stack
-   r = r.circle(0.25)                                              # circle will operate on all four points
-   result = r.extrude(0.125)                                       # make prism
+   r = cq.Workplane("front").circle(2.0)  # make base
+   r = r.pushPoints(
+       [(1.5, 0), (0, 1.5), (-1.5, 0), (0, -1.5)]
+   )  # now four points are on the stack
+   r = r.circle(0.25)  # circle will operate on all four points
+   result = r.extrude(0.125)  # make prism
 
 .. topic:: Api References
 
@@ -197,8 +212,13 @@ correct for small hole sizes.
 
 .. cadquery::
 
-    result = (cq.Workplane("front").box(3.0, 4.0, 0.25).pushPoints([(0, 0.75), (0, -0.75)])
-        .polygon(6, 1.0).cutThruAll())
+    result = (
+        cq.Workplane("front")
+        .box(3.0, 4.0, 0.25)
+        .pushPoints([(0, 0.75), (0, -0.75)])
+        .polygon(6, 1.0)
+        .cutThruAll()
+    )
 
 .. topic:: Api References
 
@@ -220,14 +240,14 @@ This example uses a polyline to create one half of an i-beam shape, which is mir
 
     (L, H, W, t) = (100.0, 20.0, 20.0, 1.0)
     pts = [
-        (0, H/2.0),
-        (W/2.0, H/2.0),
-        (W/2.0, (H/2.0 - t)),
-        (t/2.0, (H/2.0 - t)),
-        (t/2.0, (t - H/2.0)),
-        (W/2.0, (t - H/2.0)),
-        (W/2.0, H/-2.0),
-        (0, H/-2.0)
+        (0, H / 2.0),
+        (W / 2.0, H / 2.0),
+        (W / 2.0, (H / 2.0 - t)),
+        (t / 2.0, (H / 2.0 - t)),
+        (t / 2.0, (t - H / 2.0)),
+        (W / 2.0, (t - H / 2.0)),
+        (W / 2.0, H / -2.0),
+        (0, H / -2.0),
     ]
     result = cq.Workplane("front").polyline(pts).mirrorY().extrude(L)
 
@@ -259,7 +279,7 @@ needs a complex profile
         (1.5, 1.0),
         (1.0, 1.25),
         (0.5, 1.0),
-        (0, 1.0)
+        (0, 1.0),
     ]
     r = s.lineTo(3.0, 0).lineTo(3.0, 1.0).spline(sPnts, includeCurrent=True).close()
     result = r.extrude(0.5)
@@ -284,9 +304,11 @@ introduce horizontal and vertical lines, which make for slightly easier coding.
 
 .. cadquery::
 
-   r = cq.Workplane("front").hLine(1.0)                       # 1.0 is the distance, not coordinate
-   r = r.vLine(0.5).hLine(-0.25).vLine(-0.25).hLineTo(0.0)    # hLineTo allows using xCoordinate not distance
-   result = r.mirrorY().extrude(0.25)                         # mirror the geometry and extrude
+   r = cq.Workplane("front").hLine(1.0)  # 1.0 is the distance, not coordinate
+   r = (
+       r.vLine(0.5).hLine(-0.25).vLine(-0.25).hLineTo(0.0)
+   )  # hLineTo allows using xCoordinate not distance
+   result = r.mirrorY().extrude(0.25)  # mirror the geometry and extrude
 
 .. topic:: Api References
 
@@ -306,32 +328,34 @@ Mirroring 3D Objects
 
 .. cadquery::
 
-    result0 = (cadquery.Workplane("XY")
-               .moveTo(10, 0)
-               .lineTo(5, 0)
-               .threePointArc((3.9393, 0.4393), (3.5, 1.5))
-               .threePointArc((3.0607, 2.5607), (2, 3))
-               .lineTo(1.5, 3)
-               .threePointArc((0.4393, 3.4393), (0, 4.5))
-               .lineTo(0, 13.5)
-               .threePointArc((0.4393, 14.5607), (1.5, 15))
-               .lineTo(28, 15)
-               .lineTo(28, 13.5)
-               .lineTo(24, 13.5)
-               .lineTo(24, 11.5)
-               .lineTo(27, 11.5)
-               .lineTo(27, 10)
-               .lineTo(22, 10)
-               .lineTo(22, 13.2)
-               .lineTo(14.5, 13.2)
-               .lineTo(14.5, 10)
-               .lineTo(12.5, 10)
-               .lineTo(12.5, 13.2)
-               .lineTo(5.5, 13.2)
-               .lineTo(5.5, 2)
-               .threePointArc((5.793, 1.293), (6.5, 1))
-               .lineTo(10, 1)
-               .close())
+    result0 = (
+        cadquery.Workplane("XY")
+        .moveTo(10, 0)
+        .lineTo(5, 0)
+        .threePointArc((3.9393, 0.4393), (3.5, 1.5))
+        .threePointArc((3.0607, 2.5607), (2, 3))
+        .lineTo(1.5, 3)
+        .threePointArc((0.4393, 3.4393), (0, 4.5))
+        .lineTo(0, 13.5)
+        .threePointArc((0.4393, 14.5607), (1.5, 15))
+        .lineTo(28, 15)
+        .lineTo(28, 13.5)
+        .lineTo(24, 13.5)
+        .lineTo(24, 11.5)
+        .lineTo(27, 11.5)
+        .lineTo(27, 10)
+        .lineTo(22, 10)
+        .lineTo(22, 13.2)
+        .lineTo(14.5, 13.2)
+        .lineTo(14.5, 10)
+        .lineTo(12.5, 10)
+        .lineTo(12.5, 13.2)
+        .lineTo(5.5, 13.2)
+        .lineTo(5.5, 2)
+        .threePointArc((5.793, 1.293), (6.5, 1))
+        .lineTo(10, 1)
+        .close()
+    )
     result = result0.extrude(100)
 
     result = result.rotate((0, 0, 0), (1, 0, 0), 90)
@@ -367,12 +391,7 @@ This example shows how you can mirror about a selected face. It also shows how t
 
 .. cadquery::
 
-    result = (cq.Workplane("XY")
-              .line(0, 1)
-              .line(1, 0)
-              .line(0, -.5)
-              .close()
-              .extrude(1))
+    result = cq.Workplane("XY").line(0, 1).line(1, 0).line(0, -0.5).close().extrude(1)
 
     result = result.mirror(result.faces(">X"), union=True)
 
@@ -410,7 +429,9 @@ through the centerOption argument of :py:meth:`Workplane.workplane`.
 .. cadquery::
 
     result = cq.Workplane("front").box(2, 3, 0.5)  # make a basic prism
-    result = result.faces(">Z").workplane().hole(0.5)  # find the top-most face and make a hole
+    result = (
+        result.faces(">Z").workplane().hole(0.5)
+    )  # find the top-most face and make a hole
 
 .. topic:: Api References
 
@@ -437,8 +458,10 @@ part, no matter how deep the part is.
 
 .. cadquery::
 
-    result = cq.Workplane("front").box(3,2, 0.5)  # make a basic prism
-    result = result.faces(">Z").vertices("<XY").workplane(centerOption="CenterOfMass")  # select the lower left vertex and make a workplane
+    result = cq.Workplane("front").box(3, 2, 0.5)  # make a basic prism
+    result = (
+        result.faces(">Z").vertices("<XY").workplane(centerOption="CenterOfMass")
+    )  # select the lower left vertex and make a workplane
     result = result.circle(1.0).cutThruAll()  # cut the corner out
 
 .. topic:: Api References
@@ -464,9 +487,11 @@ This example uses an offset workplane to make a compound object, which is perfec
 
 .. cadquery::
 
-    result = cq.Workplane("front").box(3, 2, 0.5)         # make a basic prism
-    result = result.faces("<X").workplane(offset=0.75)    # workplane is offset from the object surface
-    result = result.circle(1.0).extrude(0.5)              # disc
+    result = cq.Workplane("front").box(3, 2, 0.5)  # make a basic prism
+    result = result.faces("<X").workplane(
+        offset=0.75
+    )  # workplane is offset from the object surface
+    result = result.circle(1.0).extrude(0.5)  # disc
 
 .. topic:: Api References
 
@@ -485,13 +510,19 @@ An existing CQ object can copy a workplane from another CQ object.
 
 .. cadquery::
 
-    result = (cq.Workplane("front").circle(1).extrude(10)  # make a cylinder
-              # We want to make a second cylinder perpendicular to the first,
-              # but we have no face to base the workplane off
-              .copyWorkplane(
-                  # create a temporary object with the required workplane
-                  cq.Workplane("right", origin=(-5, 0, 0))
-              ).circle(1).extrude(10))
+    result = (
+        cq.Workplane("front")
+        .circle(1)
+        .extrude(10)  # make a cylinder
+        # We want to make a second cylinder perpendicular to the first,
+        # but we have no face to base the workplane off
+        .copyWorkplane(
+            # create a temporary object with the required workplane
+            cq.Workplane("right", origin=(-5, 0, 0))
+        )
+        .circle(1)
+        .extrude(10)
+    )
 
 .. topic:: API References
 
@@ -510,9 +541,16 @@ You can create a rotated work plane by specifying angles of rotation relative to
 
 .. cadquery::
 
-    result = (cq.Workplane("front").box(4.0, 4.0, 0.25).faces(">Z").workplane()
-         .transformed(offset=cq.Vector(0, -1.5, 1.0),rotate=cq.Vector(60, 0, 0))
-         .rect(1.5, 1.5, forConstruction=True).vertices().hole(0.25))
+    result = (
+        cq.Workplane("front")
+        .box(4.0, 4.0, 0.25)
+        .faces(">Z")
+        .workplane()
+        .transformed(offset=cq.Vector(0, -1.5, 1.0), rotate=cq.Vector(60, 0, 0))
+        .rect(1.5, 1.5, forConstruction=True)
+        .vertices()
+        .hole(0.25)
+    )
 
 .. topic:: Api References
 
@@ -534,8 +572,15 @@ In the example below, a rectangle is drawn, and its vertices are used to locate 
 
 .. cadquery::
 
-    result = (cq.Workplane("front").box(2, 2, 0.5).faces(">Z").workplane()
-        .rect(1.5, 1.5, forConstruction=True).vertices().hole(0.125))
+    result = (
+        cq.Workplane("front")
+        .box(2, 2, 0.5)
+        .faces(">Z")
+        .workplane()
+        .rect(1.5, 1.5, forConstruction=True)
+        .vertices()
+        .hole(0.125)
+    )
 
 .. topic:: Api References
 
@@ -578,12 +623,7 @@ Multiple faces can be removed using more complex selectors.
 
 .. cadquery::
 
-   result = (
-        cq.Workplane("front")
-        .box(2, 2, 2)
-        .faces("+Z or -X or +X")
-        .shell(0.1)
-   )
+   result = cq.Workplane("front").box(2, 2, 2).faces("+Z or -X or +X").shell(0.1)
 
 .. topic:: Api References
 
@@ -604,8 +644,15 @@ and a circular section.
 
 .. cadquery::
 
-    result = (cq.Workplane("front").box(4.0, 4.0, 0.25).faces(">Z").circle(1.5)
-        .workplane(offset=3.0).rect(0.75, 0.5).loft(combine=True))
+    result = (
+        cq.Workplane("front")
+        .box(4.0, 4.0, 0.25)
+        .faces(">Z")
+        .circle(1.5)
+        .workplane(offset=3.0)
+        .rect(0.75, 0.5)
+        .loft(combine=True)
+    )
 
 
 .. topic:: Api References
@@ -630,12 +677,13 @@ or even give a :class:`~cadquery.Face` object for the `until` argument of
 
 .. cadquery::
 
-    result = (cq.Workplane(origin = (20,0,0))
+    result = (
+        cq.Workplane(origin=(20, 0, 0))
         .circle(2)
-        .revolve(180, (-20,0,0),(-20,-1,0))
-        .center(-20,0)
+        .revolve(180, (-20, 0, 0), (-20, -1, 0))
+        .center(-20, 0)
         .workplane()
-        .rect(20,4)
+        .rect(20, 4)
         .extrude("next")
     )
 
@@ -645,67 +693,58 @@ same is true for :meth:`~cadquery.Workplane.extrude`).
 
 .. cadquery::
 
-    skyscrapers_locations = [(-16,1),(-8,0),(7,0.2),(17,-1.2)]
-    angles = iter([15,0,-8,10])
-    skyscrapers = (cq.Workplane()
+    skyscrapers_locations = [(-16, 1), (-8, 0), (7, 0.2), (17, -1.2)]
+    angles = iter([15, 0, -8, 10])
+    skyscrapers = (
+        cq.Workplane()
         .pushPoints(skyscrapers_locations)
-        .eachpoint(lambda loc: (cq.Workplane()
-                                .rect(5,16)
-                                .workplane(offset=10)
-                                .ellipse(3,8)
-                                .workplane(offset=10)
-                                .slot2D(20,5, 90)
-                                .loft()
-                                .rotateAboutCenter((0,0,1),next(angles))
-                                .val().located(loc)
-                                )
-        )    
+        .eachpoint(
+            lambda loc: (
+                cq.Workplane()
+                .rect(5, 16)
+                .workplane(offset=10)
+                .ellipse(3, 8)
+                .workplane(offset=10)
+                .slot2D(20, 5, 90)
+                .loft()
+                .rotateAboutCenter((0, 0, 1), next(angles))
+                .val()
+                .located(loc)
+            )
+        )
     )
 
-    result = (skyscrapers
-        .transformed((0,-90,0))
-        .moveTo(15,0)
-        .rect(3,3, forConstruction=True)
+    result = (
+        skyscrapers.transformed((0, -90, 0))
+        .moveTo(15, 0)
+        .rect(3, 3, forConstruction=True)
         .vertices()
-        .circle(1)    
+        .circle(1)
         .cutBlind("last")
     )
 
 Here is a typical situation where extruding and cuting until a given surface is very handy. It allows us to extrude or cut until a curved surface without overlapping issues.
 
 .. cadquery::
-    
+
     import cadquery as cq
 
     sphere = cq.Workplane().sphere(5)
-    base = (cq.Workplane(origin=(0,0,-2))
-        .box(12,12,10)
-        .cut(sphere)
-        .edges("|Z")
-        .fillet(2)
-    )
+    base = cq.Workplane(origin=(0, 0, -2)).box(12, 12, 10).cut(sphere).edges("|Z").fillet(2)
     sphere_face = base.faces(">>X[2] and (not |Z) and (not |Y)").val()
-    base = (base
-        .faces("<Z")
-        .workplane()
-        .circle(2)
-        .extrude(10)
-    )
+    base = base.faces("<Z").workplane().circle(2).extrude(10)
 
-    shaft = (cq.Workplane()
-        .sphere(4.5)
-        .circle(1.5)
-        .extrude(20)
-    )
+    shaft = cq.Workplane().sphere(4.5).circle(1.5).extrude(20)
 
-    spherical_joint = (base.union(shaft)
+    spherical_joint = (
+        base.union(shaft)
         .faces(">X")
         .workplane(centerOption="CenterOfMass")
-        .move(0,4)
-        .slot2D(10,2,90)
-        .cutBlind(sphere_face)    
+        .move(0, 4)
+        .slot2D(10, 2, 90)
+        .cutBlind(sphere_face)
         .workplane(offset=10)
-        .move(0,2)
+        .move(0, 2)
         .circle(0.9)
         .extrude("next")
     )
@@ -780,13 +819,7 @@ inwards or outwards, and with different techniques for extending the corners.
 .. cadquery::
 
     original = cq.Workplane().polygon(5, 10).extrude(0.1).translate((0, 0, 2))
-    arc = (
-        cq.Workplane()
-        .polygon(5, 10)
-        .offset2D(1, "arc")
-        .extrude(0.1)
-        .translate((0, 0, 1))
-    )
+    arc = cq.Workplane().polygon(5, 10).offset2D(1, "arc").extrude(0.1).translate((0, 0, 1))
     intersection = cq.Workplane().polygon(5, 10).offset2D(1, "intersection").extrude(0.1)
     result = original.add(arc).add(intersection)
 
@@ -862,29 +895,49 @@ The :py:meth:`Workplane.workplaneFromTagged` method applies :py:meth:`Workplane.
 
 .. cadquery::
 
-    result = (cq.Workplane("XY")
-              # create and tag the base workplane
-              .box(10, 10, 10).faces(">Z").workplane().tag("baseplane")
-              # extrude a cylinder
-              .center(-3, 0).circle(1).extrude(3)
-              # to reselect the base workplane, simply
-              .workplaneFromTagged("baseplane")
-              # extrude a second cylinder
-              .center(3, 0).circle(1).extrude(2))
+    result = (
+        cq.Workplane("XY")
+        # create and tag the base workplane
+        .box(10, 10, 10)
+        .faces(">Z")
+        .workplane()
+        .tag("baseplane")
+        # extrude a cylinder
+        .center(-3, 0)
+        .circle(1)
+        .extrude(3)
+        # to reselect the base workplane, simply
+        .workplaneFromTagged("baseplane")
+        # extrude a second cylinder
+        .center(3, 0)
+        .circle(1)
+        .extrude(2)
+    )
 
 
 Tags can also be used with most selectors, including :py:meth:`Workplane.vertices`, :py:meth:`Workplane.faces`, :py:meth:`Workplane.edges`, :py:meth:`Workplane.wires`, :py:meth:`Workplane.shells`, :py:meth:`Workplane.solids` and :py:meth:`Workplane.compounds`.
 
 .. cadquery::
 
-    result = (cq.Workplane("XY")
-              # create a triangular prism and tag it
-              .polygon(3, 5).extrude(4).tag("prism")
-              # create a sphere that obscures the prism
-              .sphere(10)
-              # create features based on the prism's faces
-              .faces("<X", tag="prism").workplane().circle(1).cutThruAll()
-              .faces(">X", tag="prism").faces(">Y").workplane().circle(1).cutThruAll())
+    result = (
+        cq.Workplane("XY")
+        # create a triangular prism and tag it
+        .polygon(3, 5)
+        .extrude(4)
+        .tag("prism")
+        # create a sphere that obscures the prism
+        .sphere(10)
+        # create features based on the prism's faces
+        .faces("<X", tag="prism")
+        .workplane()
+        .circle(1)
+        .cutThruAll()
+        .faces(">X", tag="prism")
+        .faces(">Y")
+        .workplane()
+        .circle(1)
+        .cutThruAll()
+    )
 
 .. topic:: Api References
 
@@ -910,10 +963,18 @@ with just a few lines of code.
 
         (length, height, bearing_diam, thickness, padding) = (30.0, 40.0, 22.0, 10.0, 8.0)
 
-        result = (cq.Workplane("XY").box(length, height, thickness).faces(">Z").workplane().hole(bearing_diam)
-                .faces(">Z").workplane()
-                .rect(length-padding, height-padding, forConstruction=True)
-                .vertices().cboreHole(2.4, 4.4, 2.1))
+        result = (
+            cq.Workplane("XY")
+            .box(length, height, thickness)
+            .faces(">Z")
+            .workplane()
+            .hole(bearing_diam)
+            .faces(">Z")
+            .workplane()
+            .rect(length - padding, height - padding, forConstruction=True)
+            .vertices()
+            .cboreHole(2.4, 4.4, 2.1)
+        )
 
 
 Splitting an Object
@@ -958,9 +1019,14 @@ ones at 13 lines, but that's very short compared to the pythonOCC version, which
     s = cq.Workplane("XY")
 
     # Draw half the profile of the bottle and extrude it
-    p = (s.center(-L/2.0, 0).vLine(w/2.0)
-        .threePointArc((L/2.0, w/2.0 + t), (L, w/2.0)).vLine(-w/2.0)
-        .mirrorX().extrude(30.0, True))
+    p = (
+        s.center(-L / 2.0, 0)
+        .vLine(w / 2.0)
+        .threePointArc((L / 2.0, w / 2.0 + t), (L, w / 2.0))
+        .vLine(-w / 2.0)
+        .mirrorX()
+        .extrude(30.0, True)
+    )
 
     # Make the neck
     p = p.faces(">Z").workplane(centerOption="CenterOfMass").circle(3.0).extrude(2.0, True)
@@ -995,7 +1061,9 @@ A Parametric Enclosure
 
     p_thickness = 3.0  # Thickness of the box walls
     p_sideRadius = 10.0  # Radius for the curves around the sides of the box
-    p_topAndBottomRadius = 2.0  # Radius for the curves on the top and bottom edges of the box
+    p_topAndBottomRadius = (
+        2.0  # Radius for the curves on the top and bottom edges of the box
+    )
 
     p_screwpostInset = 12.0  # How far in from the edges the screw posts should be place.
     p_screwpostID = 4.0  # Inner Diameter of the screw post holes, should be roughly screw diameter not including threads
@@ -1009,7 +1077,11 @@ A Parametric Enclosure
     p_lipHeight = 1.0  # Height of lip on the underside of the lid.\nSits inside the box body for a snug fit.
 
     # outer shell
-    oshell = cq.Workplane("XY").rect(p_outerWidth, p_outerLength).extrude(p_outerHeight + p_lipHeight)
+    oshell = (
+        cq.Workplane("XY")
+        .rect(p_outerWidth, p_outerLength)
+        .extrude(p_outerHeight + p_lipHeight)
+    )
 
     # weird geometry happens if we make the fillets in the wrong order
     if p_sideRadius > p_topAndBottomRadius:
@@ -1020,9 +1092,13 @@ A Parametric Enclosure
         oshell = oshell.edges("|Z").fillet(p_sideRadius)
 
     # inner shell
-    ishell = (oshell.faces("<Z").workplane(p_thickness, True)
-        .rect((p_outerWidth - 2.0*p_thickness), (p_outerLength - 2.0*p_thickness))
-        .extrude((p_outerHeight - 2.0*p_thickness), False)  # set combine false to produce just the new boss
+    ishell = (
+        oshell.faces("<Z")
+        .workplane(p_thickness, True)
+        .rect((p_outerWidth - 2.0 * p_thickness), (p_outerLength - 2.0 * p_thickness))
+        .extrude(
+            (p_outerHeight - 2.0 * p_thickness), False
+        )  # set combine false to produce just the new boss
     )
     ishell = ishell.edges("|Z").fillet(p_sideRadius - p_thickness)
 
@@ -1030,32 +1106,52 @@ A Parametric Enclosure
     box = oshell.cut(ishell)
 
     # make the screw posts
-    POSTWIDTH = (p_outerWidth - 2.0*p_screwpostInset)
-    POSTLENGTH = (p_outerLength - 2.0*p_screwpostInset)
+    POSTWIDTH = p_outerWidth - 2.0 * p_screwpostInset
+    POSTLENGTH = p_outerLength - 2.0 * p_screwpostInset
 
-    box = (box.faces(">Z").workplane(-p_thickness)
+    box = (
+        box.faces(">Z")
+        .workplane(-p_thickness)
         .rect(POSTWIDTH, POSTLENGTH, forConstruction=True)
-        .vertices().circle(p_screwpostOD/2.0).circle(p_screwpostID/2.0)
-        .extrude(-1.0*(p_outerHeight + p_lipHeight - p_thickness),True))
+        .vertices()
+        .circle(p_screwpostOD / 2.0)
+        .circle(p_screwpostID / 2.0)
+        .extrude(-1.0 * (p_outerHeight + p_lipHeight - p_thickness), True)
+    )
 
     # split lid into top and bottom parts
-    (lid, bottom) = box.faces(">Z").workplane(-p_thickness - p_lipHeight).split(keepTop=True, keepBottom=True).all()  # splits into two solids
+    (lid, bottom) = (
+        box.faces(">Z")
+        .workplane(-p_thickness - p_lipHeight)
+        .split(keepTop=True, keepBottom=True)
+        .all()
+    )  # splits into two solids
 
     # translate the lid, and subtract the bottom from it to produce the lid inset
     lowerLid = lid.translate((0, 0, -p_lipHeight))
-    cutlip = lowerLid.cut(bottom).translate((p_outerWidth + p_thickness, 0, p_thickness - p_outerHeight + p_lipHeight))
+    cutlip = lowerLid.cut(bottom).translate(
+        (p_outerWidth + p_thickness, 0, p_thickness - p_outerHeight + p_lipHeight)
+    )
 
     # compute centers for screw holes
-    topOfLidCenters = (cutlip.faces(">Z").workplane(centerOption="CenterOfMass")
-        .rect(POSTWIDTH, POSTLENGTH, forConstruction=True).vertices())
+    topOfLidCenters = (
+        cutlip.faces(">Z")
+        .workplane(centerOption="CenterOfMass")
+        .rect(POSTWIDTH, POSTLENGTH, forConstruction=True)
+        .vertices()
+    )
 
     # add holes of the desired type
     if p_boreDiameter > 0 and p_boreDepth > 0:
-        topOfLid = topOfLidCenters.cboreHole(p_screwpostID, p_boreDiameter, p_boreDepth, 2.0*p_thickness)
+        topOfLid = topOfLidCenters.cboreHole(
+            p_screwpostID, p_boreDiameter, p_boreDepth, 2.0 * p_thickness
+        )
     elif p_countersinkDiameter > 0 and p_countersinkAngle > 0:
-        topOfLid = topOfLidCenters.cskHole(p_screwpostID, p_countersinkDiameter, p_countersinkAngle, 2.0*p_thickness)
+        topOfLid = topOfLidCenters.cskHole(
+            p_screwpostID, p_countersinkDiameter, p_countersinkAngle, 2.0 * p_thickness
+        )
     else:
-        topOfLid = topOfLidCenters.hole(p_screwpostID, 2.0*p_thickness)
+        topOfLid = topOfLidCenters.hole(p_screwpostID, 2.0 * p_thickness)
 
     # flip lid upside down if desired
     if p_flipLid:
@@ -1100,9 +1196,9 @@ regarding the underside of the brick.
     #####
     # Inputs
     ######
-    lbumps = 6     # number of bumps long
-    wbumps = 2     # number of bumps wide
-    thin = True    # True for thin, False for thick
+    lbumps = 6  # number of bumps long
+    wbumps = 2  # number of bumps wide
+    thin = True  # True for thin, False for thick
 
     #
     # Lego Brick Constants-- these make a Lego brick a Lego :)
@@ -1118,8 +1214,8 @@ regarding the underside of the brick.
 
     t = (pitch - (2 * clearance) - bumpDiam) / 2.0
     postDiam = pitch - t  # works out to 6.5
-    total_length = lbumps*pitch - 2.0*clearance
-    total_width = wbumps*pitch - 2.0*clearance
+    total_length = lbumps * pitch - 2.0 * clearance
+    total_width = wbumps * pitch - 2.0 * clearance
 
     # make the base
     s = cq.Workplane("XY").box(total_length, total_width, height)
@@ -1128,23 +1224,37 @@ regarding the underside of the brick.
     s = s.faces("<Z").shell(-1.0 * t)
 
     # make the bumps on the top
-    s = (s.faces(">Z").workplane().
-        rarray(pitch, pitch, lbumps, wbumps, True).circle(bumpDiam / 2.0)
-        .extrude(bumpHeight))
+    s = (
+        s.faces(">Z")
+        .workplane()
+        .rarray(pitch, pitch, lbumps, wbumps, True)
+        .circle(bumpDiam / 2.0)
+        .extrude(bumpHeight)
+    )
 
     # add posts on the bottom. posts are different diameter depending on geometry
     # solid studs for 1 bump, tubes for multiple, none for 1x1
     tmp = s.faces("<Z").workplane(invert=True)
 
     if lbumps > 1 and wbumps > 1:
-        tmp = (tmp.rarray(pitch, pitch, lbumps - 1, wbumps - 1, center=True).
-            circle(postDiam / 2.0).circle(bumpDiam / 2.0).extrude(height - t))
+        tmp = (
+            tmp.rarray(pitch, pitch, lbumps - 1, wbumps - 1, center=True)
+            .circle(postDiam / 2.0)
+            .circle(bumpDiam / 2.0)
+            .extrude(height - t)
+        )
     elif lbumps > 1:
-        tmp = (tmp.rarray(pitch, pitch, lbumps - 1, 1, center=True).
-            circle(t).extrude(height - t))
+        tmp = (
+            tmp.rarray(pitch, pitch, lbumps - 1, 1, center=True)
+            .circle(t)
+            .extrude(height - t)
+        )
     elif wbumps > 1:
-        tmp = (tmp.rarray(pitch, pitch, 1, wbumps - 1, center=True).
-            circle(t).extrude(height - t))
+        tmp = (
+            tmp.rarray(pitch, pitch, 1, wbumps - 1, center=True)
+            .circle(t)
+            .extrude(height - t)
+        )
     else:
         tmp = s
 
@@ -1161,7 +1271,7 @@ Braille Example
     # text_lines is a list of text lines.
     # Braille (converted with braille-converter:
     # https://github.com/jpaugh/braille-converter.git).
-    text_lines = ['⠠ ⠋ ⠗ ⠑ ⠑ ⠠ ⠉ ⠠ ⠁ ⠠ ⠙']
+    text_lines = ["⠠ ⠋ ⠗ ⠑ ⠑ ⠠ ⠉ ⠠ ⠁ ⠠ ⠙"]
     # See http://www.tiresias.org/research/reports/braille_cell.htm for examples
     # of braille cell geometry.
     horizontal_interdot = 2.5
@@ -1174,13 +1284,17 @@ Braille Example
     base_thickness = 1.5
 
     # End of configuration.
-    BrailleCellGeometry = namedtuple('BrailleCellGeometry',
-                                     ('horizontal_interdot',
-                                      'vertical_interdot',
-                                      'intercell',
-                                      'interline',
-                                      'dot_height',
-                                      'dot_diameter'))
+    BrailleCellGeometry = namedtuple(
+        "BrailleCellGeometry",
+        (
+            "horizontal_interdot",
+            "vertical_interdot",
+            "intercell",
+            "interline",
+            "dot_height",
+            "dot_diameter",
+        ),
+    )
 
 
     class Point(object):
@@ -1198,7 +1312,7 @@ Braille Example
             return (self.x, self.y)[index]
 
         def __str__(self):
-            return '({}, {})'.format(self.x, self.y)
+            return "({}, {})".format(self.x, self.y)
 
 
     def brailleToPoints(text, cell_geometry):
@@ -1227,14 +1341,14 @@ Braille Example
         pos = (pos1, pos2, pos3, pos4, pos5, pos6, pos7, pos8)
 
         # Braille blank pattern (u'\u2800').
-        blank = '⠀'
+        blank = "⠀"
         points = []
         # Position of dot1 along the x-axis (horizontal).
         character_origin = 0
         for c in text:
             for m, p in zip(masks, pos):
                 delta_to_blank = ord(c) - ord(blank)
-                if (m & delta_to_blank):
+                if m & delta_to_blank:
                     points.append(p + Point(character_origin, 0))
             character_origin += cell_geometry.intercell
         return points
@@ -1243,18 +1357,22 @@ Braille Example
     def get_plate_height(text_lines, cell_geometry):
         # cell_geometry.vertical_interdot is also used as space between base
         # borders and characters.
-        return (2 * cell_geometry.vertical_interdot +
-                2 * cell_geometry.vertical_interdot +
-                (len(text_lines) - 1) * cell_geometry.interline)
+        return (
+            2 * cell_geometry.vertical_interdot
+            + 2 * cell_geometry.vertical_interdot
+            + (len(text_lines) - 1) * cell_geometry.interline
+        )
 
 
     def get_plate_width(text_lines, cell_geometry):
         # cell_geometry.horizontal_interdot is also used as space between base
         # borders and characters.
         max_len = max([len(t) for t in text_lines])
-        return (2 * cell_geometry.horizontal_interdot +
-                cell_geometry.horizontal_interdot +
-                (max_len - 1) * cell_geometry.intercell)
+        return (
+            2 * cell_geometry.horizontal_interdot
+            + cell_geometry.horizontal_interdot
+            + (max_len - 1) * cell_geometry.intercell
+        )
 
 
     def get_cylinder_radius(cell_geometry):
@@ -1266,22 +1384,23 @@ Braille Example
         """
         h = cell_geometry.dot_height
         r = cell_geometry.dot_diameter / 2
-        return (r ** 2 + h ** 2) / 2 / h
+        return (r**2 + h**2) / 2 / h
 
 
     def get_base_plate_thickness(plate_thickness, cell_geometry):
         """Return the height on which the half spheres will sit"""
-        return (plate_thickness +
-                get_cylinder_radius(cell_geometry) -
-                cell_geometry.dot_height)
+        return (
+            plate_thickness + get_cylinder_radius(cell_geometry) - cell_geometry.dot_height
+        )
 
 
     def make_base(text_lines, cell_geometry, plate_thickness):
         base_width = get_plate_width(text_lines, cell_geometry)
         base_height = get_plate_height(text_lines, cell_geometry)
         base_thickness = get_base_plate_thickness(plate_thickness, cell_geometry)
-        base = cq.Workplane('XY').box(base_width, base_height, base_thickness,
-                                      centered=False)
+        base = cq.Workplane("XY").box(
+            base_width, base_height, base_thickness, centered=False
+        )
         return base
 
 
@@ -1307,16 +1426,22 @@ Braille Example
             line_start_pos += Point(0, -cell_geometry.interline)
 
         r = get_cylinder_radius(cell_geometry)
-        base = (base.faces('>Z').vertices('<XY').workplane()
-            .pushPoints(dot_pos).circle(r)
-            .extrude(r))
+        base = (
+            base.faces(">Z")
+            .vertices("<XY")
+            .workplane()
+            .pushPoints(dot_pos)
+            .circle(r)
+            .extrude(r)
+        )
         # Make a fillet almost the same radius to get a pseudo spherical cap.
-        base = (base.faces('>Z').edges()
-            .fillet(r - 0.001))
-        hidding_box = cq.Workplane('XY').box(
-            base_width, base_height, base_thickness, centered=False)
+        base = base.faces(">Z").edges().fillet(r - 0.001)
+        hidding_box = cq.Workplane("XY").box(
+            base_width, base_height, base_thickness, centered=False
+        )
         result = hidding_box.union(base)
         return result
+
 
     _cell_geometry = BrailleCellGeometry(
         horizontal_interdot,
@@ -1324,10 +1449,11 @@ Braille Example
         horizontal_intercell,
         vertical_interline,
         dot_height,
-        dot_diameter)
+        dot_diameter,
+    )
 
     if base_thickness < get_cylinder_radius(_cell_geometry):
-        raise ValueError('Base thickness should be at least {}'.format(dot_height))
+        raise ValueError("Base thickness should be at least {}".format(dot_height))
 
     result = make_embossed_plate(text_lines, _cell_geometry)
 
@@ -1348,35 +1474,188 @@ Panel With Various Connector Holes
 
     h_sep = 60
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(157, 210 - idx*h_sep).moveTo(-23.5, 0).circle(1.6).moveTo(23.5, 0).circle(1.6).moveTo(-17.038896, -5.7).threePointArc((-19.44306, -4.70416), (-20.438896, -2.3)).lineTo(-21.25, 2.3).threePointArc((-20.25416, 4.70416), (-17.85, 5.7)).lineTo(17.85, 5.7).threePointArc((20.25416, 4.70416), (21.25, 2.3)).lineTo(20.438896, -2.3).threePointArc((19.44306, -4.70416), (17.038896, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(157, 210 - idx * h_sep)
+            .moveTo(-23.5, 0)
+            .circle(1.6)
+            .moveTo(23.5, 0)
+            .circle(1.6)
+            .moveTo(-17.038896, -5.7)
+            .threePointArc((-19.44306, -4.70416), (-20.438896, -2.3))
+            .lineTo(-21.25, 2.3)
+            .threePointArc((-20.25416, 4.70416), (-17.85, 5.7))
+            .lineTo(17.85, 5.7)
+            .threePointArc((20.25416, 4.70416), (21.25, 2.3))
+            .lineTo(20.438896, -2.3)
+            .threePointArc((19.44306, -4.70416), (17.038896, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(157, -30 - idx*h_sep).moveTo(-16.65, 0).circle(1.6).moveTo(16.65, 0).circle(1.6).moveTo(-10.1889, -5.7).threePointArc((-12.59306, -4.70416), (-13.5889, -2.3)).lineTo(-14.4, 2.3).threePointArc((-13.40416, 4.70416), (-11, 5.7)).lineTo(11, 5.7).threePointArc((13.40416, 4.70416), (14.4, 2.3)).lineTo(13.5889, -2.3).threePointArc((12.59306, -4.70416), (10.1889, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(157, -30 - idx * h_sep)
+            .moveTo(-16.65, 0)
+            .circle(1.6)
+            .moveTo(16.65, 0)
+            .circle(1.6)
+            .moveTo(-10.1889, -5.7)
+            .threePointArc((-12.59306, -4.70416), (-13.5889, -2.3))
+            .lineTo(-14.4, 2.3)
+            .threePointArc((-13.40416, 4.70416), (-11, 5.7))
+            .lineTo(11, 5.7)
+            .threePointArc((13.40416, 4.70416), (14.4, 2.3))
+            .lineTo(13.5889, -2.3)
+            .threePointArc((12.59306, -4.70416), (10.1889, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     h_sep4DB9 = 30
     for idx in range(8):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(91, 225 - idx*h_sep4DB9).moveTo(-12.5, 0).circle(1.6).moveTo(12.5, 0).circle(1.6).moveTo(-6.038896, -5.7).threePointArc((-8.44306, -4.70416), (-9.438896, -2.3)).lineTo(-10.25, 2.3).threePointArc((-9.25416, 4.70416), (-6.85, 5.7)).lineTo(6.85, 5.7).threePointArc((9.25416, 4.70416), (10.25, 2.3)).lineTo(9.438896, -2.3).threePointArc((8.44306, -4.70416), (6.038896, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(91, 225 - idx * h_sep4DB9)
+            .moveTo(-12.5, 0)
+            .circle(1.6)
+            .moveTo(12.5, 0)
+            .circle(1.6)
+            .moveTo(-6.038896, -5.7)
+            .threePointArc((-8.44306, -4.70416), (-9.438896, -2.3))
+            .lineTo(-10.25, 2.3)
+            .threePointArc((-9.25416, 4.70416), (-6.85, 5.7))
+            .lineTo(6.85, 5.7)
+            .threePointArc((9.25416, 4.70416), (10.25, 2.3))
+            .lineTo(9.438896, -2.3)
+            .threePointArc((8.44306, -4.70416), (6.038896, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(25, 210 - idx*h_sep).moveTo(-23.5, 0).circle(1.6).moveTo(23.5, 0).circle(1.6).moveTo(-17.038896, -5.7).threePointArc((-19.44306, -4.70416), (-20.438896, -2.3)).lineTo(-21.25, 2.3).threePointArc((-20.25416, 4.70416), (-17.85, 5.7)).lineTo(17.85, 5.7).threePointArc((20.25416, 4.70416), (21.25, 2.3)).lineTo(20.438896, -2.3).threePointArc((19.44306, -4.70416), (17.038896, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(25, 210 - idx * h_sep)
+            .moveTo(-23.5, 0)
+            .circle(1.6)
+            .moveTo(23.5, 0)
+            .circle(1.6)
+            .moveTo(-17.038896, -5.7)
+            .threePointArc((-19.44306, -4.70416), (-20.438896, -2.3))
+            .lineTo(-21.25, 2.3)
+            .threePointArc((-20.25416, 4.70416), (-17.85, 5.7))
+            .lineTo(17.85, 5.7)
+            .threePointArc((20.25416, 4.70416), (21.25, 2.3))
+            .lineTo(20.438896, -2.3)
+            .threePointArc((19.44306, -4.70416), (17.038896, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(25, -30 - idx*h_sep).moveTo(-16.65, 0).circle(1.6).moveTo(16.65, 0).circle(1.6).moveTo(-10.1889, -5.7).threePointArc((-12.59306, -4.70416), (-13.5889, -2.3)).lineTo(-14.4, 2.3).threePointArc((-13.40416, 4.70416), (-11, 5.7)).lineTo(11, 5.7).threePointArc((13.40416, 4.70416), (14.4, 2.3)).lineTo(13.5889, -2.3).threePointArc((12.59306, -4.70416), (10.1889, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(25, -30 - idx * h_sep)
+            .moveTo(-16.65, 0)
+            .circle(1.6)
+            .moveTo(16.65, 0)
+            .circle(1.6)
+            .moveTo(-10.1889, -5.7)
+            .threePointArc((-12.59306, -4.70416), (-13.5889, -2.3))
+            .lineTo(-14.4, 2.3)
+            .threePointArc((-13.40416, 4.70416), (-11, 5.7))
+            .lineTo(11, 5.7)
+            .threePointArc((13.40416, 4.70416), (14.4, 2.3))
+            .lineTo(13.5889, -2.3)
+            .threePointArc((12.59306, -4.70416), (10.1889, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(8):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(-41, 225 - idx*h_sep4DB9).moveTo(-12.5, 0).circle(1.6).moveTo(12.5, 0).circle(1.6).moveTo(-6.038896, -5.7).threePointArc((-8.44306, -4.70416), (-9.438896, -2.3)).lineTo(-10.25, 2.3).threePointArc((-9.25416, 4.70416), (-6.85, 5.7)).lineTo(6.85, 5.7).threePointArc((9.25416, 4.70416), (10.25, 2.3)).lineTo(9.438896, -2.3).threePointArc((8.44306, -4.70416), (6.038896, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(-41, 225 - idx * h_sep4DB9)
+            .moveTo(-12.5, 0)
+            .circle(1.6)
+            .moveTo(12.5, 0)
+            .circle(1.6)
+            .moveTo(-6.038896, -5.7)
+            .threePointArc((-8.44306, -4.70416), (-9.438896, -2.3))
+            .lineTo(-10.25, 2.3)
+            .threePointArc((-9.25416, 4.70416), (-6.85, 5.7))
+            .lineTo(6.85, 5.7)
+            .threePointArc((9.25416, 4.70416), (10.25, 2.3))
+            .lineTo(9.438896, -2.3)
+            .threePointArc((8.44306, -4.70416), (6.038896, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(-107, 210 - idx*h_sep).moveTo(-23.5, 0).circle(1.6).moveTo(23.5, 0).circle(1.6).moveTo(-17.038896, -5.7).threePointArc((-19.44306, -4.70416), (-20.438896, -2.3)).lineTo(-21.25, 2.3).threePointArc((-20.25416, 4.70416), (-17.85, 5.7)).lineTo(17.85, 5.7).threePointArc((20.25416, 4.70416), (21.25, 2.3)).lineTo(20.438896, -2.3).threePointArc((19.44306, -4.70416), (17.038896, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(-107, 210 - idx * h_sep)
+            .moveTo(-23.5, 0)
+            .circle(1.6)
+            .moveTo(23.5, 0)
+            .circle(1.6)
+            .moveTo(-17.038896, -5.7)
+            .threePointArc((-19.44306, -4.70416), (-20.438896, -2.3))
+            .lineTo(-21.25, 2.3)
+            .threePointArc((-20.25416, 4.70416), (-17.85, 5.7))
+            .lineTo(17.85, 5.7)
+            .threePointArc((20.25416, 4.70416), (21.25, 2.3))
+            .lineTo(20.438896, -2.3)
+            .threePointArc((19.44306, -4.70416), (17.038896, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(-107, -30 - idx*h_sep).circle(14).rect(24.7487, 24.7487,  forConstruction=True).vertices().hole(3.2).cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(-107, -30 - idx * h_sep)
+            .circle(14)
+            .rect(24.7487, 24.7487, forConstruction=True)
+            .vertices()
+            .hole(3.2)
+            .cutThruAll()
+        )
 
     for idx in range(8):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(-173, 225 - idx*h_sep4DB9).moveTo(-12.5, 0).circle(1.6).moveTo(12.5, 0).circle(1.6).moveTo(-6.038896, -5.7).threePointArc((-8.44306, -4.70416), (-9.438896, -2.3)).lineTo(-10.25, 2.3).threePointArc((-9.25416, 4.70416), (-6.85, 5.7)).lineTo(6.85, 5.7).threePointArc((9.25416, 4.70416), (10.25, 2.3)).lineTo(9.438896, -2.3).threePointArc((8.44306, -4.70416), (6.038896, -5.7)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(-173, 225 - idx * h_sep4DB9)
+            .moveTo(-12.5, 0)
+            .circle(1.6)
+            .moveTo(12.5, 0)
+            .circle(1.6)
+            .moveTo(-6.038896, -5.7)
+            .threePointArc((-8.44306, -4.70416), (-9.438896, -2.3))
+            .lineTo(-10.25, 2.3)
+            .threePointArc((-9.25416, 4.70416), (-6.85, 5.7))
+            .lineTo(6.85, 5.7)
+            .threePointArc((9.25416, 4.70416), (10.25, 2.3))
+            .lineTo(9.438896, -2.3)
+            .threePointArc((8.44306, -4.70416), (6.038896, -5.7))
+            .close()
+            .cutThruAll()
+        )
 
     for idx in range(4):
-        result = result.workplane(offset=1, centerOption="CenterOfBoundBox").center(-173, -30 - idx*h_sep).moveTo(-2.9176, -5.3).threePointArc((-6.05, 0), (-2.9176, 5.3)).lineTo(2.9176, 5.3).threePointArc((6.05, 0), (2.9176, -5.3)).close().cutThruAll()
+        result = (
+            result.workplane(offset=1, centerOption="CenterOfBoundBox")
+            .center(-173, -30 - idx * h_sep)
+            .moveTo(-2.9176, -5.3)
+            .threePointArc((-6.05, 0), (-2.9176, 5.3))
+            .lineTo(2.9176, 5.3)
+            .threePointArc((6.05, 0), (2.9176, -5.3))
+            .close()
+            .cutThruAll()
+        )
 
 
 Cycloidal gear
@@ -1391,19 +1670,36 @@ This specific examples generates a helical cycloidal gear.
     import cadquery as cq
     from math import sin, cos, pi, floor
 
+
     # define the generating function
     def hypocycloid(t, r1, r2):
-        return ((r1-r2)*cos(t)+r2*cos(r1/r2*t-t), (r1-r2)*sin(t)+r2*sin(-(r1/r2*t-t)))
+        return (
+            (r1 - r2) * cos(t) + r2 * cos(r1 / r2 * t - t),
+            (r1 - r2) * sin(t) + r2 * sin(-(r1 / r2 * t - t)),
+        )
+
 
     def epicycloid(t, r1, r2):
-        return ((r1+r2)*cos(t)-r2*cos(r1/r2*t+t), (r1+r2)*sin(t)-r2*sin(r1/r2*t+t))
+        return (
+            (r1 + r2) * cos(t) - r2 * cos(r1 / r2 * t + t),
+            (r1 + r2) * sin(t) - r2 * sin(r1 / r2 * t + t),
+        )
+
 
     def gear(t, r1=4, r2=1):
-        if (-1)**(1+floor(t/2/pi*(r1/r2))) < 0:
+        if (-1) ** (1 + floor(t / 2 / pi * (r1 / r2))) < 0:
             return epicycloid(t, r1, r2)
         else:
             return hypocycloid(t, r1, r2)
 
+
     # create the gear profile and extrude it
-    result = (cq.Workplane('XY').parametricCurve(lambda t: gear(t*2*pi, 6, 1))
-        .twistExtrude(15, 90).faces('>Z').workplane().circle(2).cutThruAll())
+    result = (
+        cq.Workplane("XY")
+        .parametricCurve(lambda t: gear(t * 2 * pi, 6, 1))
+        .twistExtrude(15, 90)
+        .faces(">Z")
+        .workplane()
+        .circle(2)
+        .cutThruAll()
+    )

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -18,17 +18,25 @@ Using OpenCascade methods
 The easiest way to extend CadQuery is to simply use OpenCascade/OCP scripting inside of your build method.  Just about
 any valid OCP script will execute just fine. For example, this simple CadQuery script::
 
-    return cq.Workplane("XY").box(1.0,2.0,3.0).val()
+    return cq.Workplane("XY").box(1.0, 2.0, 3.0).val()
 
 is actually equivalent to::
 
-    return cq.Shape.cast(BRepPrimAPI_MakeBox(gp_Ax2(Vector(-0.1, -1.0, -1.5), Vector(0, 0, 1)), 1.0, 2.0, 3.0).Shape())
+    return cq.Shape.cast(
+        BRepPrimAPI_MakeBox(
+            gp_Ax2(Vector(-0.1, -1.0, -1.5), Vector(0, 0, 1)), 1.0, 2.0, 3.0
+        ).Shape()
+    )
 
 As long as you return a valid OCP Shape, you can use any OCP methods you like. You can even mix and match the
 two. For example, consider this script, which creates a OCP box, but then uses CadQuery to select its faces::
 
-    box = cq.Shape.cast(BRepPrimAPI_MakeBox(gp_Ax2(Vector(-0.1, -1.0, -1.5), Vector(0, 0, 1)), 1.0, 2.0, 3.0).Shape())
-    cq = Workplane(box).faces(">Z").size() # returns 6
+    box = cq.Shape.cast(
+        BRepPrimAPI_MakeBox(
+            gp_Ax2(Vector(-0.1, -1.0, -1.5), Vector(0, 0, 1)), 1.0, 2.0, 3.0
+        ).Shape()
+    )
+    cq = Workplane(box).faces(">Z").size()  # returns 6
 
 
 Extending CadQuery: Plugins
@@ -130,9 +138,10 @@ You can also accept other arguments.
 
 To install it, simply attach it to the CadQuery or Workplane object, like this::
 
-    def _yourFunction(self,arg1,arg):
+    def _yourFunction(self, arg1, arg):
         # do stuff
         return whatever_you_want
+
 
     cq.Workplane.yourPlugin = _yourFunction
 
@@ -156,24 +165,31 @@ This ultra simple plugin makes cubes of the specified size for each stack point.
 
 .. code-block:: python
 
-        def makeCubes(self,length):
-            #self refers to the CQ or Workplane object
+        def makeCubes(self, length):
+            # self refers to the CQ or Workplane object
 
-            #inner method that creates a cube
+            # inner method that creates a cube
             def _singleCube(loc):
-                #loc is a location in local coordinates
-                #since we're using eachpoint with useLocalCoordinates=True
-                return cq.Solid.makeBox(length,length,length,pnt).locate(loc)
+                # loc is a location in local coordinates
+                # since we're using eachpoint with useLocalCoordinates=True
+                return cq.Solid.makeBox(length, length, length, pnt).locate(loc)
 
-            #use CQ utility method to iterate over the stack, call our
-            #method, and convert to/from local coordinates.
-            return self.eachpoint(_singleCube,True)
+            # use CQ utility method to iterate over the stack, call our
+            # method, and convert to/from local coordinates.
+            return self.eachpoint(_singleCube, True)
 
-        #link the plugin into CadQuery
+
+        # link the plugin into CadQuery
         cq.Workplane.makeCubes = makeCubes
 
-        #use the plugin
-        result = cq.Workplane("XY").box(6.0,8.0,0.5).faces(">Z")\
-            .rect(4.0,4.0,forConstruction=True).vertices() \
-            .makeCubes(1.0).combineSolids()
+        # use the plugin
+        result = (
+            cq.Workplane("XY")
+            .box(6.0, 8.0, 0.5)
+            .faces(">Z")
+            .rect(4.0, 4.0, forConstruction=True)
+            .vertices()
+            .makeCubes(1.0)
+            .combineSolids()
+        )
 

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -131,7 +131,7 @@ You can also accept other arguments.
 To install it, simply attach it to the CadQuery or Workplane object, like this::
 
     def _yourFunction(self,arg1,arg):
-        do stuff
+        # do stuff
         return whatever_you_want
 
     cq.Workplane.yourPlugin = _yourFunction

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -75,7 +75,7 @@ There are no parameters for this method other than the file path to import.
 
     import cadquery as cq
 
-    result = cq.importers.importStep('/path/to/step/block.stp')
+    result = cq.importers.importStep("/path/to/step/block.stp")
 
 Exporting STEP
 ###############
@@ -157,7 +157,7 @@ export with all defaults is shown below.
     assy.add(pin, color=cq.Color(0, 1, 0), name="pin")
 
     # Save the assembly to STEP
-    assy.save('out.step')
+    assy.save("out.step")
 
 This will produce a STEP file that is nested with auto-generated object names. The colors of each assembly object will be
 preserved, but the names that were set for each will not.
@@ -195,7 +195,11 @@ This is done by setting the name property of the assembly before calling :meth:`
 .. code-block:: python
 
     assy = Assembly(name="my_assembly")
-    assy.save("out.stp", cq.exporters.ExportTypes.STEP, mode=cq.exporters.assembly.ExportModes.FUSED)
+    assy.save(
+        "out.stp",
+        cq.exporters.ExportTypes.STEP,
+        mode=cq.exporters.assembly.ExportModes.FUSED,
+    )
 
 If an assembly name is not specified, a UUID will be used to avoid name conflicts.
 
@@ -229,7 +233,7 @@ Without options:
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/box.svg')
+    exporters.export(result, "/path/to/file/box.svg")
 
 Results in:
 
@@ -248,21 +252,21 @@ The following is an example of using options to alter the resulting SVG output b
     result = cq.Workplane().box(10, 10, 10)
 
     exporters.export(
-                result,
-                '/path/to/file/box_custom_options.svg',
-                opt={
-                    "width": 300,
-                    "height": 300,
-                    "marginLeft": 10,
-                    "marginTop": 10,
-                    "showAxes": False,
-                    "projectionDir": (0.5, 0.5, 0.5),
-                    "strokeWidth": 0.25,
-                    "strokeColor": (255, 0, 0),
-                    "hiddenColor": (0, 0, 255),
-                    "showHidden": True,
-                },
-            )
+        result,
+        "/path/to/file/box_custom_options.svg",
+        opt={
+            "width": 300,
+            "height": 300,
+            "marginLeft": 10,
+            "marginTop": 10,
+            "showAxes": False,
+            "projectionDir": (0.5, 0.5, 0.5),
+            "strokeWidth": 0.25,
+            "strokeColor": (255, 0, 0),
+            "hiddenColor": (0, 0, 255),
+            "showHidden": True,
+        },
+    )
 
 Which results in the following image:
 
@@ -290,7 +294,7 @@ optimum values that will produce an acceptable mesh.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/mesh.stl')
+    exporters.export(result, "/path/to/file/mesh.stl")
 
 Exporting AMF and 3MF
 ######################
@@ -311,7 +315,7 @@ optimum values that will produce an acceptable mesh. Note that parameters for co
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/mesh.amf', tolerance=0.01, angularTolerance=0.1)
+    exporters.export(result, "/path/to/file/mesh.amf", tolerance=0.01, angularTolerance=0.1)
 
 
 Exporting TJS
@@ -333,7 +337,13 @@ optimum values that will produce an acceptable mesh.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/mesh.json', tolerance=0.01, angularTolerance=0.1, exportType=exporters.ExportTypes.TJS)
+    exporters.export(
+        result,
+        "/path/to/file/mesh.json",
+        tolerance=0.01,
+        angularTolerance=0.1,
+        exportType=exporters.ExportTypes.TJS,
+    )
 
 Note that the export type was explicitly specified as ``TJS`` because the extension that was used for the file name was ``.json``. If the extension ``.tjs`` 
 had been used, CadQuery would have understood to use the ``TJS`` export format.
@@ -357,7 +367,9 @@ optimum values that will produce an acceptable mesh.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/mesh.vrml', tolerance=0.01, angularTolerance=0.1)
+    exporters.export(
+        result, "/path/to/file/mesh.vrml", tolerance=0.01, angularTolerance=0.1
+    )
 
 Exporting DXF
 ##############
@@ -427,7 +439,9 @@ Document units can be set to any :doc:`unit supported by ezdxf <ezdxf-stable:con
     result = cq.Workplane().box(10, 10, 10)
 
     exporters.exportDXF(
-        result, "/path/to/file/object.dxf", doc_units=6,  # set DXF document units to meters
+        result,
+        "/path/to/file/object.dxf",
+        doc_units=6,  # set DXF document units to meters
     )
 
     # or
@@ -452,11 +466,7 @@ By default, the DXF exporter will output splines exactly as they are represented
 .. code-block:: python
     :caption: DXF document with curves approximated with cubic splines.
 
-    cq.exporters.exportDXF(
-        result,
-        "/path/to/file/object.dxf",
-        approx="spline"
-    )
+    cq.exporters.exportDXF(result, "/path/to/file/object.dxf", approx="spline")
 
 
 Exporting Other Formats
@@ -472,7 +482,7 @@ using the following structure.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/object.[file_extension]')
+    exporters.export(result, "/path/to/file/object.[file_extension]")
 
 Be sure to use the correct file extension so that CadQuery can determine the export format. If in doubt, fall 
 back to setting the type explicitly by using :py:class:`exporters.ExportTypes`.
@@ -486,4 +496,4 @@ For example:
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, '/path/to/file/object.dxf', exporters.ExportTypes.DXF)
+    exporters.export(result, "/path/to/file/object.dxf", exporters.ExportTypes.DXF)

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,7 +20,9 @@ Install the Conda Package Manager
 
 In principle, any Conda distribution will work, but it is probably best to install `Miniforge <https://github.com/conda-forge/miniforge>`_ to a local directory and to avoid running `conda init`. After performing a local directory installation, Miniforge can be activated via the [scripts,bin]/activate scripts. This will help avoid polluting and breaking the local Python installation.
 
-In Linux/MacOS, the local directory installation method looks something like this::
+In Linux/MacOS, the local directory installation method looks something like this:
+
+.. code-block::
 
     # Install the script to ~/miniforge
     wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh
@@ -30,7 +32,9 @@ In Linux/MacOS, the local directory installation method looks something like thi
     source $HOME/miniforge/bin/activate
 
 
-On Windows, download the installer and double click it on the file browser or install non-interactively as follows::
+On Windows, download the installer and double click it on the file browser or install non-interactively as follows:
+
+.. code-block::
 
     :: Install
     curl -L -o miniforge.exe https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe
@@ -49,19 +53,25 @@ Note that miniforge automatically sets *conda-forge* as the default channel.  ``
 conda
 `````
 
-Install the latest released version of cadquery [#f1]_::
+Install the latest released version of cadquery [#f1]_:
+
+.. code-block::
 
     conda create -n cqrel
     conda activate cqrel
     conda install -c conda-forge cadquery occt=7.7.0
 
-or install a given version of cadquery [#f1]_::
+or install a given version of cadquery [#f1]_:
+
+.. code-block::
 
     conda create -n cq22
     conda activate cq22
     conda install -c conda-forge cadquery=2.2.0 occt=7.7.0
 
-or install the latest dev version::
+or install the latest dev version:
+
+.. code-block::
 
     conda create -n cqdev
     conda activate cqdev
@@ -73,25 +83,35 @@ Install via pip
 
 CadQuery has a complex set of dependencies including OCP, which is our set of bindings to the OpenCASCADE CAD kernel. OCP is distributed as binary wheels for Linux, MacOS and Windows. However, there are some limitations. Only Python 3.8 through 3.10 are currently supported, and some older Linux distributions such as Ubuntu 18.04 are not supported. If the pip installation method does not work for your system, you can try the conda installation method.
 
-It is highly recommended that a virtual environment is used when installing CadQuery, although it is not strictly required. Installing CadQuery via pip requires an up-to-date version of pip, which can be obtained with the following command line (or a slight variation thereof).::
+It is highly recommended that a virtual environment is used when installing CadQuery, although it is not strictly required. Installing CadQuery via pip requires an up-to-date version of pip, which can be obtained with the following command line (or a slight variation thereof).:
+
+.. code-block::
 
     python3 -m pip install --upgrade pip
 
-Once a current version of pip is installed, CadQuery can be installed using the following command line.::
+Once a current version of pip is installed, CadQuery can be installed using the following command line.:
+
+.. code-block::
 
     pip install cadquery
 
-It is also possible to install the very latest changes directly from CadQuery's GitHub repository, with the understanding that sometimes breaking changes can occur. To install from the git repository, run the following command line.::
+It is also possible to install the very latest changes directly from CadQuery's GitHub repository, with the understanding that sometimes breaking changes can occur. To install from the git repository, run the following command line.:
+
+.. code-block::
 
     pip install git+https://github.com/CadQuery/cadquery.git
 
 You should now have a working CadQuery installation, but developers or users who want to use CadQuery with IPython/Jupyter or to set up a developer environment can read the rest of this section.
 
-If you are installing CadQuery to use with IPython/Jupyter, you may want to run the following command line to install the extra dependencies.::
+If you are installing CadQuery to use with IPython/Jupyter, you may want to run the following command line to install the extra dependencies.:
+
+.. code-block::
 
     pip install cadquery[ipython]
 
-If you want to create a developer setup to contribute to CadQuery, the following command line will install all the development dependencies that are needed.::
+If you want to create a developer setup to contribute to CadQuery, the following command line will install all the development dependencies that are needed.:
+
+.. code-block::
 
     pip install cadquery[dev]
 
@@ -123,13 +143,17 @@ Linux/MacOS
 4. Launch the **run.sh** script from the file brower (again make executable first and then run as program).
 
 
-To install from command line, download the installer using curl or wget or your favorite program and run the script.::
+To install from command line, download the installer using curl or wget or your favorite program and run the script.:
+
+.. code-block::
 
     curl -LO https://github.com/CadQuery/CQ-editor/releases/download/nightly/CQ-editor-master-Linux-x86_64.sh
     sh CQ-editor-master-Linux-x86_64.sh
 
 
-To run from command.::
+To run from command.:
+
+.. code-block::
 
     $HOME/cq-editor/run.sh
 
@@ -146,7 +170,9 @@ Windows
 2. Launch the **run.bat** script from the file brower (select **Open**).
 
 
-To run from command line, activate the environment, then run cq-editor::
+To run from command line, activate the environment, then run cq-editor:
+
+.. code-block::
 
     C:\Users\<username>\cq-editor\run.bat
 
@@ -158,12 +184,16 @@ Installing extra packages
 
 First activate the environment, then call mamba or pip to install additional packages.
 
-On windows.::
+On windows.:
+
+.. code-block::
 
     C:\Users\<username>\cq-editor\Scripts\activate
     mamba install <packagename>
 
-On Linux/MacOS. ::
+On Linux/MacOS.:
+
+.. code-block::
 
     source $HOME/cq-editor/bin/activate
     mamba install <packagename>
@@ -174,14 +204,18 @@ Adding CQ-editor to an Existing Environment
 
 You can install CQ-editor into a conda environment or Python virtual environment using conda (mamba) or pip.
 
-Example cq-editor installation with conda (this installs both cadquery and cq-editor)::
+Example cq-editor installation with conda (this installs both cadquery and cq-editor):
+
+.. code-block::
 
     conda create -n cqdev
     conda activate cqdev
     conda install -c cadquery -c conda-forge cq-editor=master
 
 
-Example cq-editor installation with pip::
+Example cq-editor installation with pip:
+
+.. code-block::
 
     pip install PyQt5 spyder pyqtgraph logbook
     pip install git+https://github.com/CadQuery/CQ-editor.git
@@ -208,14 +242,18 @@ pip
        pip install jupyterlab
 
 
-Start JupyterLab::
+Start JupyterLab:
+
+.. code-block::
 
     jupyter lab
 
 
 JupyterLab will open automatically in your browser.  Create a Notebook to interactively edit/view CadQuery models.
 
-Call ``display`` to show the model.::
+Call ``display`` to show the model.:
+
+.. code-block::
 
     display(<Workplane, Shape, or Assembly object>)
 
@@ -226,7 +264,9 @@ Call ``display`` to show the model.::
 Test Your Installation
 ------------------------
 
-If all has gone well, you can open a command line/prompt, and type::
+If all has gone well, you can open a command line/prompt, and type:
+
+.. code-block::
 
       $ python
       $ import cadquery

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -26,20 +26,28 @@ Using CadQuery, you can build fully parametric models with a very small amount o
 produces a flat plate with a hole in the middle::
 
     thickness = 0.5
-    width=2.0
-    result = Workplane("front").box(width,width,thickness).faces(">Z").hole(thickness)
+    width = 2.0
+    result = Workplane("front").box(width, width, thickness).faces(">Z").hole(thickness)
 
 ..  image:: _static/simpleblock.png
 
 That's a bit of a dixie-cup example. But it is pretty similar to a more useful part: a parametric pillow block for a
 standard 608-size ball bearing::
 
-    (length,height,diam, thickness,padding) = ( 30.0,40.0,22.0,10.0,8.0)
+    (length, height, diam, thickness, padding) = (30.0, 40.0, 22.0, 10.0, 8.0)
 
-    result = Workplane("XY").box(length,height,thickness).faces(">Z").workplane().hole(diam)\
-            .faces(">Z").workplane() \
-            .rect(length-padding,height-padding,forConstruction=True) \
-            .vertices().cboreHole(2.4,4.4,2.1)
+    result = (
+        Workplane("XY")
+        .box(length, height, thickness)
+        .faces(">Z")
+        .workplane()
+        .hole(diam)
+        .faces(">Z")
+        .workplane()
+        .rect(length - padding, height - padding, forConstruction=True)
+        .vertices()
+        .cboreHole(2.4, 4.4, 2.1)
+    )
 
 ..  image:: _static/pillowblock.png
 

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -288,27 +288,31 @@ Fluent API <=> Direct API
 
 Here are all the possibilities you have to get an object from the Direct API (i.e a topological object).
 
-You can end the Fluent API call chain and get the last object on the stack with :py:meth:`Workplane.val` alternatively you can get all 
-the objects with :py:meth:`Workplane.vals` ::
+You can end the Fluent API call chain and get the last object on the stack with :py:meth:`Workplane.val` alternatively you can get all
+the objects with :py:meth:`Workplane.vals`
 
-  box = Workplane().box(10,5,5)
-  print(type(box))
-  >>> <class cadquery.cq.Workplane>
+.. code-block:: pycon
 
-  box = Workplane().box(10,5,5).val()
-  print(type(box))
-  >>> <class cadquery.occ_impl.shapes.Solid> 
+    >>> box = Workplane().box(10, 5, 5)
+    >>> print(type(box))
+    <class cadquery.cq.Workplane>
 
-If you are only interested in getting the context solid of your Workplane, you can use :py:meth:`Workplane.findSolid`::
+    >>> box = Workplane().box(10, 5, 5).val()
+    >>> print(type(box))
+    <class cadquery.occ_impl.shapes.Solid>
 
-  part = Workplane().box(10,5,5).circle(3).val()
-  print(type(part))
-  >>> <class cadquery.cq.Wire>
+If you are only interested in getting the context solid of your Workplane, you can use :py:meth:`Workplane.findSolid`:
 
-  part = Workplane().box(10,5,5).circle(3).findSolid()
-  print(type(part))
-  >>> <class cadquery.occ_impl.shapes.Compound> 
-  # The return type of findSolid is either a Solid or a Compound object 
+.. code-block::
+
+    >>> part = Workplane().box(10,5,5).circle(3).val()
+    >>> print(type(part))
+    <class cadquery.cq.Wire>
+
+    >>> part = Workplane().box(10,5,5).circle(3).findSolid()
+    >>> print(type(part))
+    <class cadquery.occ_impl.shapes.Compound>
+    # The return type of findSolid is either a Solid or a Compound object
 
 If you want to go the other way around i.e using objects from the topological API in the Fluent API here are your options :
 
@@ -331,26 +335,30 @@ You can add a topological object as a new operation/step in the Fluent API call 
 Direct API <=> OCCT API
 -------------------------
 
-Every object of the Direct API stores its OCCT equivalent object in its :attr:`wrapped` attribute. ::
+Every object of the Direct API stores its OCCT equivalent object in its :attr:`wrapped` attribute.:
 
-  box = Solid.makeBox(10,5,5)
-  print(type(box))
-  >>> <class cadquery.occ_impl.shapes.Solid> 
+.. code-block::
 
-  box = Solid.makeBox(10,5,5).wrapped
-  print(type(box))
-  >>> <class OCP.TopoDS.TopoDS_Solid> 
+    >>> box = Solid.makeBox(10,5,5)
+    >>> print(type(box))
+    <class cadquery.occ_impl.shapes.Solid>
+
+    >>> box = Solid.makeBox(10,5,5).wrapped
+    >>> print(type(box))
+    <class OCP.TopoDS.TopoDS_Solid>
 
 
-If you want to cast an OCCT object into a Direct API one you can just pass it as a parameter of the intended class ::
+If you want to cast an OCCT object into a Direct API one you can just pass it as a parameter of the intended class:
 
-  occt_box = BRepPrimAPI_MakeBox(5,5,5).Solid()
-  print(type(occt_box))
-  >>> <class OCP.TopoDS.TopoDS_Solid> 
+.. code-block::
 
-  direct_api_box = Solid(occt_box)
-  print(type(direct_api_box))
-  >>> <class cadquery.occ_impl.shapes.Solid> 
+    >>> occt_box = BRepPrimAPI_MakeBox(5,5,5).Solid()
+    >>> print(type(occt_box))
+    <class OCP.TopoDS.TopoDS_Solid>
+
+    >>> direct_api_box = Solid(occt_box)
+    >>> print(type(direct_api_box))
+    <class cadquery.occ_impl.shapes.Solid>
 
 .. note::
   You can cast into the direct API the types found `here <https://dev.opencascade.org/doc/refman/html/class_topo_d_s___shape.html>`_
@@ -682,12 +690,14 @@ context's :attr:`~cadquery.cq.CQContext.pendingWires` has been cleared by
     :meth:`~cadquery.Workplane.val` or :meth:`~cadquery.Workplane.findSolid` to get at the
     :class:`~cadquery.Compound` object, then use :meth:`cadquery.Shape.Solids` to return a list
     of the :class:`~cadquery.Solid` objects contained in the :class:`~cadquery.Compound`, which in
-    this example will be a single :class:`~cadquery.Solid` object. For example::
+    this example will be a single :class:`~cadquery.Solid` object. For example:
 
-        >>> a_compound = part.findSolid()
-        >>> a_list_of_solids = a_compound.Solids()
-        >>> len(a_list_of_solids)
-        1
+.. code-block:: pycon
+
+    >>> a_compound = part.findSolid()
+    >>> a_list_of_solids = a_compound.Solids()
+    >>> len(a_list_of_solids)
+    1
 
 Now we will create a small cylinder protruding from a face on the original box. We need to set up a
 workplane to draw a circle on, so firstly we will select the correct face::

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -144,7 +144,7 @@ your operations, and defines the first solid object created as the 'context soli
 you create are automatically combined (unless you specify otherwise) with that solid.  This happens even if the
 solid was created  a long way up in the stack.  For example::
 
-    Workplane('XY').box(1,2,3).faces(">Z").circle(0.25).extrude(1)
+    Workplane("XY").box(1, 2, 3).faces(">Z").circle(0.25).extrude(1)
 
 Will create a 1x2x3 box, with a cylindrical boss extending from the top face.  It was not necessary to manually
 combine the cylinder created by extruding the circle with the box, because the default behavior for extrude is
@@ -161,7 +161,7 @@ CAD models often have repeated geometry, and its really annoying to resort to fo
 Many CadQuery methods operate automatically on each element on the stack, so that you don't have to write loops.
 For example, this::
 
-    Workplane('XY').box(1,2,3).faces(">Z").vertices().circle(0.5)
+    Workplane("XY").box(1, 2, 3).faces(">Z").vertices().circle(0.5)
 
 Will actually create 4 circles, because ``vertices()`` selects 4 vertices of a rectangular face, and the ``circle()`` method
 iterates on each member of the stack.
@@ -186,7 +186,7 @@ The Fluent API
 What we call the fluent API is what you work with when you first start using CadQuery, the :class:`~cadquery.Workplane` class and all its methods defines the Fluent API.
 This is the API you will use and see most of the time, it's fairly easy to use and it simplifies a lot of things for you. A classic example could be : ::
 
-    part = Workplane('XY').box(1,2,3).faces(">Z").vertices().circle(0.5).cutThruAll()
+    part = Workplane("XY").box(1, 2, 3).faces(">Z").vertices().circle(0.5).cutThruAll()
 
 Here we create a :class:`~cadquery.Workplane` object on which we subsequently call several methods to create our part. A general way of thinking about the Fluent API is to 
 consider the :class:`~cadquery.Workplane` as your part object and all it's methods as operations that will affect your part.
@@ -195,18 +195,12 @@ Often you will start with an empty :class:`~cadquery.Workplane`, then add more f
 This hierarchical structure of operations modifying a part is well seen with the traditional code style used in CadQuery code. 
 Code written with the CadQuery fluent API will often look like this : ::
 
-    part = (Workplane('XY')
-            .box(1,2,3)
-            .faces(">Z")
-            .vertices()
-            .circle(0.5)
-            .cutThruAll()
-            )
+    part = Workplane("XY").box(1, 2, 3).faces(">Z").vertices().circle(0.5).cutThruAll()
 
 Or like this : ::
 
-    part = Workplane('XY')
-    part = part.box(1,2,3)
+    part = Workplane("XY")
+    part = part.box(1, 2, 3)
     part = part.faces(">Z")
     part = part.vertices()
     part = part.circle(0.5)
@@ -240,7 +234,7 @@ topological classes. A Wire is made of several edges which are themselves made o
 
 For example we can create a circular face like so ::
 
-  circle_wire = Wire.makeCircle(10,Vector(0,0,0), Vector(0,0,1))
+  circle_wire = Wire.makeCircle(10, Vector(0, 0, 0), Vector(0, 0, 1))
   circular_face = Face.makeFromWires(circle_wire, [])
 
 .. note::
@@ -318,18 +312,20 @@ If you want to go the other way around i.e using objects from the topological AP
 
 You can pass a topological object as a base object to the :class:`~cadquery.Workplane` object. ::
 
-  solid_box = Solid.makeBox(10,10,10)
-  part = Workplane(obj = solid_box) 
-  # And you can continue your modelling in the fluent API 
+  solid_box = Solid.makeBox(10, 10, 10)
+  part = Workplane(obj=solid_box)
+  # And you can continue your modelling in the fluent API
   part = part.faces(">Z").circle(1).extrude(10)
 
 
 You can add a topological object as a new operation/step in the Fluent API call chain with :py:meth:`Workplane.newObject` ::
-   
-  circle_wire = Wire.makeCircle(1,Vector(0,0,0), Vector(0,0,1))
-  box = Workplane().box(10,10,10).newObject([circle_wire])
-  # And you can continue modelling 
-  box = box.toPending().cutThruAll() # notice the call to `toPending` that is needed if you want to use it in a subsequent operation
+
+  circle_wire = Wire.makeCircle(1, Vector(0, 0, 0), Vector(0, 0, 1))
+  box = Workplane().box(10, 10, 10).newObject([circle_wire])
+  # And you can continue modelling
+  box = (
+      box.toPending().cutThruAll()
+  )  # notice the call to `toPending` that is needed if you want to use it in a subsequent operation
 
 -------------------------
 Direct API <=> OCCT API
@@ -392,14 +388,14 @@ patch them in::
 
 
     def tidy_repr(obj):
-        """ Shortens a default repr string
-        """
-        return repr(obj).split('.')[-1].rstrip('>')
+        """Shortens a default repr string"""
+        return repr(obj).split(".")[-1].rstrip(">")
 
 
     def _ctx_str(self):
         return (
-            tidy_repr(self) + ":\n"
+            tidy_repr(self)
+            + ":\n"
             + f"    pendingWires: {self.pendingWires}\n"
             + f"    pendingEdges: {self.pendingEdges}\n"
             + f"    tags: {self.tags}"
@@ -411,7 +407,8 @@ patch them in::
 
     def _plane_str(self):
         return (
-            tidy_repr(self) + ":\n"
+            tidy_repr(self)
+            + ":\n"
             + f"    origin: {self.origin.toTuple()}\n"
             + f"    z direction: {self.zDir.toTuple()}"
         )
@@ -817,14 +814,16 @@ A simple example could look as follows::
     d = 10
     h = 10
 
-    part1 = Workplane().box(2*w,2*d,h)
-    part2 = Workplane().box(w,d,2*h)
-    part3 = Workplane().box(w,d,3*h)
+    part1 = Workplane().box(2 * w, 2 * d, h)
+    part2 = Workplane().box(w, d, 2 * h)
+    part3 = Workplane().box(w, d, 3 * h)
 
     assy = (
-        Assembly(part1, loc=Location(Vector(-w,0,h/2)))
-        .add(part2, loc=Location(Vector(1.5*w,-.5*d,h/2)), color=Color(0,0,1,0.5))
-        .add(part3, loc=Location(Vector(-.5*w,-.5*d,2*h)), color=Color("red"))
+        Assembly(part1, loc=Location(Vector(-w, 0, h / 2)))
+        .add(
+            part2, loc=Location(Vector(1.5 * w, -0.5 * d, h / 2)), color=Color(0, 0, 1, 0.5)
+        )
+        .add(part3, loc=Location(Vector(-0.5 * w, -0.5 * d, 2 * h)), color=Color("red"))
     )
 
 Resulting in:
@@ -847,20 +846,20 @@ constraints to obtain a fully parametric assembly. This can be achieved in the f
     d = 10
     h = 10
 
-    part1 = Workplane().box(2*w,2*d,h)
-    part2 = Workplane().box(w,d,2*h)
-    part3 = Workplane().box(w,d,3*h)
+    part1 = Workplane().box(2 * w, 2 * d, h)
+    part2 = Workplane().box(w, d, 2 * h)
+    part3 = Workplane().box(w, d, 3 * h)
 
     assy = (
-        Assembly(part1, name='part1',loc=Location(Vector(-w,0,h/2)))
-        .add(part2, name='part2',color=Color(0,0,1,0.5))
-        .add(part3, name='part3',color=Color("red"))
-        .constrain('part1@faces@>Z','part3@faces@<Z','Axis')
-        .constrain('part1@faces@>Z','part2@faces@<Z','Axis')
-        .constrain('part1@faces@>Y','part3@faces@<Y','Axis')
-        .constrain('part1@faces@>Y','part2@faces@<Y','Axis')
-        .constrain('part1@vertices@>(-1,-1,1)','part3@vertices@>(-1,-1,-1)','Point')
-        .constrain('part1@vertices@>(1,-1,-1)','part2@vertices@>(-1,-1,-1)','Point')
+        Assembly(part1, name="part1", loc=Location(Vector(-w, 0, h / 2)))
+        .add(part2, name="part2", color=Color(0, 0, 1, 0.5))
+        .add(part3, name="part3", color=Color("red"))
+        .constrain("part1@faces@>Z", "part3@faces@<Z", "Axis")
+        .constrain("part1@faces@>Z", "part2@faces@<Z", "Axis")
+        .constrain("part1@faces@>Y", "part3@faces@<Y", "Axis")
+        .constrain("part1@faces@>Y", "part2@faces@<Y", "Axis")
+        .constrain("part1@vertices@>(-1,-1,1)", "part3@vertices@>(-1,-1,-1)", "Point")
+        .constrain("part1@vertices@>(1,-1,-1)", "part2@vertices@>(-1,-1,-1)", "Point")
         .solve()
     )
 
@@ -875,25 +874,25 @@ using tags. Tags can be directly referenced when constructing the constraints::
     d = 10
     h = 10
 
-    part1 = Workplane().box(2*w,2*d,h)
-    part2 = Workplane().box(w,d,2*h)
-    part3 = Workplane().box(w,d,3*h)
+    part1 = Workplane().box(2 * w, 2 * d, h)
+    part2 = Workplane().box(w, d, 2 * h)
+    part3 = Workplane().box(w, d, 3 * h)
 
-    part1.faces('>Z').edges('<X').vertices('<Y').tag('pt1')
-    part1.faces('>X').edges('<Z').vertices('<Y').tag('pt2')
-    part3.faces('<Z').edges('<X').vertices('<Y').tag('pt1')
-    part2.faces('<X').edges('<Z').vertices('<Y').tag('pt2')
+    part1.faces(">Z").edges("<X").vertices("<Y").tag("pt1")
+    part1.faces(">X").edges("<Z").vertices("<Y").tag("pt2")
+    part3.faces("<Z").edges("<X").vertices("<Y").tag("pt1")
+    part2.faces("<X").edges("<Z").vertices("<Y").tag("pt2")
 
     assy1 = (
-        Assembly(part1, name='part1',loc=Location(Vector(-w,0,h/2)))
-        .add(part2, name='part2',color=Color(0,0,1,0.5))
-        .add(part3, name='part3',color=Color("red"))
-        .constrain('part1@faces@>Z','part3@faces@<Z','Axis')
-        .constrain('part1@faces@>Z','part2@faces@<Z','Axis')
-        .constrain('part1@faces@>Y','part3@faces@<Y','Axis')
-        .constrain('part1@faces@>Y','part2@faces@<Y','Axis')
-        .constrain('part1?pt1','part3?pt1','Point')
-        .constrain('part1?pt2','part2?pt2','Point')
+        Assembly(part1, name="part1", loc=Location(Vector(-w, 0, h / 2)))
+        .add(part2, name="part2", color=Color(0, 0, 1, 0.5))
+        .add(part3, name="part3", color=Color("red"))
+        .constrain("part1@faces@>Z", "part3@faces@<Z", "Axis")
+        .constrain("part1@faces@>Z", "part2@faces@<Z", "Axis")
+        .constrain("part1@faces@>Y", "part3@faces@<Y", "Axis")
+        .constrain("part1@faces@>Y", "part2@faces@<Y", "Axis")
+        .constrain("part1?pt1", "part3?pt1", "Point")
+        .constrain("part1?pt2", "part2?pt2", "Point")
         .solve()
     )
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -76,7 +76,7 @@ This modification will do the trick:
 
 .. code-block:: python
    :linenos:
-   :emphasize-lines: 4,8
+   :emphasize-lines: 4,10-12
 
     height = 60.0
     width = 80.0
@@ -134,7 +134,7 @@ Good news!-- we can get the job done with just a few lines of code. Here's the c
 
 .. code-block:: python
    :linenos:
-   :emphasize-lines: 5,10-13
+   :emphasize-lines: 5,11-17
 
     height = 60.0
     width = 80.0
@@ -204,7 +204,7 @@ We can do that using the preset dictionaries in the parameter definition:
 
 .. code-block:: python
    :linenos:
-   :emphasize-lines: 13
+   :emphasize-lines: 17-18
 
     height = 60.0
     width = 80.0
@@ -249,7 +249,7 @@ This can be easily accomplished using the :py:meth:`cadquery.exporters.export` f
 
 .. code-block:: python
    :linenos:
-   :emphasize-lines: 13
+   :emphasize-lines: 17-18
 
     height = 60.0
     width = 80.0

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -84,8 +84,12 @@ This modification will do the trick:
     diameter = 22.0
 
     # make the base
-    result = (cq.Workplane("XY").box(height, width, thickness)
-        .faces(">Z").workplane().hole(diameter)
+    result = (
+        cq.Workplane("XY")
+        .box(height, width, thickness)
+        .faces(">Z")
+        .workplane()
+        .hole(diameter)
     )
 
     # Render the solid
@@ -139,11 +143,15 @@ Good news!-- we can get the job done with just a few lines of code. Here's the c
     padding = 12.0
 
     # make the base
-    result = (cq.Workplane("XY")
+    result = (
+        cq.Workplane("XY")
         .box(height, width, thickness)
-        .faces(">Z").workplane().hole(diameter)
-        .faces(">Z").workplane()
-        .rect(height - padding,width - padding,forConstruction=True)
+        .faces(">Z")
+        .workplane()
+        .hole(diameter)
+        .faces(">Z")
+        .workplane()
+        .rect(height - padding, width - padding, forConstruction=True)
         .vertices()
         .cboreHole(2.4, 4.4, 2.1)
     )
@@ -205,13 +213,19 @@ We can do that using the preset dictionaries in the parameter definition:
     padding = 12.0
 
     # make the base
-    result = (cq.Workplane("XY")
+    result = (
+        cq.Workplane("XY")
         .box(height, width, thickness)
-        .faces(">Z").workplane().hole(diameter)
-        .faces(">Z").workplane()
+        .faces(">Z")
+        .workplane()
+        .hole(diameter)
+        .faces(">Z")
+        .workplane()
         .rect(height - padding, width - padding, forConstruction=True)
-        .vertices().cboreHole(2.4, 4.4, 2.1)
-        .edges("|Z").fillet(2.0)
+        .vertices()
+        .cboreHole(2.4, 4.4, 2.1)
+        .edges("|Z")
+        .fillet(2.0)
     )
 
     # Render the solid
@@ -244,22 +258,28 @@ This can be easily accomplished using the :py:meth:`cadquery.exporters.export` f
     padding = 12.0
 
     # make the base
-    result = (cq.Workplane("XY")
+    result = (
+        cq.Workplane("XY")
         .box(height, width, thickness)
-        .faces(">Z").workplane().hole(diameter)
-        .faces(">Z").workplane()
+        .faces(">Z")
+        .workplane()
+        .hole(diameter)
+        .faces(">Z")
+        .workplane()
         .rect(height - padding, width - padding, forConstruction=True)
-        .vertices().cboreHole(2.4, 4.4, 2.1)
-        .edges("|Z").fillet(2.0)
+        .vertices()
+        .cboreHole(2.4, 4.4, 2.1)
+        .edges("|Z")
+        .fillet(2.0)
     )
 
     # Render the solid
     show_object(result)
-    
+
     # Export
-    cq.exporters.export(result,'result.stl')
-    cq.exporters.export(result.section(),'result.dxf')
-    cq.exporters.export(result,'result.step')
+    cq.exporters.export(result, "result.stl")
+    cq.exporters.export(result.section(), "result.dxf")
+    cq.exporters.export(result, "result.step")
 
 Done!
 ============

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -36,12 +36,7 @@ Selectors can be combined logically, currently defined operators include **and**
 
 .. cadquery::
 
-    result = (
-        cq.Workplane("XY")
-        .box(2, 2, 2)
-        .edges("|Z and >Y")
-        .chamfer(0.2)
-    )
+    result = cq.Workplane("XY").box(2, 2, 2).edges("|Z and >Y").chamfer(0.2)
 
 Much more complex expressions are possible as well:
 
@@ -147,4 +142,4 @@ It is possible to use user defined vectors as a basis for the selectors. For exa
     result = cq.Workplane("XY").box(10, 10, 10)
 
     # chamfer only one edge
-    result = result.edges('>(-1, 1, 0)').chamfer(1)
+    result = result.edges(">(-1, 1, 0)").chamfer(1)

--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -22,15 +22,16 @@ combining them using boolean operations.
     import cadquery as cq
 
     result = (
-       cq.Sketch()
-       .trapezoid(4,3,90)
-       .vertices()
-       .circle(.5, mode='s')
-       .reset()
-       .vertices()
-       .fillet(.25)
-       .reset()
-       .rarray(.6,1,5,1).slot(1.5,0.4, mode='s', angle=90)
+        cq.Sketch()
+        .trapezoid(4, 3, 90)
+        .vertices()
+        .circle(0.5, mode="s")
+        .reset()
+        .vertices()
+        .fillet(0.25)
+        .reset()
+        .rarray(0.6, 1, 5, 1)
+        .slot(1.5, 0.4, mode="s", angle=90)
     )
 
 Note that selectors are implemented, but selection has to be explicitly reset. Sketch
@@ -45,16 +46,16 @@ Every operation from the face API accepts a mode parameter to define how to comb
     :height: 600px
 
     result = (
-       cq.Sketch()
-       .rect(1, 2, mode='c', tag='base')
-       .vertices(tag='base')
-       .circle(.7)
-       .reset()
-       .edges('|Y', tag='base')
-       .ellipse(1.2, 1, mode='i')
-       .reset()
-       .rect(2, 2, mode='i')
-       .clean()
+        cq.Sketch()
+        .rect(1, 2, mode="c", tag="base")
+        .vertices(tag="base")
+        .circle(0.7)
+        .reset()
+        .edges("|Y", tag="base")
+        .ellipse(1.2, 1, mode="i")
+        .reset()
+        .rect(2, 2, mode="i")
+        .clean()
     )
 
 
@@ -70,12 +71,12 @@ If needed, one can construct sketches by placing individual edges.
 
     result = (
         cq.Sketch()
-        .segment((0.,0),(0.,2.))
-        .segment((2.,0))
+        .segment((0.0, 0), (0.0, 2.0))
+        .segment((2.0, 0))
         .close()
-        .arc((.6,.6),0.4,0.,360.)
-        .assemble(tag='face')
-        .edges('%LINE',tag='face')
+        .arc((0.6, 0.6), 0.4, 0.0, 360.0)
+        .assemble(tag="face")
+        .edges("%LINE", tag="face")
         .vertices()
         .chamfer(0.2)
     )
@@ -97,11 +98,11 @@ and circles.
 
     result = (
         cq.Sketch()
-        .arc((0,0),1.,0.,360.)
-        .arc((1,1.5),0.5,0.,360.)
-        .segment((0.,2),(-1,3.))
+        .arc((0, 0), 1.0, 0.0, 360.0)
+        .arc((1, 1.5), 0.5, 0.0, 360.0)
+        .segment((0.0, 2), (-1, 3.0))
         .hull()
-       )
+    )
 
 Constraint-based sketches
 =========================
@@ -118,12 +119,12 @@ far only line segments and arcs can be used in such a use case.
 
     result = (
         cq.Sketch()
-        .segment((0,0), (0,3.),"s1")
-        .arc((0.,3.), (1.5,1.5), (0.,0.),"a1")
-        .constrain("s1","Fixed",None)
-        .constrain("s1", "a1","Coincident",None)
-        .constrain("a1", "s1","Coincident",None)
-        .constrain("s1",'a1', "Angle", 45)
+        .segment((0, 0), (0, 3.0), "s1")
+        .arc((0.0, 3.0), (1.5, 1.5), (0.0, 0.0), "a1")
+        .constrain("s1", "Fixed", None)
+        .constrain("s1", "a1", "Coincident", None)
+        .constrain("a1", "s1", "Coincident", None)
+        .constrain("s1", "a1", "Angle", 45)
         .solve()
         .assemble()
     )
@@ -204,15 +205,15 @@ Constructing sketches in-place can be accomplished as follows.
 
     result = (
         cq.Workplane()
-        .box(5,5,1)
-        .faces('>Z')
+        .box(5, 5, 1)
+        .faces(">Z")
         .sketch()
-        .regularPolygon(2,3,tag='outer')
-        .regularPolygon(1.5,3,mode='s')
-        .vertices(tag='outer')
-        .fillet(.2)
+        .regularPolygon(2, 3, tag="outer")
+        .regularPolygon(1.5, 3, mode="s")
+        .vertices(tag="outer")
+        .fillet(0.2)
         .finalize()
-        .extrude(.5)
+        .extrude(0.5)
     )
 
 Sketch API is available after the :meth:`~cadquery.Workplane.sketch` call and original `workplane`.
@@ -226,21 +227,21 @@ When multiple elements are selected before constructing the sketch, multiple ske
 
     result = (
         cq.Workplane()
-        .box(5,5,1)
-        .faces('>Z')
+        .box(5, 5, 1)
+        .faces(">Z")
         .workplane()
-        .rarray(2,2,2,2)
-        .rect(1.5,1.5)
-        .extrude(.5)
-        .faces('>Z')
+        .rarray(2, 2, 2, 2)
+        .rect(1.5, 1.5)
+        .extrude(0.5)
+        .faces(">Z")
         .sketch()
         .circle(0.4)
         .wires()
         .distribute(6)
-        .circle(0.1,mode='a')
+        .circle(0.1, mode="a")
         .clean()
         .finalize()
-        .cutBlind(-0.5,taper=10)
+        .cutBlind(-0.5, taper=10)
     )
 
 Sometimes it is desired to reuse existing sketches and place them as-is on a workplane.
@@ -251,22 +252,17 @@ Sometimes it is desired to reuse existing sketches and place them as-is on a wor
 
     import cadquery as cq
 
-    s = (
-         cq.Sketch()
-         .trapezoid(3,1,110)
-         .vertices()
-         .fillet(0.2)
-         )
+    s = cq.Sketch().trapezoid(3, 1, 110).vertices().fillet(0.2)
 
     result = (
         cq.Workplane()
-        .box(5,5,5)
-        .faces('>X')
+        .box(5, 5, 5)
+        .faces(">X")
         .workplane()
-        .transformed((0,0,-90))
+        .transformed((0, 0, -90))
         .placeSketch(s)
         .cutThruAll()
-        )
+    )
 
 Reusing of existing sketches is needed when using :meth:`~cadquery.Workplane.loft`.
 
@@ -275,24 +271,10 @@ Reusing of existing sketches is needed when using :meth:`~cadquery.Workplane.lof
 
     from cadquery import Workplane, Sketch, Vector, Location
 
-    s1 = (
-         Sketch()
-         .trapezoid(3,1,110)
-         .vertices()
-         .fillet(0.2)
-         )
+    s1 = Sketch().trapezoid(3, 1, 110).vertices().fillet(0.2)
 
-    s2 = (
-         Sketch()
-         .rect(2,1)
-         .vertices()
-         .fillet(0.2)
-         )
+    s2 = Sketch().rect(2, 1).vertices().fillet(0.2)
 
-    result = (
-        Workplane()
-        .placeSketch(s1, s2.moved(Location(Vector(0, 0, 3))))
-        .loft()
-        )
+    result = Workplane().placeSketch(s1, s2.moved(Location(Vector(0, 0, 3)))).loft()
 
 When lofting only outer wires are taken into account and inner wires are silently ignored.


### PR DESCRIPTION
[Blacken-docs](https://github.com/adamchainz/blacken-docs) was used to format Sphinx code blocks.

Tasks

- ~~Convert default language blocks `::` to explicit `.. code-block:: python`.~~ See https://github.com/CadQuery/cadquery/issues/1222#issuecomment-1637040330
-  [X] Fix syntax errors in code blocks.
-  [X] Convert non-Python RST literal blocks to explicit `.. code-block::` to avoid blacken-docs parsing them as Python.
- [X] Run blacken-docs over the `doc/` and `cadquery/` directories using the `--rst-literal-blocks` option.
- [X] Fix emphasize-lines after formatting with blacken-docs.

A few syntax errors we discovered and fixed, e.g. mismatched parentheses:

```diff
-        CQ(aCube).edges(BoxSelector((0,1,0), (1,2,1))
+        CQ(aCube).edges(BoxSelector((0, 1, 0), (1, 2, 1)))
```

incorrect indentation:

```diff
-            Workplane("XY")
-            .center(10, 20).ellipse(100,10)
-            .center(0, 0).ellipse(50, 5)
+            Workplane("XY").center(10, 20).ellipse(100, 10).center(0, 0).ellipse(50, 5)
```

and syntax errors:

```diff
-    //a dictionary of InputParameter objects
+    # a dictionary of InputParameter objects
```

Explicit `.. code-block: python` was removed from blocks containing un-parsable fragments, e.g.:

```diff
-it is possible to pass :py:class:`cadquery.Shape` objects to the :py:meth:`cadquery.Assembly.constrain` method directly. For example, the above
+it is possible to pass :py:class:`cadquery.Shape` objects to the :py:meth:`cadquery.Assembly.constrain` method directly. For example, the above::
 
-.. code-block:: python
-
-    .constrain('part1@faces@>Z','part3@faces@<Z','Axis')
+    .constrain("part1@faces@>Z", "part3@faces@<Z", "Axis")
```

Closes #1222