### PR TITLE
Limit DXF BSpline Degree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/*
 MANIFEST
 out.*
 res?.dxf
+limit?.dxf
 .~*
 .*.swp
 assy.wrl

--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -104,7 +104,7 @@ def export(
 
     elif exportType == ExportTypes.DXF:
         if isinstance(w, Workplane):
-            exportDXF(w, fname)
+            exportDXF(w, fname, opt)
         else:
             raise ValueError("Only Workplanes can be exported as DXF")
 

--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -2,7 +2,7 @@ import tempfile
 import os
 import io as StringIO
 
-from typing import IO, Optional, Union, cast
+from typing import IO, Optional, Union, cast, Dict, Any
 from typing_extensions import Literal
 
 from OCP.VrmlAPI import VrmlAPI
@@ -43,7 +43,7 @@ def export(
     exportType: Optional[ExportLiterals] = None,
     tolerance: float = 0.1,
     angularTolerance: float = 0.1,
-    opt=None,
+    opt: Optional[Dict[str, Any]] = None,
 ):
 
     """
@@ -59,6 +59,9 @@ def export(
 
     shape: Shape
     f: IO
+
+    if not opt:
+        opt = {}
 
     if isinstance(w, Workplane):
         shape = toCompound(w)
@@ -98,21 +101,18 @@ def export(
             aw.writeAmf(f)
 
     elif exportType == ExportTypes.THREEMF:
-        tmfw = ThreeMFWriter(shape, tolerance, angularTolerance, **opt or {})
+        tmfw = ThreeMFWriter(shape, tolerance, angularTolerance, **opt)
         with open(fname, "wb") as f:
             tmfw.write3mf(f)
 
     elif exportType == ExportTypes.DXF:
         if isinstance(w, Workplane):
-            exportDXF(w, fname, opt)
+            exportDXF(w, fname, **opt)
         else:
             raise ValueError("Only Workplanes can be exported as DXF")
 
     elif exportType == ExportTypes.STEP:
-        if opt:
-            shape.exportStep(fname, **opt)
-        else:
-            shape.exportStep(fname)
+        shape.exportStep(fname, **opt)
 
     elif exportType == ExportTypes.STL:
         if opt:

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -119,7 +119,7 @@ def exportDXF(
     :param w: Workplane to be exported.
     :param fname: Output filename.
     :param approx: Approximation strategy. None means no approximation is applied.
-    "spline" results in all splines being approximated as cubic splines."arc" results
+    "spline" results in all splines being approximated as cubic splines. "arc" results
     in all curves being approximated as arcs and straight segments.
     :param tolerance: Approximation tolerance.
 

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -15,7 +15,7 @@ CURVE_TOLERANCE = 1e-9
 
 
 def _dxf_line(
-    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane, opt: Dict[str, Any]
+    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane
 ):
 
     msp.add_line(
@@ -24,7 +24,7 @@ def _dxf_line(
 
 
 def _dxf_circle(
-    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane, opt: Dict[str, Any]
+    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane
 ):
 
     geom = e._geomAdaptor()
@@ -54,7 +54,7 @@ def _dxf_circle(
 
 
 def _dxf_ellipse(
-    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane, opt: Dict[str, Any]
+    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane
 ):
 
     geom = e._geomAdaptor()
@@ -77,7 +77,7 @@ def _dxf_ellipse(
 
 
 def _dxf_spline(
-    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane, opt: Dict[str, Any]
+    e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane
 ):
 
     adaptor = e._geomAdaptor()
@@ -89,16 +89,6 @@ def _dxf_spline(
 
     # need to apply the transform on the geometry level
     spline.Transform(plane.fG.wrapped.Trsf())
-
-    if opt["approximate"]:
-        approx_spline = GeomConvert_ApproxCurve(
-            spline,
-            opt["approximationError"],
-            GeomAbs_C0,
-            opt["maxSegments"],
-            opt["maxDegree"],
-        )
-        spline = approx_spline.Curve()
 
     order = spline.Degree() + 1
     knots = list(spline.KnotSequence())
@@ -125,6 +115,17 @@ DXF_CONVERTERS = {
     "BSPLINE": _dxf_spline,
 }
 
+'''
+    if opt["approximate"]:
+        approx_spline = GeomConvert_ApproxCurve(
+            spline,
+            opt["approximationError"],
+            GeomAbs_C0,
+            opt["maxSegments"],
+            opt["maxDegree"],
+        )
+        spline = approx_spline.Curve()
+'''
 
 def exportDXF(w: Workplane, fname: str, opt=None):
     """
@@ -166,6 +167,6 @@ def exportDXF(w: Workplane, fname: str, opt=None):
     for e in shape.Edges():
 
         conv = DXF_CONVERTERS.get(e.geomType(), _dxf_spline)
-        conv(e, msp, plane, d)
+        conv(e, msp, plane)
 
     dxf.saveas(fname)

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -118,7 +118,9 @@ def exportDXF(
 
     :param w: Workplane to be exported.
     :param fname: Output filename.
-    :param approx: Approximation strategy. None means no apporximation is applied.
+    :param approx: Approximation strategy. None means no approximation is applied.
+    "spline" results in all splines being approximated as cubic splines."arc" results
+    in all curves being approximated as arcs and straight segments.
     :param tolerance: Approximation tolerance.
 
     """

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -19,8 +19,7 @@ def _dxf_line(
 ):
 
     msp.add_line(
-        e.startPoint().toTuple(),
-        e.endPoint().toTuple(),
+        e.startPoint().toTuple(), e.endPoint().toTuple(),
     )
 
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2578,7 +2578,7 @@ class Face(Shape):
 
     def toArcs(self, tolerance: float = 1e-3) -> "Face":
         """
-        Approximate planar face arcs and straight line segments.
+        Approximate planar face with arcs and straight line segments.
 
         :param tolerance: Approximation tolerance.
         """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1265,8 +1265,8 @@ class Shape(object):
             tolerance,  # 2D tolerance
             degree,
             1,  # dumy value, degree is leading
-            ga.GeomAbs_C2,
-            ga.GeomAbs_C2,
+            ga.GeomAbs_C0,
+            ga.GeomAbs_C0,
             True,  # set degree to be leading
             not nurbs,
             params,

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2578,7 +2578,7 @@ class Face(Shape):
 
     def toArcs(self, tolerance: float = 1e-3) -> "Face":
         """
-        Approximate a planar faces arcs and straight line segments.
+        Approximate planar face arcs and straight line segments.
 
         :param tolerance: Approximation tolerance.
         """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -236,6 +236,10 @@ from OCP.Aspect import Aspect_TOL_SOLID
 
 from OCP.Interface import Interface_Static
 
+from OCP.ShapeCustom import ShapeCustom, ShapeCustom_RestrictionParameters
+
+from OCP.BRepAlgo import BRepAlgo
+
 from math import pi, sqrt, inf
 
 import warnings
@@ -1241,6 +1245,34 @@ class Shape(object):
             offset += poly.NbNodes()
 
         return vertices, triangles
+
+    def toSplines(
+        self: T, degree: int = 3, tolerance: float = 1e-3, nurbs: bool = False
+    ) -> T:
+        """
+        Approximate shape with b-splines of the specified degree.
+
+        :param degree: Maximum degree.
+        :param tolerance: Approximation tolerance.
+        :param nurbs: Use rational splines.
+        """
+
+        params = ShapeCustom_RestrictionParameters()
+
+        result = ShapeCustom.BSplineRestriction_s(
+            self.wrapped,
+            tolerance,  # 3D tolerance
+            tolerance,  # 2D tolerance
+            degree,
+            1,  # dumy value, degree is leading
+            ga.GeomAbs_C2,
+            ga.GeomAbs_C2,
+            True,  # set degree to be leading
+            not nurbs,
+            params,
+        )
+
+        return self.__class__(result)
 
     def toVtkPolyData(
         self,
@@ -2543,6 +2575,15 @@ class Face(Shape):
         inner_p = (tcast(Wire, w.project(other, d)) for w in self.innerWires())
 
         return self.constructOn(other, outer_p, *inner_p)
+
+    def toArcs(self, tolerance: float = 1e-3) -> "Face":
+        """
+        Approximate a planar faces arcs and straight line segments.
+
+        :param tolerance: Approximation tolerance.
+        """
+
+        return self.__class__(BRepAlgo.ConvertFace_s(self.wrapped, tolerance))
 
 
 class Shell(Shape):

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -234,12 +234,10 @@ optimum values that will produce an acceptable mesh.
 Exporting DXF
 ##############
 
-By default, the DXF exporter will output splines exactly as they are represented by the OpenCascade kernel. Unfortunately some software can not handle higher-order splines, so if some of curves and arcs appear to be missing CadQuery can be instructed to approximate splines during the export process. This approximation is controlled by the following entries in the options dictionary:
+By default, the DXF exporter will output splines exactly as they are represented by the OpenCascade kernel. Unfortunately some software can not handle higher-order splines, so if some of curves and arcs appear to be missing CadQuery can be instructed to approximate splines during the export process. This approximation is controlled by the following options:
 
-* ``approximate`` - Boolean, when ``True`` splines are approximated to conform to ``maxDegree`` and ``approximationError``. Defaults to ``False``.
-* ``maxDegree``: Maximum degree of splines in the output, ignored if ``approximate`` is ``False``. Defaults to 3, which should work well for most software.
-* ``maxSegments``: Maximum number of segments in approximated splines, ignored if ``approximate`` is ``False``. Defaults to 50.
-* ``approximationError``: Acceptable error in the spline approximation, in the DXF's coordinate system. Defaults to 0.001 (1 thou for inch-scale drawings, 1 µm for mm-scale drawings).
+* ``approx`` - ``None``, ``"spline"`` or ``"arc"``. ``"spline"`` results in all splines approximated with cubic splines. ``"arc"`` results in all curves approximated with arcs and line segments.
+* ``tolerance``: Acceptable error of the approximation, in the DXF's coordinate system. Defaults to 0.001 (1 thou for inch-scale drawings, 1 µm for mm-scale drawings).
 
 .. code-block:: python
 
@@ -248,17 +246,11 @@ By default, the DXF exporter will output splines exactly as they are represented
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(
-                result,
-                '/path/to/file/object.dxf',
-                exporters.ExportTypes.DXF
-                opt={
-                    "approximate": True,
-                    "maxDegree": 2,
-                    "maxSegments": 25,
-                    "approximationError": 0.001,
-                }
-            )
+    exporters.exportDXF(
+        result,
+        '/path/to/file/object.dxf',
+        approx="spline"
+    )
 
 
 Exporting Other Formats

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -231,6 +231,36 @@ optimum values that will produce an acceptable mesh.
 
     exporters.export(result, '/path/to/file/mesh.vrml', tolerance=0.01, angularTolerance=0.1)
 
+Exporting DXF
+##############
+
+By default, the DXF exporter will output splines exactly as they are represented by the OpenCascade kernel. Unfortunately some software can not handle higher-order splines, so if some of curves and arcs appear to be missing CadQuery can be instructed to approximate splines during the export process. This approximation is controlled by the following entries in the options dictionary:
+
+* ``approximate`` - Boolean, when ``True`` splines are approximated to conform to ``maxDegree`` and ``approximationError``. Defaults to ``False``.
+* ``maxDegree``: Maximum degree of splines in the output, ignored if ``approximate`` is ``False``. Defaults to 3, which should work well for most software.
+* ``maxSegments``: Maximum number of segments in approximated splines, ignored if ``approximate`` is ``False``. Defaults to 50.
+* ``approximationError``: Acceptable error in the spline approximation, in the DXF's coordinate system. Defaults to 0.001 (1 thou for inch-scale drawings, 1 µm for mm-scale drawings).
+
+.. code-block:: python
+
+    import cadquery as cq
+    from cadquery import exporters
+
+    result = cq.Workplane().box(10, 10, 10)
+
+    exporters.export(
+                result,
+                '/path/to/file/object.dxf',
+                exporters.ExportTypes.DXF
+                opt={
+                    "approximate": True,
+                    "maxDegree": 2,
+                    "maxSegments": 25,
+                    "approximationError": 0.001,
+                }
+            )
+
+
 Exporting Other Formats
 ########################
 

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -234,19 +234,15 @@ optimum values that will produce an acceptable mesh.
 Exporting DXF
 ##############
 
-By default, the DXF exporter will output splines exactly as they are represented by the OpenCascade kernel. Unfortunately some software can not handle higher-order splines, so if some of curves and arcs appear to be missing CadQuery can be instructed to approximate splines during the export process. This approximation is controlled by the following options:
+By default, the DXF exporter will output splines exactly as they are represented by the OpenCascade kernel. Unfortunately some software cannot handle higher-order splines resulting in missing curves after DXF import. To resolve this, specify an approximation strategy controlled by the following options:
 
 * ``approx`` - ``None``, ``"spline"`` or ``"arc"``. ``"spline"`` results in all splines approximated with cubic splines. ``"arc"`` results in all curves approximated with arcs and line segments.
 * ``tolerance``: Acceptable error of the approximation, in the DXF's coordinate system. Defaults to 0.001 (1 thou for inch-scale drawings, 1 µm for mm-scale drawings).
 
 .. code-block:: python
 
-    import cadquery as cq
-    from cadquery import exporters
 
-    result = cq.Workplane().box(10, 10, 10)
-
-    exporters.exportDXF(
+    cq.exporters.exportDXF(
         result,
         '/path/to/file/object.dxf',
         approx="spline"

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -10,9 +10,20 @@ import sys
 import pytest
 import ezdxf
 
+from pytest import approx
+
 # my modules
-from cadquery import *
-from cadquery import exporters, importers
+from cadquery import (
+    exporters,
+    importers,
+    Workplane,
+    Edge,
+    Vertex,
+    Assembly,
+    Plane,
+    Location,
+    Vector,
+)
 from tests import BaseTest
 from OCP.GeomConvert import GeomConvert
 from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
@@ -256,31 +267,6 @@ class TestExporters(BaseTest):
 
         self.assertAlmostEqual(s5.val().Area(), s5_i.val().Area(), 4)
 
-    def testDXFOptions(self):
-        options = {
-            "approximate": True,
-            "maxDegree": 2,
-            "maxSegments": 25,
-            "approximationError": 0.001,
-        }
-        pts = [(0, 0), (0, 0.5), (1, 1)]
-        s1 = (
-            Workplane().spline(pts).close().extrude(1).edges("|Z").fillet(0.1).section()
-        )
-        exporters.export(s1, "limit1.dxf", opt=options)
-
-        s1_i = importers.importDXF("limit1.dxf")
-
-        self.assertAlmostEqual(s1.val().Area(), s1_i.val().Area(), 4)
-        self.assertAlmostEqual(s1.edges().size(), s1_i.edges().size())
-
-        dxf = ezdxf.readfile("limit1.dxf")
-        msp = dxf.modelspace()
-
-        for el in msp:
-            if isinstance(el, ezdxf.entities.Spline):
-                self.assertLess(el.dxf.degree, 3)
-
     def testTypeHandling(self):
 
         with self.assertRaises(ValueError):
@@ -383,3 +369,53 @@ def test_tessellate(box123):
     verts, triangles = box123.val().tessellate(1e-6)
     assert len(verts) == 24
     assert len(triangles) == 12
+
+
+def _dxf_spline_max_degree(fname):
+
+    dxf = ezdxf.readfile(fname)
+    msp = dxf.modelspace()
+
+    rv = 0
+
+    for el in msp:
+        if isinstance(el, ezdxf.entities.Spline):
+            rv = el.dxf.degree if el.dxf.degree > rv else rv
+
+    return rv
+
+
+def _check_dxf_no_spline(fname):
+
+    dxf = ezdxf.readfile(fname)
+    msp = dxf.modelspace()
+
+    for el in msp:
+        if isinstance(el, ezdxf.entities.Spline):
+            return False
+
+    return True
+
+
+def test_dxf_approx():
+
+    pts = [(0, 0), (0, 0.5), (1, 1)]
+    w1 = Workplane().spline(pts).close().extrude(1).edges("|Z").fillet(0.1).section()
+    exporters.exportDXF(w1, "orig.dxf")
+
+    assert _dxf_spline_max_degree("orig.dxf") == 6
+
+    exporters.exportDXF(w1, "limit1.dxf", approx="spline")
+    w1_i1 = importers.importDXF("limit1.dxf")
+
+    assert _dxf_spline_max_degree("limit1.dxf") == 3
+
+    assert w1.val().Area() == approx(w1_i1.val().Area(), 1e-3)
+    assert w1.edges().size() == w1_i1.edges().size()
+
+    exporters.exportDXF(w1, "limit2.dxf", approx="arc")
+    w1_i2 = importers.importDXF("limit2.dxf")
+
+    assert _check_dxf_no_spline("limit2.dxf")
+
+    assert w1.val().Area() == approx(w1_i2.val().Area(), 1e-3)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -177,7 +177,7 @@ class TestExporters(BaseTest):
 
         s1_i = importers.importDXF("res1.dxf")
 
-        self.assertAlmostEqual(s1.val().Area(), s1_i.val().Area(), 6)
+        self.assertAlmostEqual(s1.val().Area(), s1_i.val().Area(), 5)
         self.assertAlmostEqual(s1.edges().size(), s1_i.edges().size())
 
         pts = [(0, 0), (0, 0.5), (1, 1)]
@@ -188,7 +188,7 @@ class TestExporters(BaseTest):
 
         s2_i = importers.importDXF("res2.dxf")
 
-        self.assertAlmostEqual(s2.val().Area(), s2_i.val().Area(), 6)
+        self.assertAlmostEqual(s2.val().Area(), s2_i.val().Area(), 4)
         self.assertAlmostEqual(s2.edges().size(), s2_i.edges().size())
 
         s3 = (
@@ -204,7 +204,7 @@ class TestExporters(BaseTest):
 
         s3_i = importers.importDXF("res3.dxf")
 
-        self.assertAlmostEqual(s3.val().Area(), s3_i.val().Area(), 6)
+        self.assertAlmostEqual(s3.val().Area(), s3_i.val().Area(), 3)
         self.assertAlmostEqual(s3.edges().size(), s3_i.edges().size())
 
         cyl = Workplane("XY").circle(22).extrude(10, both=True).translate((-50, 0, 0))
@@ -215,7 +215,7 @@ class TestExporters(BaseTest):
 
         s4_i = importers.importDXF("res4.dxf")
 
-        self.assertAlmostEqual(s4.val().Area(), s4_i.val().Area(), 6)
+        self.assertAlmostEqual(s4.val().Area(), s4_i.val().Area(), 5)
         self.assertAlmostEqual(s4.edges().size(), s4_i.edges().size())
 
         # test periodic spline
@@ -224,7 +224,7 @@ class TestExporters(BaseTest):
 
         w_i = importers.importDXF("res5.dxf")
 
-        self.assertAlmostEqual(w.val().Length(), w_i.wires().val().Length(), 6)
+        self.assertAlmostEqual(w.val().Length(), w_i.wires().val().Length(), 5)
 
         # test rational spline
         c = Edge.makeCircle(1)
@@ -236,7 +236,7 @@ class TestExporters(BaseTest):
 
         e_i = importers.importDXF("res6.dxf")
 
-        self.assertAlmostEqual(e.val().Length(), e_i.wires().val().Length(), 6)
+        self.assertAlmostEqual(e.val().Length(), e_i.wires().val().Length(), 3)
 
         # test non-planar section
         s5 = (
@@ -253,7 +253,7 @@ class TestExporters(BaseTest):
 
         s5_i = importers.importDXF("res7.dxf")
 
-        self.assertAlmostEqual(s5.val().Area(), s5_i.val().Area(), 4)
+        self.assertAlmostEqual(s5.val().Area(), s5_i.val().Area(), 3)
 
     def testTypeHandling(self):
 


### PR DESCRIPTION
Most DXF renderers and processing tools can't handle BSplines with degree >= 3 (order >= 4). For maximum compatibility, we should approximate such BSplines using degree-3 splines. This change uses the OpenCascade facilities to do so, though ezdxf.math also provides some spline approximation facilities that could be used. Using the OpenCascade approach allows us to match FreeCAD's parameters which are presumably tuned on a diversity of real-world designs.

Fixes #1225