### PR TITLE
fix bug: extrude both direction and cut #1090

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3037,7 +3037,7 @@ class Workplane(object):
 
         # If subtractive mode is requested, use cutBlind
         if combine in ("cut", "s"):
-            return self.cutBlind(until, clean, taper)
+            return self.cutBlind(until, clean, both, taper)
 
         # Handle `until` multiple values
         elif until in ("next", "last") and combine in (True, "a"):
@@ -3162,7 +3162,7 @@ class Workplane(object):
             from warnings import warn
 
             warn(
-                "sweepAlongWires keyword argument is is deprecated and will "
+                "sweepAlongWires keyword argument is deprecated and will "
                 "be removed in the next version; use multisection instead",
                 DeprecationWarning,
             )
@@ -3440,6 +3440,7 @@ class Workplane(object):
         self: T,
         until: Union[float, Literal["next", "last"], Face],
         clean: bool = True,
+        both: bool = False,
         taper: Optional[float] = None,
     ) -> T:
         """
@@ -3455,6 +3456,7 @@ class Workplane(object):
           normal.  "last" cuts to the last face. If a object of type Face is passed then the cut
           will extend until this face.
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param boolean both: cutBlind both directions
         :param float taper: angle for optional tapered extrusion
         :raises ValueError: if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected
@@ -3463,19 +3465,39 @@ class Workplane(object):
         """
         # Handling of `until` passed values
         s: Union[Compound, Solid, Shape]
+        if isinstance(both, float) and not taper:
+            from warnings import warn
+
+            warn(
+                "cutBlind added a new keyword argument `both=True`. "
+                "The signature is changed from "
+                "(until, clean, taper) -> (until, clean, both, taper)",
+                DeprecationWarning,
+            )
+
+            # assign 3rd argument value to taper
+            taper = both
+            both = False
+
         if isinstance(until, str) and until in ("next", "last"):
             if until == "next":
                 faceIndex = 0
             elif until == "last":
                 faceIndex = -1
 
-            s = self._extrude(None, taper=taper, upToFace=faceIndex, additive=False)
+            s = self._extrude(
+                None, both=both, taper=taper, upToFace=faceIndex, additive=False
+            )
 
         elif isinstance(until, Face):
-            s = self._extrude(None, taper=taper, upToFace=until, additive=False)
+            s = self._extrude(
+                None, both=both, taper=taper, upToFace=until, additive=False
+            )
 
         elif isinstance(until, (int, float)):
-            toCut = self._extrude(until, taper=taper, upToFace=None, additive=False)
+            toCut = self._extrude(
+                until, both=both, taper=taper, upToFace=None, additive=False
+            )
             solidRef = self.findSolid()
             s = solidRef.cut(toCut)
         else:
@@ -3621,8 +3643,6 @@ class Workplane(object):
         direction = "AlongAxis" if additive else "Opposite"
         taper = 0.0 if taper is None else taper
 
-        toFuse = []
-
         if upToFace is not None:
             res = self.findSolid()
             for face in faces:
@@ -3655,8 +3675,8 @@ class Workplane(object):
                         upToFace=limitFace2,
                         additive=additive,
                     )
-
         else:
+            toFuse = []
             for face in faces:
                 res = Solid.extrudeLinear(face, eDir, taper=taper)
                 toFuse.append(res)
@@ -3664,8 +3684,9 @@ class Workplane(object):
                 if both:
                     res = Solid.extrudeLinear(face, eDir.multiply(-1.0), taper=taper)
                     toFuse.append(res)
+            res = Compound.makeCompound(toFuse)
 
-        return res if upToFace is not None else Compound.makeCompound(toFuse)
+        return res
 
     def _revolve(
         self, angleDegrees: float, axisStart: VectorLike, axisEnd: VectorLike

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3620,6 +3620,17 @@ class TestCadQuery(BaseTest):
         r = box.faces(">Z").workplane(invert=True).circle(0.5).extrude(4, combine="cut")
         self.assertGreater(box.val().Volume(), r.val().Volume())
 
+        # Test extrude with both=True and combine="cut"
+        wp_ref = Workplane("XY").rect(40, 40).extrude(20, both=True)
+
+        wp_ref_regular_cut = (
+            wp_ref.workplane(offset=-20).rect(20, 20).extrude(40, combine="s")
+        )
+
+        wp = wp_ref.workplane().rect(20, 20).extrude(20, both=True, combine="s")
+
+        self.assertAlmostEqual(wp_ref_regular_cut.val().Volume(), wp.val().Volume())
+
     def testTaperedExtrudeCutBlind(self):
 
         h = 1.0


### PR DESCRIPTION
This RP tries to fix a bug #1090 that when `both=True` and `combine="cut"` used in `extrude`, the `both=True` is ignored. The simple fix is to add a `both` argument to `cutBlind`, which is called by `extrude` when `combine=cut` is used. A corresponding test is also added.

However, there is a subtle numerical issue (I believe) caused by flipping the norm direction:
https://github.com/CadQuery/cadquery/blob/a2c1f7c4a6176ef431c1dd84170d2caebef71e8e/cadquery/cq.py#L3648

This will result a fathom face between the two extruded objects, as shown below:
 
![extrude_both_cut](https://user-images.githubusercontent.com/2334880/212526237-a71e5445-8413-4e0c-b26e-14794a6bb47f.png)

This shouldn't be a problem for exporting to stl, but it is troubling nonetheless. Please feel free to make changes.