### PR TITLE
Update cadquery_cheatsheet.html

### DIFF
--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -494,7 +494,7 @@
 						<td>&#43;Z</td>
 						<td>DirectionSelector</td>
 						<td>Faces with normal in +z direction</td>
-						<td>0 or 1</td>
+						<td>0..many</td>
 					</tr>
 					<tr>
 						<td>&#124;Z</td>


### PR DESCRIPTION
'+Z' may select multiple faces, so its 'Objects Returned' should be '0..many'. Actually, the third example in this table, namely -X selector, is already correct result, which should be the same with +Z.