### PR TITLE
Fix rst syntax errors

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -447,7 +447,7 @@ class Assembly(object):
         :param exportType: export format (default: None, results in format being inferred form the path)
         :param tolerance: the deflection tolerance, in model units. Only used for GLTF, VRML. Default 0.1.
         :param angularTolerance: the angular tolerance, in radians. Only used for GLTF, VRML. Default 0.1.
-        :param **kwargs: Additional keyword arguments.  Only used for STEP.
+        :param \**kwargs: Additional keyword arguments.  Only used for STEP.
             See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
         """
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -154,7 +154,7 @@ class Workplane(object):
 
     .. note::
         You can also create workplanes on the surface of existing faces using
-        :py:meth:`CQ.workplane`
+        :meth:`workplane`
     """
 
     objects: List[CQObject]
@@ -227,8 +227,7 @@ class Workplane(object):
         Tags the current CQ object for later reference.
 
         :param name: the name to tag this object with
-        :type name: string
-        :returns: self, a cq object with tag applied
+        :returns: self, a CQ object with tag applied
         """
         self._tag = name
         self.ctx.tags[name] = self
@@ -279,14 +278,14 @@ class Workplane(object):
         """
         Splits a solid on the stack into two parts, optionally keeping the separate parts.
 
-        :param boolean keepTop: True to keep the top, False or None to discard it
-        :param boolean keepBottom: True to keep the bottom, False or None to discard it
+        :param bool keepTop: True to keep the top, False or None to discard it
+        :param bool keepBottom: True to keep the bottom, False or None to discard it
         :raises ValueError: if keepTop and keepBottom are both false.
         :raises ValueError: if there is no solid in the current stack or parent chain
         :returns: CQ object with the desired objects on the stack.
 
         The most common operation splits a solid and keeps one half. This sample creates
-        split bushing::
+        a split bushing::
 
             # drill a hole in the side
             c = Workplane().box(1,1,1).faces(">Z").workplane().circle(0.25).cutThruAll()
@@ -368,7 +367,7 @@ class Workplane(object):
         After the operation, the returned solid is also the context solid.
 
         :param otherCQToCombine: another CadQuery to combine.
-        :return: a cQ object with the resulting combined solid on the stack.
+        :return: a CQ object with the resulting combined solid on the stack.
 
         Most of the time, both objects will contain a single solid, which is
         combined and returned on the stack of the new object.
@@ -423,7 +422,7 @@ class Workplane(object):
         :rtype: list of occ_impl objects
         :returns: the values of the objects on the stack.
 
-        Contrast with :py:meth:`all`, which returns CQ objects for all of the items on the stack
+        Contrast with :meth:`all`, which returns CQ objects for all of the items on the stack
         """
         return self.objects
 
@@ -447,7 +446,7 @@ class Workplane(object):
         :type obj: a Workplane, CAD primitive, or list of CAD primitives
         :return: a Workplane with the requested operation performed
 
-        If an Workplane object, the values of that object's stack are added. If
+        If a Workplane object, the values of that object's stack are added. If
         a list of cad primitives, they are all added. If a single CAD primitive
         then it is added.
 
@@ -527,10 +526,7 @@ class Workplane(object):
         :param invert:  invert the normal direction from that of the face.
         :param centerOption: how local origin of workplane is determined.
         :param origin: origin for plane center, requires 'ProjectedOrigin' centerOption.
-        :type offset: float or None=0.0
-        :type invert: boolean or None=False
         :type centerOption: string or None='ProjectedOrigin'
-        :type origin: Vector or None
         :rtype: Workplane object
 
         The first element on the stack must be a face, a set of
@@ -580,8 +576,9 @@ class Workplane(object):
         def _computeXdir(normal):
             """
             Figures out the X direction based on the given normal.
-            :param :normal The direction that's normal to the plane.
-            :type :normal A Vector
+
+            :param normal: The direction that's normal to the plane.
+            :type normal: A Vector
             :return A vector representing the X direction.
             """
             xd = Vector(0, 0, 1).cross(normal)
@@ -692,7 +689,6 @@ class Workplane(object):
         Copies the workplane from a tagged parent.
 
         :param name: tag to search for
-        :type name: string
         :returns: a CQ object with name's workplane
         """
         tagged = self._getTagged(name)
@@ -827,7 +823,6 @@ class Workplane(object):
         :param objType: the type of object we are searching for
         :type objType: string: (Vertex|Edge|Wire|Solid|Shell|Compound|CompSolid)
         :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
         :return: a CQ object with the selected objects on the stack.
 
         **Implementation Note**: This is the base implementation of the vertices,edges,faces,
@@ -859,29 +854,26 @@ class Workplane(object):
         are multiple objects on the stack, the vertices of all objects are collected and a list of
         all the distinct vertices is returned.
 
-        :param selector:
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
         :return: a CQ object who's stack contains  the *distinct* vertices of *all* objects on the
-           current stack, after being filtered by the selector, if provided
+            current stack, after being filtered by the selector, if provided
 
         If there are no vertices for any objects on the current stack, an empty CQ object
         is returned
 
         The typical use is to select the vertices of a single object on the stack. For example::
 
-           Workplane().box(1,1,1).faces("+Z").vertices().size()
+            Workplane().box(1, 1, 1).faces("+Z").vertices().size()
 
-        returns 4, because the topmost face of cube will contain four vertices. While this::
+        returns 4, because the topmost face of a cube will contain four vertices. While this::
 
-           Workplane().box(1,1,1).faces().vertices().size()
+            Workplane().box(1, 1, 1).faces().vertices().size()
 
         returns 8, because a cube has a total of 8 vertices
 
         **Note** Circles are peculiar, they have a single vertex at the center!
-
-        :py:class:`StringSyntaxSelector`
 
         """
         return self._selectObjects("Vertices", selector, tag)
@@ -896,27 +888,26 @@ class Workplane(object):
         multiple objects on the stack, the faces of all objects are collected and a list of all the
         distinct faces is returned.
 
-        :param selector: A selector
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
         :return: a CQ object who's stack contains all of the *distinct* faces of *all* objects on
             the current stack, filtered by the provided selector.
 
-        If there are no vertices for any objects on the current stack, an empty CQ object
+        If there are no faces for any objects on the current stack, an empty CQ object
         is returned.
 
         The typical use is to select the faces of a single object on the stack. For example::
 
-           CQ(aCube).faces("+Z").size()
+            Workplane().box(1, 1, 1).faces("+Z").size()
 
         returns 1, because a cube has one face with a normal in the +Z direction. Similarly::
 
-           CQ(aCube).faces().size()
+            Workplane().box(1, 1, 1).faces().size()
 
         returns 6, because a cube has a total of 6 faces, And::
 
-            CQ(aCube).faces("|Z").size()
+            Workplane().box(1, 1, 1).faces("|Z").size()
 
         returns 2, because a cube has 2 faces having normals parallel to the z direction
         """
@@ -932,10 +923,9 @@ class Workplane(object):
         multiple objects on the stack, the edges of all objects are collected and a list of all the
         distinct edges is returned.
 
-        :param selector: A selector
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
         :return: a CQ object who's stack contains all of the *distinct* edges of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -943,15 +933,15 @@ class Workplane(object):
 
         The typical use is to select the edges of a single object on the stack. For example::
 
-           CQ(aCube).faces("+Z").edges().size()
+            Workplane().box(1, 1, 1).faces("+Z").edges().size()
 
-        returns 4, because a cube has one face with a normal in the +Z direction. Similarly::
+        returns 4, because the topmost face of a cube will contain four edges. Similarly::
 
-           CQ(aCube).edges().size()
+            Workplane().box(1, 1, 1).edges().size()
 
         returns 12, because a cube has a total of 12 edges, And::
 
-            CQ(aCube).edges("|Z").size()
+            Workplane().box(1, 1, 1).edges("|Z").size()
 
         returns 4, because a cube has 4 edges parallel to the z direction
         """
@@ -967,10 +957,9 @@ class Workplane(object):
         multiple objects on the stack, the wires of all objects are collected and a list of all the
         distinct wires is returned.
 
-        :param selector: A selector
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
         :return: a CQ object who's stack contains all of the *distinct* wires of *all* objects on
             the current stack, filtered by the provided selector.
 
@@ -978,7 +967,7 @@ class Workplane(object):
 
         The typical use is to select the wires of a single object on the stack. For example::
 
-           CQ(aCube).faces("+Z").wires().size()
+            Workplane().box(1, 1, 1).faces("+Z").wires().size()
 
         returns 1, because a face typically only has one outer wire
         """
@@ -994,22 +983,21 @@ class Workplane(object):
         multiple objects on the stack, the solids of all objects are collected and a list of all the
         distinct solids is returned.
 
-        :param selector: A selector
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
         :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no solids for any objects on the current stack, an empty CQ object is returned
 
-        The typical use is to select the  a single object on the stack. For example::
+        The typical use is to select a single object on the stack. For example::
 
-           CQ(aCube).solids().size()
+            Workplane().box(1, 1, 1).solids().size()
 
         returns 1, because a cube consists of one solid.
 
-        It is possible for single CQ object ( or even a single CAD primitive ) to contain
+        It is possible for a single CQ object ( or even a single CAD primitive ) to contain
         multiple solids.
         """
         return self._selectObjects("Solids", selector, tag)
@@ -1024,11 +1012,10 @@ class Workplane(object):
         multiple objects on the stack, the shells of all objects are collected and a list of all the
         distinct shells is returned.
 
-        :param selector: A selector
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
-        :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
+        :return: a CQ object who's stack contains all of the *distinct* shells of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no shells for any objects on the current stack, an empty CQ object is returned
@@ -1048,11 +1035,10 @@ class Workplane(object):
         objects on the stack, they are collected and a list of all the distinct compounds
         is returned.
 
-        :param selector: A selector
-        :type selector:  None, a Selector object, or a string selector expression.
-        :param tag: if set, search the tagged CQ object instead of self
-        :type tag: string
-        :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
+        :param selector: optional Selector object, or string selector expression
+            (see :class:`StringSyntaxSelector`)
+        :param tag: if set, search the tagged object instead of self
+        :return: a CQ object who's stack contains all of the *distinct* compounds of *all* objects on
             the current stack, filtered by the provided selector.
 
         A compound contains multiple CAD primitives that resulted from a single operation, such as
@@ -1078,8 +1064,7 @@ class Workplane(object):
 
         For testing purposes mainly.
 
-        :param fileName: the filename to export
-        :type fileName: String, absolute path to the file
+        :param fileName: the filename to export, absolute path to the file
         """
         exportSVG(self, fileName)
 
@@ -1093,10 +1078,9 @@ class Workplane(object):
         :param axisEndPoint: the second point of axis of rotation
         :type axisEndPoint: a three-tuple in global coordinates
         :param angleDegrees: the rotation angle, in degrees
-        :type angleDegrees: float
         :returns: a CQ object, with all items rotated.
 
-        WARNING: This version returns the same cq object instead of a new one-- the
+        WARNING: This version returns the same CQ object instead of a new one-- the
         old object is not accessible.
 
         Future Enhancements:
@@ -1133,7 +1117,6 @@ class Workplane(object):
         :param axisEndPoint: The second point of the axis of rotation
         :type axisEndPoint: a 3-tuple of floats
         :param angleDegrees: the rotation angle, in degrees
-        :type angleDegrees: float
         :returns: a CQ object
         """
         return self.newObject(
@@ -1160,9 +1143,7 @@ class Workplane(object):
         :type mirrorPlane: string, one of "XY", "YX", "XZ", "ZX", "YZ", "ZY" the planes
             or the normal vector of the plane eg (1,0,0) or a Face object
         :param basePointVector: the base point to mirror about (this is overwritten if a Face is passed)
-        :type basePointVector: tuple
         :param union: If true will perform a union operation on the mirrored object
-        :type union: bool
         """
 
         mp: Union[Literal["XY", "YX", "XZ", "ZX", "YZ", "ZY"], Vector]
@@ -1261,10 +1242,9 @@ class Workplane(object):
         parent chain of the selected edges.
 
         :param radius: the radius of the fillet, must be > zero
-        :type radius: positive float
         :raises ValueError: if at least one edge is not selected
         :raises ValueError: if the solid containing the edge is not in the chain
-        :returns: cq object with the resulting solid selected.
+        :returns: CQ object with the resulting solid selected.
 
         This example will create a unit cube, with the top edges filleted::
 
@@ -1296,11 +1276,9 @@ class Workplane(object):
 
         :param length: the length of the chamfer, must be greater than zero
         :param length2: optional parameter for asymmetrical chamfer
-        :type length: positive float
-        :type length2: positive float
         :raises ValueError: if at least one edge is not selected
         :raises ValueError: if the solid containing the edge is not in the chain
-        :returns: cq object with the resulting solid selected.
+        :returns: CQ object with the resulting solid selected.
 
         This example will create a unit cube, with the top edges chamfered::
 
@@ -1388,7 +1366,6 @@ class Workplane(object):
 
         WARNING: only the last object on the stack is used.
 
-        NOTE:
         """
         obj = self.objects[-1] if self.objects else self.plane.origin
 
@@ -1543,7 +1520,7 @@ class Workplane(object):
             body = s.circle(0.05).cutThruAll()
 
         Here the circle function operates on all three points, and is then extruded to create three
-        holes. See :py:meth:`circle` for how it works.
+        holes. See :meth:`circle` for how it works.
         """
         vecs: List[Union[Location, Vector]] = []
         for pnt in pntList:
@@ -1559,9 +1536,9 @@ class Workplane(object):
 
         The location is specified in terms of local coordinates.
 
-        :param float x: the new x location
-        :param float y: the new y location
-        :returns: the workplane object, with the center adjusted.
+        :param x: the new x location
+        :param y: the new y location
+        :returns: the Workplane object, with the center adjusted.
 
         The current point is set to the new center.
         This method is useful to adjust the center point after it has been created automatically on
@@ -1579,7 +1556,6 @@ class Workplane(object):
 
         The result is a cube with a round boss on the corner
         """
-        "Shift local coordinates to the specified location, according to current coordinates"
         new_origin = self.plane.toWorldCoords((x, y))
         n = self.newObject([new_origin])
         n.plane.setOrigin2d(x, y)
@@ -1589,11 +1565,11 @@ class Workplane(object):
         """
         Make a line from the current point to the provided point
 
-        :param float x: the x point, in workplane plane coordinates
-        :param float y: the y point, in workplane plane coordinates
+        :param x: the x point, in workplane plane coordinates
+        :param y: the y point, in workplane plane coordinates
         :return: the Workplane object with the current point at the end of the new line
 
-        see :py:meth:`line` if you want to use relative dimensions to make a line instead.
+        See :meth:`line` if you want to use relative dimensions to make a line instead.
         """
         startPoint = self._findFromPoint(False)
 
@@ -1612,11 +1588,11 @@ class Workplane(object):
         Make a line from the current point to the provided point, using
         dimensions relative to the current point
 
-        :param float xDist: x distance from current point
-        :param float yDist: y distance from current point
+        :param xDist: x distance from current point
+        :param yDist: y distance from current point
         :return: the workplane object with the current point at the end of the new line
 
-        see :py:meth:`lineTo` if you want to use absolute coordinates to make a line instead.
+        see :meth:`lineTo` if you want to use absolute coordinates to make a line instead.
         """
         p = self._findFromPoint(True)  # return local coordinates
         return self.lineTo(p.x + xDist, yDist + p.y, forConstruction)
@@ -1625,8 +1601,8 @@ class Workplane(object):
         """
         Make a vertical line from the current point the provided distance
 
-        :param float distance: (y) distance from current point
-        :return: the workplane object with the current point at the end of the new line
+        :param distance: (y) distance from current point
+        :return: the Workplane object with the current point at the end of the new line
         """
         return self.line(0, distance, forConstruction)
 
@@ -1634,7 +1610,7 @@ class Workplane(object):
         """
         Make a horizontal line from the current point the provided distance
 
-        :param float distance: (x) distance from current point
+        :param distance: (x) distance from current point
         :return: the Workplane object with the current point at the end of the new line
         """
         return self.line(distance, 0, forConstruction)
@@ -1644,9 +1620,9 @@ class Workplane(object):
         Make a vertical line from the current point to the provided y coordinate.
 
         Useful if it is more convenient to specify the end location rather than distance,
-        as in :py:meth:`vLine`
+        as in :meth:`vLine`
 
-        :param float yCoord: y coordinate for the end of the line
+        :param yCoord: y coordinate for the end of the line
         :return: the Workplane object with the current point at the end of the new line
         """
         p = self._findFromPoint(True)
@@ -1657,9 +1633,9 @@ class Workplane(object):
         Make a horizontal line from the current point to the provided x coordinate.
 
         Useful if it is more convenient to specify the end location rather than distance,
-        as in :py:meth:`hLine`
+        as in :meth:`hLine`
 
-        :param float xCoord: x coordinate for the end of the line
+        :param xCoord: x coordinate for the end of the line
         :return: the Workplane object with the current point at the end of the new line
         """
         p = self._findFromPoint(True)
@@ -1671,8 +1647,8 @@ class Workplane(object):
         """
         Make a line of the given length, at the given angle from the current point
 
-        :param float distance: distance of the end of the line from the current point
-        :param float angle: angle of the vector to the end of the line with the x-axis
+        :param distance: distance of the end of the line from the current point
+        :param angle: angle of the vector to the end of the line with the x-axis
         :return: the Workplane object with the current point at the end of the new line
         """
         x = math.cos(math.radians(angle)) * distance
@@ -1689,8 +1665,8 @@ class Workplane(object):
         Useful if it is more convenient to specify the end location rather than
         the distance and angle from the current point
 
-        :param float distance: distance of the end of the line from the origin
-        :param float angle: angle of the vector to the end of the line with the x-axis
+        :param distance: distance of the end of the line from the origin
+        :param angle: angle of the vector to the end of the line with the x-axis
         :return: the Workplane object with the current point at the end of the new line
         """
         x = math.cos(math.radians(angle)) * distance
@@ -1708,11 +1684,11 @@ class Workplane(object):
         :param y: desired y location, in local coordinates
         :type y: float, or none for zero.
 
-        Not to be confused with :py:meth:`center`, which moves the center of the entire
+        Not to be confused with :meth:`center`, which moves the center of the entire
         workplane, this method only moves the current point ( and therefore does not affect objects
         already drawn ).
 
-        See :py:meth:`move` to do the same thing but using relative dimensions
+        See :meth:`move` to do the same thing but using relative dimensions
         """
         newCenter = Vector(x, y, 0)
         return self.newObject([self.plane.toWorldCoords(newCenter)])
@@ -1727,11 +1703,11 @@ class Workplane(object):
         :param yDist: desired y distance, in local coordinates
         :type yDist: float, or none for zero.
 
-        Not to be confused with :py:meth:`center`, which moves the center of the entire
+        Not to be confused with :meth:`center`, which moves the center of the entire
         workplane, this method only moves the current point ( and therefore does not affect objects
         already drawn ).
 
-        See :py:meth:`moveTo` to do the same thing but using absolute coordinates
+        See :meth:`moveTo` to do the same thing but using absolute coordinates
         """
         p = self._findFromPoint(True)
         newCenter = p + Vector(xDist, yDist, 0)
@@ -1746,9 +1722,9 @@ class Workplane(object):
         :param angle: angle of slot in degrees, with 0 being along x-axis
         :return: a new CQ object with the created wires on the stack
 
-        Can be used to create arrays of slots, such as in cooling applications:
+        Can be used to create arrays of slots, such as in cooling applications::
 
-        result = cq.Workplane("XY").box(10,25,1).rarray(1,2,1,10).slot2D(8,1,0).cutThruAll()
+            Workplane().box(10, 25, 1).rarray(1, 2, 1, 10).slot2D(8, 1, 0).cutThruAll()
         """
 
         radius = diameter / 2
@@ -1839,8 +1815,8 @@ class Workplane(object):
         :param makeWire: convert the resulting spline edge to a wire
         :return: a Workplane object with the current point at the end of the spline
 
-        The spline will begin at the current point, and
-        end with the last point in the XY tuple list
+        The spline will begin at the current point, and end with the last point in the
+        XY tuple list.
 
         This example creates a block with a spline for one side::
 
@@ -2130,7 +2106,7 @@ class Workplane(object):
         The sagitta is the distance from the center of the arc to the arc base.
         Given that a closed contour is drawn clockwise;
         A positive sagitta means convex arc and negative sagitta means concave arc.
-        See "https://en.wikipedia.org/wiki/Sagitta_(geometry)" for more information.
+        See `<https://en.wikipedia.org/wiki/Sagitta_(geometry)>`_ for more information.
         """
 
         startPoint = self._findFromPoint(useLocalCoords=True)
@@ -2197,7 +2173,6 @@ class Workplane(object):
         :param endpoint: point for the arc to end at
         :type endpoint: 2-tuple, 3-tuple or Vector
         :param relative: True if endpoint is specified relative to the current point, False if endpoint is in workplane coordinates
-        :type relative: Bool
         :return: a Workplane object with an arc on the stack
 
         Requires the the current first object on the stack is an Edge, as would
@@ -2281,8 +2256,6 @@ class Workplane(object):
         """
         Queues an edge for later combination into a wire.
 
-        :param edge:
-        :return:
         """
         self.ctx.pendingEdges.append(edge)
 
@@ -2301,7 +2274,7 @@ class Workplane(object):
         CadQuery tracks edges as they are drawn, and automatically combines them into wires
         when the user does an operation that needs it.
 
-        Similarly, cadQuery tracks pending wires, and automatically combines them into faces
+        Similarly, CadQuery tracks pending wires, and automatically combines them into faces
         when necessary to make a solid.
         """
         self.ctx.pendingWires.append(wire)
@@ -2391,9 +2364,10 @@ class Workplane(object):
 
         :param callBackFunction: the function to call for each item on the current stack.
         :param useLocalCoordinates: should  values be converted from local coordinates first?
-        :type useLocalCoordinates: boolean
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
 
         The callback function must accept one argument, which is the item on the stack, and return
@@ -2448,9 +2422,10 @@ class Workplane(object):
         :return: CadQuery object which contains a list of  vectors (points ) on its stack.
 
         :param useLocalCoordinates: should points be in local or global coordinates
-        :type useLocalCoordinates: boolean
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
 
         The resulting object has a point on the stack for each object on the original stack.
@@ -2555,7 +2530,6 @@ class Workplane(object):
         Make a circle for each item on the stack.
 
         :param radius: radius of the circle
-        :type radius: float > 0
         :param forConstruction: should the new wires be reference geometry only?
         :type forConstruction: true if the wires are for reference, false if they are creating
             part geometry
@@ -2597,11 +2571,8 @@ class Workplane(object):
         Make an ellipse for each item on the stack.
 
         :param x_radius: x radius of the ellipse (x-axis of plane the ellipse should lie in)
-        :type x_radius: float > 0
         :param y_radius: y radius of the ellipse (y-axis of plane the ellipse should lie in)
-        :type y_radius: float > 0
-        :param rotation_angle: angle to rotate the ellipse (0 = no rotation = default)
-        :type rotation_angle: float
+        :param rotation_angle: angle to rotate the ellipse
         :param forConstruction: should the new wires be reference geometry only?
         :type forConstruction: true if the wires are for reference, false if they are creating
             part geometry
@@ -2775,8 +2746,8 @@ class Workplane(object):
         and then cuts the result from the context solid.
 
         :param fcn: a function suitable for use in the eachpoint method: ie, that accepts a vector
-        :param useLocalCoords: same as for :py:meth:`eachpoint`
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param useLocalCoords: same as for :meth:`eachpoint`
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :raises ValueError: if no solids or compounds are found in the stack or parent chain
         :return: a CQ object that contains the resulting solid
         """
@@ -2806,14 +2777,12 @@ class Workplane(object):
         Makes a counterbored hole for each item on the stack.
 
         :param diameter: the diameter of the hole
-        :type diameter: float > 0
-        :param cboreDiameter: the diameter of the cbore
-        :type cboreDiameter: float > 0 and > diameter
+        :param cboreDiameter: the diameter of the cbore, must be greater than hole diameter
         :param cboreDepth: depth of the counterbore
         :type cboreDepth: float > 0
         :param depth: the depth of the hole
-        :type depth: float > 0 or None to drill thru the entire part.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :type depth: float > 0 or None to drill thru the entire part
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
         The surface of the hole is at the current workplane plane.
 
@@ -2835,7 +2804,7 @@ class Workplane(object):
         **Plugin Note**: this is one example of the power of plugins. Counterbored holes are quite
         time consuming to create, but are quite easily defined by users.
 
-        see :py:meth:`cskHole` to make countersinks instead of counterbores
+        see :meth:`cskHole` to make countersinks instead of counterbores
         """
         if depth is None:
             depth = self.largestDimension()
@@ -2868,13 +2837,12 @@ class Workplane(object):
 
         :param diameter: the diameter of the hole
         :type diameter: float > 0
-        :param cskDiameter: the diameter of the countersink
-        :type cskDiameter: float > 0 and > diameter
+        :param cskDiameter: the diameter of the countersink, must be greater than hole diameter
         :param cskAngle: angle of the countersink, in degrees ( 82 is common )
         :type cskAngle: float > 0
         :param depth: the depth of the hole
         :type depth: float > 0 or None to drill thru the entire part.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
         The surface of the hole is at the current workplane.
 
@@ -2896,7 +2864,7 @@ class Workplane(object):
         **Plugin Note**: this is one example of the power of plugins. CounterSunk holes are quite
         time consuming to create, but are quite easily defined by users.
 
-        see :py:meth:`cboreHole` to make counterbores instead of countersinks
+        see :meth:`cboreHole` to make counterbores instead of countersinks
         """
 
         if depth is None:
@@ -2925,10 +2893,9 @@ class Workplane(object):
         Makes a hole for each item on the stack.
 
         :param diameter: the diameter of the hole
-        :type diameter: float > 0
         :param depth: the depth of the hole
         :type depth: float > 0 or None to drill thru the entire part.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
         The surface of the hole is at the current workplane.
 
@@ -2950,7 +2917,7 @@ class Workplane(object):
         **Plugin Note**: this is one example of the power of plugins. CounterSunk holes are quite
         time consuming to create, but are quite easily defined by users.
 
-        see :py:meth:`cboreHole` and :py:meth:`cskHole` to make counterbores or countersinks
+        see :meth:`cboreHole` and :meth:`cskHole` to make counterbores or countersinks
         """
         if depth is None:
             depth = self.largestDimension()
@@ -2985,8 +2952,10 @@ class Workplane(object):
 
         :param distance: the distance to extrude normal to the workplane
         :param angle: angle (in degrees) to rotate through the extrusion
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :return: a CQ object with the resulting solid selected.
         """
         faces = self._getFaces()
@@ -3028,10 +2997,12 @@ class Workplane(object):
             to the normal of the plane. The string "next" extrudes until the next face orthogonal to
             the wire normal. "last" extrudes to the last face. If a object of type Face is passed then
             the extrusion will extend until this face. **Note that the Workplane must contain a Solid for extruding to a given face.**
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :param boolean both: extrude in both directions symmetrically
-        :param float taper: angle for optional tapered extrusion
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
+        :param both: extrude in both directions symmetrically
+        :param taper: angle for optional tapered extrusion
         :return: a CQ object with the resulting solid selected.
 
         The returned object is always a CQ object, and depends on whether combine is True, and
@@ -3088,11 +3059,11 @@ class Workplane(object):
         :param angleDegrees: the angle to revolve through.
         :type angleDegrees: float, anything less than 360 degrees will leave the shape open
         :param axisStart: the start point of the axis of rotation
-        :type axisStart: tuple, a two tuple
         :param axisEnd: the end point of the axis of rotation
-        :type axisEnd: tuple, a two tuple
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :return: a CQ object with the resulting solid selected.
 
         The returned object is always a CQ object, and depends on whether combine is True, and
@@ -3104,7 +3075,7 @@ class Workplane(object):
 
         .. note::
             Keep in mind that `axisStart` and `axisEnd` are defined relative to the current Workplane center position.
-            So if for example you want to revolve a circle centered at (10,0,0) around the Y axis, be sure to either :py:meth:`move` (or :py:meth:`moveTo`)
+            So if for example you want to revolve a circle centered at (10,0,0) around the Y axis, be sure to either :meth:`move` (or :meth:`moveTo`)
             the current Workplane position or specify `axisStart` and `axisEnd` with the correct vector position.
             In this example (0,0,0), (0,1,0) as axis coords would fail.
         """
@@ -3155,9 +3126,12 @@ class Workplane(object):
         Use all un-extruded wires in the parent chain to create a swept solid.
 
         :param path: A wire along which the pending wires will be swept
-        :param boolean multiSection: False to create multiple swept from wires on the chain along path. True to create only one solid swept along path with shape following the list of wires on the chain
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param multiSection: False to create multiple swept from wires on the chain along path.
+            True to create only one solid swept along path with shape following the list of wires on the chain
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :param transition: handling of profile orientation at C1 path discontinuities. Possible values are {'transformed','round', 'right'} (default: 'right').
         :param normal: optional fixed normal for extrusion
         :param auxSpine: a wire defining the binormal along the extrusion path
@@ -3195,6 +3169,7 @@ class Workplane(object):
     ) -> T:
         """
         Combines the provided object with the base solid, if one can be found.
+
         :param obj: The object to be combined with the context solid
         :param mode: The mode to combine with the base solid (True, False, "cut", "a" or "s")
         :return: a new object that represents the result of combining the base object with obj,
@@ -3227,6 +3202,7 @@ class Workplane(object):
     def _fuseWithBase(self: T, obj: Shape) -> T:
         """
         Fuse the provided object with the base solid, if one can be found.
+
         :param obj:
         :return: a new object that represents the result of combining the base object with obj,
            or obj if one could not be found
@@ -3244,6 +3220,7 @@ class Workplane(object):
     def _cutFromBase(self: T, obj: Shape) -> T:
         """
         Cuts the provided object from the base solid, if one can be found.
+
         :param obj:
         :return: a new object that represents the result of combining the base object with obj,
            or obj if one could not be found
@@ -3261,11 +3238,12 @@ class Workplane(object):
     ) -> T:
         """
         Attempts to combine all of the items on the stack into a single item.
+
         WARNING: all of the items must be of the same type!
 
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :param boolean glue: use a faster gluing mode for non-overlapping shapes (default False)
-        :param float tol: tolerance value for fuzzy bool operation mode (default None)
+        :param clean: call :meth:`clean` afterwards to have a clean shape
+        :param glue: use a faster gluing mode for non-overlapping shapes (default False)
+        :param tol: tolerance value for fuzzy bool operation mode (default None)
         :raises: ValueError if there are no items on the stack, or if they cannot be combined
         :return: a CQ object with the resulting object selected
         """
@@ -3292,9 +3270,8 @@ class Workplane(object):
         Unions all of the items on the stack of toUnion with the current solid.
         If there is no current solid, the items in toUnion are unioned together.
 
-        :param toUnion:
-        :type toUnion: a solid object, or a Workplane object having a solid,
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape (default True)
+        :param toUnion: a solid object, or a Workplane object having a solid
+        :param clean: call :meth:`clean` afterwards to have a clean shape (default True)
         :param glue: use a faster gluing mode for non-overlapping shapes (default False)
         :param tol: tolerance value for fuzzy bool operation mode (default None)
         :raises: ValueError if there is no solid to add to in the chain
@@ -3335,6 +3312,7 @@ class Workplane(object):
     def __or__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
+
         Notice that :code:`r = a | b` is equivalent to :code:`r = a.union(b)` and :code:`r = a + b`.
 
         Example::
@@ -3348,6 +3326,7 @@ class Workplane(object):
     def __add__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
+
         Notice that :code:`r = a + b` is equivalent to :code:`r = a.union(b)` and :code:`r = a | b`.
         """
         return self.union(toUnion)
@@ -3358,9 +3337,8 @@ class Workplane(object):
         """
         Cuts the provided solid from the current solid, IE, perform a solid subtraction.
 
-        :param toCut: object to cut
-        :type toCut: a solid object, or a Workplane object having a solid,
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param toCut: a solid object, or a Workplane object having a solid
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :raises ValueError: if there is no solid to subtract from in the chain
         :return: a Workplane object with the resulting object selected
         """
@@ -3388,6 +3366,7 @@ class Workplane(object):
     def __sub__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for cut.
+
         Notice that :code:`r = a - b` is equivalent to :code:`r = a.cut(b)`.
 
         Example::
@@ -3404,9 +3383,8 @@ class Workplane(object):
         """
         Intersects the provided solid from the current solid.
 
-        :param toIntersect: object to intersect
-        :type toIntersect: a solid object, or a Workplane object having a solid,
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param toIntersect: a solid object, or a Workplane object having a solid
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :raises ValueError: if there is no solid to intersect with in the chain
         :return: a Workplane object with the resulting object selected
         """
@@ -3434,6 +3412,7 @@ class Workplane(object):
     def __and__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for intersect.
+
         Notice that :code:`r = a & b` is equivalent to :code:`r = a.intersect(b)`.
 
         Example::
@@ -3452,22 +3431,23 @@ class Workplane(object):
     ) -> T:
         """
         Use all un-extruded wires in the parent chain to create a prismatic cut from existing solid.
-        You must define either :distance: , :untilNextFace: or :untilLastFace:
+
+        Specify either a distance value, or one of "next", "last" to indicate a face to cut to.
 
         Similar to extrude, except that a solid in the parent chain is required to remove material
         from. cutBlind always removes material from a part.
 
         :param until: The distance to cut to, normal to the workplane plane. When a negative float
-          is passed the cut extends this far in the opposite direction to the normal of the plane
-          (i.e in the solid). The string "next" cuts until the next face orthogonal to the wire
-          normal.  "last" cuts to the last face. If a object of type Face is passed then the cut
-          will extend until this face.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :param float taper: angle for optional tapered extrusion
+            is passed the cut extends this far in the opposite direction to the normal of the plane
+            (i.e in the solid). The string "next" cuts until the next face orthogonal to the wire
+            normal.  "last" cuts to the last face. If an object of type Face is passed, then the cut
+            will extend until this face.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
+        :param taper: angle for optional tapered extrusion
         :raises ValueError: if there is no solid to subtract from in the chain
         :return: a CQ object with the resulting object selected
 
-        see :py:meth:`cutThruAll` to cut material from the entire part
+        see :meth:`cutThruAll` to cut material from the entire part
         """
         # Handling of `until` passed values
         s: Union[Compound, Solid, Shape]
@@ -3503,12 +3483,12 @@ class Workplane(object):
         Similar to extrude, except that a solid in the parent chain is required to remove material
         from. cutThruAll always removes material from a part.
 
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :raises ValueError: if there is no solid to subtract from in the chain
         :raises ValueError: if there are no pending wires to cut with
         :return: a CQ object with the resulting object selected
 
-        see :py:meth:`cutBlind` to cut material to a limited depth
+        see :meth:`cutBlind` to cut material to a limited depth
         """
         solidRef = self.findSolid()
 
@@ -3527,9 +3507,11 @@ class Workplane(object):
         """
         Make a lofted solid, through the set of wires.
 
-        :param boolean ruled: When set to `True` connects each section linearly and without continuity
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param ruled: When set to `True` connects each section linearly and without continuity
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
         :return: a Workplane object containing the created loft
 
@@ -3577,8 +3559,8 @@ class Workplane(object):
         Make a prismatic solid from the existing set of pending wires.
 
         :param distance: distance to extrude
-        :param boolean both: extrude in both directions symetrically
-        :param upToFace: if specified extrude up to the :upToFace: face, 0 for the next, -1 for the last
+        :param both: extrude in both directions symetrically
+        :param upToFace: if specified, extrude up to a face: 0 for the next, -1 for the last face
         :param additive: specify if extruding or cutting, required param for uptoface algorithm
 
         :return: OCCT solid(s), suitable for boolean operations.
@@ -3684,9 +3666,7 @@ class Workplane(object):
         :param angleDegrees: the angle to revolve through.
         :type angleDegrees: float, anything less than 360 degrees will leave the shape open
         :param axisStart: the start point of the axis of rotation
-        :type axisStart: tuple, a two tuple
         :param axisEnd: the end point of the axis of rotation
-        :type axisEnd: tuple, a two tuple
         :return: a OCCT solid(s), suitable for boolean operations.
 
         This method is a utility method, primarily for plugin and internal use.
@@ -3714,7 +3694,7 @@ class Workplane(object):
         Makes a swept solid from an existing set of pending wires.
 
         :param path: A wire along which the pending wires will be swept
-        :param boolean multisection:
+        :param multisection:
             False to create multiple swept from wires on the chain along path
             True to create only one solid swept along path with shape following the list of wires on the chain
         :param transition:
@@ -3772,39 +3752,25 @@ class Workplane(object):
         maxSegments: int = 9,
     ) -> T:
         """
-        Returns a plate surface that is 'thickness' thick, enclosed by 'surf_edge_pts' points,  and going
+        Returns a plate surface that is 'thickness' thick, enclosed by 'surf_edge_pts' points, and going
         through 'surf_pts' points.  Using pushPoints directly with interpPlate and combine=True, can be
-        very resources intensive depending on the complexity of the shape. In this case set combine=False.
+        very resource intensive depending on the complexity of the shape. In this case set combine=False.
 
-        :param surf_edges: list of [x,y,z] float ordered coordinates or list of ordered or unordered CadQuery wires
-        :param surf_pts: = [] (uses only edges if [])
-        :type surf_pts: list of [x,y,z] float coordinates
-        :param thickness: = 0 (returns 2D surface if 0)
-        :type thickness: float (may be negative or positive depending on thickening direction)
-        :param combine: should the results be combined with other solids on the stack
-            (and each other)?
-        :type combine: true to combine shapes, false otherwise.
-        :param clean: boolean call :py:meth:`clean` afterwards to have a clean shape
-        :param degree: = 3 (OCCT default)
-        :type degree: Integer >= 2
-        :param nbPtsOnCur: = 15 (OCCT default)
-        :type nbPtsOnCur: Integer >= 15
-        :param nbIter: = 2 (OCCT default)
-        :type nbIter: >= 2
-        :param anisotropy: = False (OCCT default)
-        :type anisotropy: Boolean
-        :param tol2d: = 0.00001 (OCCT default)
-        :type tol2d: float > 0
-        :param tol3d: = 0.0001 (OCCT default)
-        :type tol3d: float > 0
-        :param tolAng: = 0.01 (OCCT default)
-        :type tolAng: float > 0
-        :param tolCurv: = 0.1 (OCCT default)
-        :type tolCurv: float > 0
-        :param maxDeg: = 8 (OCCT default)
-        :type maxDeg: Integer >= 2 (?)
-        :param maxSegments: = 9 (OCCT default)
-        :type maxSegments: Integer >= 2 (?)
+        :param surf_edges: list of [x,y,z] ordered coordinates or list of ordered or unordered edges, wires
+        :param surf_pts: list of points (uses only edges if [])
+        :param thickness: value may be negative or positive depending on thickening direction (2D surface if 0)
+        :param combine: should the results be combined with other solids on the stack (and each other)?
+        :param clean: call :meth:`clean` afterwards to have a clean shape
+        :param degree: >= 2
+        :param nbPtsOnCur: number of points on curve >= 15
+        :param nbIter: number of iterations >= 2
+        :param anisotropy: = bool Anisotropy
+        :param tol2d: 2D tolerance
+        :param tol3d: 3D tolerance
+        :param tolAng: angular tolerance
+        :param tolCurv: tolerance for curvature
+        :param maxDeg: highest polynomial degree >= 2
+        :param maxSegments: greatest number of segments >= 2
         """
 
         # convert points to edges if needed
@@ -3854,18 +3820,15 @@ class Workplane(object):
         Return a 3d box with specified dimensions for each object on the stack.
 
         :param length: box size in X direction
-        :type length: float > 0
         :param width: box size in Y direction
-        :type width: float > 0
         :param height: box size in Z direction
-        :type height: float > 0
         :param centered: If True, the box will be centered around the reference point.
-          If False, the corner of the box will be on the reference point and it will
-          extend in the positive x, y and z directions. Can also use a 3-tuple to
-          specify centering along each axis.
+            If False, the corner of the box will be on the reference point and it will
+            extend in the positive x, y and z directions. Can also use a 3-tuple to
+            specify centering along each axis.
         :param combine: should the results be combined with other solids on the stack
             (and each other)?
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param clean: call :meth:`clean` afterwards to have a clean shape
 
         One box is created for each item on the current stack. If no items are on the stack, one box
         using the current workplane center is created.
@@ -3926,7 +3889,6 @@ class Workplane(object):
         Returns a 3D sphere with the specified radius for each point on the stack.
 
         :param radius: The radius of the sphere
-        :type radius: float > 0
         :param direct: The direction axis for the creation of the sphere
         :type direct: A three-tuple
         :param angle1: The first angle to sweep the sphere arc through
@@ -3936,13 +3898,13 @@ class Workplane(object):
         :param angle3: The third angle to sweep the sphere arc through
         :type angle3: float > 0
         :param centered: If True, the sphere will be centered around the reference point. If False,
-          the corner of a bounding box around the sphere will be on the reference point and it
-          will extend in the positive x, y and z directions. Can also use a 3-tuple to specify
-          centering along each axis.
+            the corner of a bounding box around the sphere will be on the reference point and it
+            will extend in the positive x, y and z directions. Can also use a 3-tuple to specify
+            centering along each axis.
         :param combine: Whether the results should be combined with other solids on the stack
             (and each other)
         :type combine: true to combine shapes, false otherwise
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :return: A sphere object for each point on the stack
 
         One sphere is created for each item on the current stack. If no items are on the stack, one
@@ -3989,9 +3951,7 @@ class Workplane(object):
         Returns a cylinder with the specified radius and height for each point on the stack
 
         :param height: The height of the cylinder
-        :type height: float > 0
         :param radius: The radius of the cylinder
-        :type radius: float > 0
         :param direct: The direction axis for the creation of the cylinder
         :type direct: A three-tuple
         :param angle: The angle to sweep the cylinder arc through
@@ -4003,7 +3963,7 @@ class Workplane(object):
         :param combine: Whether the results should be combined with other solids on the stack
             (and each other)
         :type combine: true to combine shapes, false otherwise
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :return: A cylinder object for each point on the stack
 
         One cylinder is created for each item on the current stack. If no items are on the stack, one
@@ -4153,8 +4113,10 @@ class Workplane(object):
         :param distance: the distance to extrude or cut, normal to the workplane plane
         :type distance: float, negative means opposite the normal direction
         :param cut: True to cut the resulting solid from the parent solids if found
-        :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
-        :param clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param combine: True or "a" to combine the resulting solid with parent solids if found,
+            "cut" or "s" to remove the resulting solid from the parent solids if found.
+            False to keep the resulting solid separated from the parent solids.
+        :param clean: call :meth:`clean` afterwards to have a clean shape
         :param font: font name
         :param fontPath: path to font file
         :param kind: font type
@@ -4207,7 +4169,7 @@ class Workplane(object):
         """
         Slices current solid at the given height.
 
-        :param float height: height to slice at (default: 0)
+        :param height: height to slice at (default: 0)
         :raises ValueError: if no solids or compounds are found
         :return: a CQ object with the resulting face(s).
         """

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -502,8 +502,9 @@ class Workplane(object):
     def toOCC(self) -> Any:
         """
         Directly returns the wrapped OCCT object.
+
         :return: The wrapped OCCT object
-        :rtype TopoDS_Shape or a subclass
+        :rtype: TopoDS_Shape or a subclass
         """
 
         v = self.val()
@@ -701,6 +702,7 @@ class Workplane(object):
     def first(self: T) -> T:
         """
         Return the first item on the stack
+
         :returns: the first item on the stack.
         :rtype: a CQ object
         """
@@ -708,8 +710,8 @@ class Workplane(object):
 
     def item(self: T, i: int) -> T:
         """
-
         Return the ith item on the stack.
+
         :rtype: a CQ object
         """
         return self.newObject([self.objects[i]])
@@ -717,6 +719,7 @@ class Workplane(object):
     def last(self: T) -> T:
         """
         Return the last item on the stack.
+
         :rtype: a CQ object
         """
         return self.newObject([self.objects[-1]])
@@ -724,6 +727,7 @@ class Workplane(object):
     def end(self, n: int = 1) -> "Workplane":
         """
         Return the nth parent of this CQ element
+
         :param n: number of ancestor to return (default: 1)
         :rtype: a CQ object
         :raises: ValueError if there are no more parents in the chain.
@@ -1154,7 +1158,7 @@ class Workplane(object):
 
         :param mirrorPlane: the plane to mirror about
         :type mirrorPlane: string, one of "XY", "YX", "XZ", "ZX", "YZ", "ZY" the planes
-        or the normal vector of the plane eg (1,0,0) or a Face object
+            or the normal vector of the plane eg (1,0,0) or a Face object
         :param basePointVector: the base point to mirror about (this is overwritten if a Face is passed)
         :type basePointVector: tuple
         :param union: If true will perform a union operation on the mirrored object
@@ -1325,6 +1329,7 @@ class Workplane(object):
         given in coordinates local to the current plane
         The new plane is rotated through the angles specified by the components of the rotation
         vector.
+
         :param rotate: 3-tuple of angles to rotate, in degrees relative to work plane coordinates
         :param offset: 3-tuple to offset the new plane, in local work plane coordinates
         :return: a new work plane, transformed as requested
@@ -2604,7 +2609,9 @@ class Workplane(object):
 
         *NOTE* Due to a bug in opencascade (https://tracker.dev.opencascade.org/view.php?id=31290)
         the center of mass (equals center for next shape) is shifted. To create concentric ellipses
-        use Workplane("XY")
+        use::
+
+            Workplane("XY")
             .center(10, 20).ellipse(100,10)
             .center(0, 0).ellipse(50, 5)
         """
@@ -2766,6 +2773,7 @@ class Workplane(object):
         """
         Evaluates the provided function at each point on the stack (ie, eachpoint)
         and then cuts the result from the context solid.
+
         :param fcn: a function suitable for use in the eachpoint method: ie, that accepts a vector
         :param useLocalCoords: same as for :py:meth:`eachpoint`
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
@@ -3016,10 +3024,10 @@ class Workplane(object):
         Use all un-extruded wires in the parent chain to create a prismatic solid.
 
         :param until: The distance to extrude, normal to the workplane plane. When a float is
-          passed, the extrusion extends this far and a negative value is in the opposite direction
-          to the normal of the plane. The string "next" extrudes until the next face orthogonal to
-          the wire normal. "last" extrudes to the last face. If a object of type Face is passed then
-          the extrusion will extend until this face. **Note that the Workplane must contain a Solid for extruding to a given face.**
+            passed, the extrusion extends this far and a negative value is in the opposite direction
+            to the normal of the plane. The string "next" extrudes until the next face orthogonal to
+            the wire normal. "last" extrudes to the last face. If a object of type Face is passed then
+            the extrusion will extend until this face. **Note that the Workplane must contain a Solid for extruding to a given face.**
         :param combine: True or "a" to combine the resulting solid with parent solids if found, "cut" or "s" to remove the resulting solid from the parent solids if found. False to keep the resulting solid separated from the parent solids.
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
         :param boolean both: extrude in both directions symmetrically
@@ -3030,9 +3038,9 @@ class Workplane(object):
         whether a context solid is already defined:
 
         *  if combine is False, the new value is pushed onto the stack. Note that when extruding
-          until a specified face, combine can not be False
+            until a specified face, combine can not be False
         *  if combine is true, the value is combined with the context solid if it exists,
-           and the resulting solid becomes the new context solid.
+            and the resulting solid becomes the new context solid.
         """
 
         # If subtractive mode is requested, use cutBlind
@@ -3768,37 +3776,35 @@ class Workplane(object):
         through 'surf_pts' points.  Using pushPoints directly with interpPlate and combine=True, can be
         very resources intensive depending on the complexity of the shape. In this case set combine=False.
 
-        :param surf_edges
-        :type 1 surf_edges: list of [x,y,z] float ordered coordinates
-        :type 2 surf_edges: list of ordered or unordered CadQuery wires
-        :param surf_pts = [] (uses only edges if [])
+        :param surf_edges: list of [x,y,z] float ordered coordinates or list of ordered or unordered CadQuery wires
+        :param surf_pts: = [] (uses only edges if [])
         :type surf_pts: list of [x,y,z] float coordinates
-        :param thickness = 0 (returns 2D surface if 0)
+        :param thickness: = 0 (returns 2D surface if 0)
         :type thickness: float (may be negative or positive depending on thickening direction)
         :param combine: should the results be combined with other solids on the stack
             (and each other)?
         :type combine: true to combine shapes, false otherwise.
-        :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
-        :param Degree = 3 (OCCT default)
-        :type Degree: Integer >= 2
-        :param NbPtsOnCur = 15 (OCCT default)
-        :type: NbPtsOnCur Integer >= 15
-        :param NbIter = 2 (OCCT default)
-        :type: NbIterInteger >= 2
-        :param anisotropy = False (OCCT default)
+        :param clean: boolean call :py:meth:`clean` afterwards to have a clean shape
+        :param degree: = 3 (OCCT default)
+        :type degree: Integer >= 2
+        :param nbPtsOnCur: = 15 (OCCT default)
+        :type nbPtsOnCur: Integer >= 15
+        :param nbIter: = 2 (OCCT default)
+        :type nbIter: >= 2
+        :param anisotropy: = False (OCCT default)
         :type anisotropy: Boolean
-        :param: Tol2d = 0.00001 (OCCT default)
-        :type Tol2d: float > 0
-        :param Tol3d = 0.0001 (OCCT default)
-        :type Tol3dReal: float > 0
-        :param TolAng = 0.01 (OCCT default)
-        :type TolAngReal: float > 0
-        :param TolCurv = 0.1 (OCCT default)
-        :type TolCurvReal: float > 0
-        :param MaxDeg = 8 (OCCT default)
-        :type MaxDegInteger: Integer >= 2 (?)
-        :param MaxSegments = 9 (OCCT default)
-        :type MaxSegments: Integer >= 2 (?)
+        :param tol2d: = 0.00001 (OCCT default)
+        :type tol2d: float > 0
+        :param tol3d: = 0.0001 (OCCT default)
+        :type tol3d: float > 0
+        :param tolAng: = 0.01 (OCCT default)
+        :type tolAng: float > 0
+        :param tolCurv: = 0.1 (OCCT default)
+        :type tolCurv: float > 0
+        :param maxDeg: = 8 (OCCT default)
+        :type maxDeg: Integer >= 2 (?)
+        :param maxSegments: = 9 (OCCT default)
+        :type maxSegments: Integer >= 2 (?)
         """
 
         # convert points to edges if needed

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -38,7 +38,7 @@ def exportAssembly(assy: AssemblyProtocol, path: str, **kwargs) -> bool:
     :param write_pcurves: Enable or disable writing parametric curves to the STEP file. Default True.
 
         If False, writes STEP file without pcurves. This decreases the size of the resulting STEP file.
-    :type write_pcurves: boolean
+    :type write_pcurves: bool
     :param precision_mode: Controls the uncertainty value for STEP entities. Specify -1, 0, or 1. Default 0.
         See OCCT documentation.
     :type precision_mode: int

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -915,7 +915,7 @@ class Shape(object):
     def copy(self: T, mesh: bool = False) -> T:
         """
         Creates a new object that is a copy of this object.
-        
+
         :param mesh: should I copy the triangulation too (default: False)
         :returns: a copy of the object
         """
@@ -1093,7 +1093,7 @@ class Shape(object):
         :axis: Axis on which the line rest
         :tol: Intersection tolerance
         :direction: Valid values : "AlongAxis", "Opposite", if specified will ignore all faces that are not in the specified direction
-        including the face where the :point: lies if it is the case
+            including the face where the :point: lies if it is the case
 
         :returns: A list of intersected faces sorted by distance from :point:
         """
@@ -1513,6 +1513,7 @@ class Mixin1D(object):
         mode: Literal["length", "parameter"] = "length",
     ) -> Vector:
         """Generate a position along the underlying curve.
+
         :param d: distance or parameter value
         :param mode: position calculation mode (default: length)
         :return: A Vector on the underlying curve located at the specified d value.
@@ -1533,6 +1534,7 @@ class Mixin1D(object):
         mode: Literal["length", "parameter"] = "length",
     ) -> List[Vector]:
         """Generate positions along the underlying curve
+
         :param ds: distance or parameter values
         :param mode: position calculation mode (default: length)
         :return: A list of Vector objects.
@@ -1548,6 +1550,7 @@ class Mixin1D(object):
         planar: bool = False,
     ) -> Location:
         """Generate a location along the underlying curve.
+
         :param d: distance or parameter value
         :param mode: position calculation mode (default: length)
         :param frame: moving frame calculation method (default: frenet)
@@ -1595,6 +1598,7 @@ class Mixin1D(object):
         planar: bool = False,
     ) -> List[Location]:
         """Generate location along the curve
+
         :param ds: distance or parameter values
         :param mode: position calculation mode (default: length)
         :param frame: moving frame calculation method (default: frenet)
@@ -1887,6 +1891,7 @@ class Edge(Shape, Mixin1D):
     ) -> "Edge":
         """
         Makes a three point arc through the provided points
+
         :param cls:
         :param v1: start vector
         :param v2: middle vector
@@ -1904,6 +1909,7 @@ class Edge(Shape, Mixin1D):
         """
         Makes a tangent arc from point v1, in the direction of v2 and ends at
         v3.
+
         :param cls:
         :param v1: start vector
         :param v2: tangent vector
@@ -1920,6 +1926,7 @@ class Edge(Shape, Mixin1D):
     def makeLine(cls, v1: VectorLike, v2: VectorLike) -> "Edge":
         """
         Create a line between two points
+
         :param v1: Vector that represents the first point
         :param v2: Vector that represents the second point
         :return: A linear edge between the two provided points
@@ -1962,6 +1969,7 @@ class Wire(Shape, Mixin1D):
     ) -> List["Wire"]:
         """
         Attempt to combine a list of wires and edges into a new wire.
+
         :param cls:
         :param listOfWires:
         :param tol: default 1e-9
@@ -1982,14 +1990,17 @@ class Wire(Shape, Mixin1D):
     def assembleEdges(cls, listOfEdges: Iterable[Edge]) -> "Wire":
         """
         Attempts to build a wire that consists of the edges in the provided list
+
         :param cls:
         :param listOfEdges: a list of Edge objects. The edges are not to be consecutive.
         :return: a wire with the edges assembled
-        :BRepBuilderAPI_MakeWire::Error() values
-            :BRepBuilderAPI_WireDone = 0
-            :BRepBuilderAPI_EmptyWire = 1
-            :BRepBuilderAPI_DisconnectedWire = 2
-            :BRepBuilderAPI_NonManifoldWire = 3
+
+        BRepBuilderAPI_MakeWire::Error() values:
+
+        * BRepBuilderAPI_WireDone = 0
+        * BRepBuilderAPI_EmptyWire = 1
+        * BRepBuilderAPI_DisconnectedWire = 2
+        * BRepBuilderAPI_NonManifoldWire = 3
         """
         wire_builder = BRepBuilderAPI_MakeWire()
 
@@ -2015,10 +2026,11 @@ class Wire(Shape, Mixin1D):
     ) -> "Wire":
         """
         Makes a Circle centered at the provided point, having normal in the provided direction
+
         :param radius: floating point radius of the circle, must be > 0
         :param center: vector representing the center of the circle
         :param normal: vector representing the direction of the plane the circle should lie in
-        :return:
+        :return: Wire
         """
 
         circle_edge = Edge.makeCircle(radius, center, normal)
@@ -2040,6 +2052,7 @@ class Wire(Shape, Mixin1D):
     ) -> "Wire":
         """
         Makes an Ellipse centered at the provided point, having normal in the provided direction
+
         :param x_radius: floating point major radius of the ellipse (x-axis), must be > 0
         :param y_radius: floating point minor radius of the ellipse (y-axis), must be > 0
         :param center: vector representing the center of the circle
@@ -2263,32 +2276,32 @@ class Face(Shape):
     ) -> "Face":
         """
         Returns a surface enclosed by a closed polygon defined by 'edges' and going through 'points'.
-        :param constraints
-        :type points: list of constraints (points or edges)
-        :param edges
+
+        :param edges:
         :type edges: list of Edge
-        :param continuity=GeomAbs_C0
+        :param constraints:
+        :param continuity: =GeomAbs_C0
         :type continuity: OCC.Core.GeomAbs continuity condition
-        :param Degree = 3 (OCCT default)
-        :type Degree: Integer >= 2
-        :param NbPtsOnCur = 15 (OCCT default)
-        :type: NbPtsOnCur Integer >= 15
-        :param NbIter = 2 (OCCT default)
-        :type: NbIterInteger >= 2
-        :param Anisotropie = False (OCCT default)
-        :type Anisotropie: Boolean
-        :param: Tol2d = 0.00001 (OCCT default)
-        :type Tol2d: float > 0
-        :param Tol3d = 0.0001 (OCCT default)
-        :type Tol3dReal: float > 0
-        :param TolAng = 0.01 (OCCT default)
-        :type TolAngReal: float > 0
-        :param TolCurv = 0.1 (OCCT default)
-        :type TolCurvReal: float > 0
-        :param MaxDeg = 8 (OCCT default)
-        :type MaxDegInteger: Integer >= 2 (?)
-        :param MaxSegments = 9 (OCCT default)
-        :type MaxSegments: Integer >= 2 (?)
+        :param degree: = 3 (OCCT default)
+        :type degree: Integer >= 2
+        :param nbPtsOnCur: = 15 (OCCT default)
+        :type nbPtsOnCur: Integer >= 15
+        :param nbIter: = 2 (OCCT default)
+        :type nbIter: Integer >= 2
+        :param anisotropy: = False (OCCT default)
+        :type anisotropy: Boolean
+        :param tol2d: = 0.00001 (OCCT default)
+        :type tol2d: float > 0
+        :param tol3d: = 0.0001 (OCCT default)
+        :type tol3d: Real: float > 0
+        :param tolAng: = 0.01 (OCCT default)
+        :type tolAng: Real: float > 0
+        :param tolCurv: = 0.1 (OCCT default)
+        :type tolCurv: Real: float > 0
+        :param maxDeg: = 8 (OCCT default)
+        :type maxDeg: Integer: Integer >= 2 (?)
+        :param maxSegments: = 9 (OCCT default)
+        :type maxSegments: Integer >= 2 (?)
         """
 
         n_sided = BRepOffsetAPI_MakeFilling(
@@ -2576,6 +2589,7 @@ class Mixin3D(object):
     def fillet(self: Any, radius: float, edgeList: Iterable[Edge]) -> Any:
         """
         Fillets the specified edges of this solid.
+
         :param radius: float > 0, the radius of the fillet
         :param edgeList:  a list of Edge objects, which must belong to this solid
         :return: Filleted solid
@@ -2594,6 +2608,7 @@ class Mixin3D(object):
     ) -> Any:
         """
         Chamfers the specified edges of this solid.
+
         :param length: length > 0, the length (length) of the chamfer
         :param length2: length2 > 0, optional parameter for asymmetrical chamfer. Should be `None` if not required.
         :param edgeList:  a list of Edge objects, which must belong to this solid
@@ -2791,33 +2806,32 @@ class Solid(Shape, Mixin3D):
         """
         Returns a plate surface that is 'thickness' thick, enclosed by 'surf_edge_pts' points,  and going through 'surf_pts' points.
 
-        :param surf_edges
-        :type 1 surf_edges: list of [x,y,z] float ordered coordinates
-        :type 2 surf_edges: list of ordered or unordered CadQuery wires
-        :param surf_pts = [] (uses only edges if [])
+        :param surf_edges: list of [x,y,z] float ordered coordinates, or list of ordered or unordered CadQuery wires
+        :type surf_edges:
+        :param surf_pts: = [] (uses only edges if [])
         :type surf_pts: list of [x,y,z] float coordinates
-        :param thickness = 0 (returns 2D surface if 0)
+        :param thickness: = 0 (returns 2D surface if 0)
         :type thickness: float (may be negative or positive depending on thickening direction)
-        :param Degree = 3 (OCCT default)
-        :type Degree: Integer >= 2
-        :param NbPtsOnCur = 15 (OCCT default)
-        :type: NbPtsOnCur Integer >= 15
-        :param NbIter = 2 (OCCT default)
-        :type: NbIterInteger >= 2
-        :param Anisotropie = False (OCCT default)
-        :type Anisotropie: Boolean
-        :param: Tol2d = 0.00001 (OCCT default)
-        :type Tol2d: float > 0
-        :param Tol3d = 0.0001 (OCCT default)
-        :type Tol3dReal: float > 0
-        :param TolAng = 0.01 (OCCT default)
-        :type TolAngReal: float > 0
-        :param TolCurv = 0.1 (OCCT default)
-        :type TolCurvReal: float > 0
-        :param MaxDeg = 8 (OCCT default)
-        :type MaxDegInteger: Integer >= 2 (?)
-        :param MaxSegments = 9 (OCCT default)
-        :type MaxSegments: Integer >= 2 (?)
+        :param degree: = 3 (OCCT default)
+        :type degree: Integer >= 2
+        :param nbPtsOnCur: = 15 (OCCT default)
+        :type nbPtsOnCur: Integer >= 15
+        :param nbIter: = 2 (OCCT default)
+        :type nbIter: >= 2
+        :param anisotropy: = False (OCCT default)
+        :type anisotropy: Boolean
+        :param tol2d: = 0.00001 (OCCT default)
+        :type tol2d: float > 0
+        :param tol3d: = 0.0001 (OCCT default)
+        :type tol3d: float > 0
+        :param tolAng: = 0.01 (OCCT default)
+        :type tolAng: float > 0
+        :param tolCurv: = 0.1 (OCCT default)
+        :type tolCurv: float > 0
+        :param maxDeg: = 8 (OCCT default)
+        :type maxDeg: Integer >= 2 (?)
+        :param maxSegments: = 9 (OCCT default)
+        :type maxSegments: Integer >= 2 (?)
         """
 
         # POINTS CONSTRAINTS: list of (x,y,z) points, optional.

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1089,13 +1089,13 @@ class Shape(object):
         """
         Computes the intersections between the provided line and the faces of this Shape
 
-        :point: Base point for defining a line
-        :axis: Axis on which the line rest
-        :tol: Intersection tolerance
-        :direction: Valid values : "AlongAxis", "Opposite", if specified will ignore all faces that are not in the specified direction
-            including the face where the :point: lies if it is the case
-
-        :returns: A list of intersected faces sorted by distance from :point:
+        :param point: Base point for defining a line
+        :param axis: Axis on which the line rests
+        :param tol: Intersection tolerance
+        :param direction: Valid values: "AlongAxis", "Opposite";
+            If specified, will ignore all faces that are not in the specified direction
+            including the face where the point lies if it is the case
+        :returns: A list of intersected faces sorted by distance from point
         """
 
         oc_point = (
@@ -1327,7 +1327,7 @@ class Vertex(Shape):
 
     def __init__(self, obj: TopoDS_Shape, forConstruction: bool = False):
         """
-        Create a vertex from a FreeCAD Vertex
+        Create a vertex
         """
         super(Vertex, self).__init__(obj)
 
@@ -1907,8 +1907,7 @@ class Edge(Shape, Mixin1D):
     @classmethod
     def makeTangentArc(cls, v1: VectorLike, v2: VectorLike, v3: VectorLike) -> "Edge":
         """
-        Makes a tangent arc from point v1, in the direction of v2 and ends at
-        v3.
+        Makes a tangent arc from point v1, in the direction of v2 and ends at v3.
 
         :param cls:
         :param v1: start vector
@@ -2030,7 +2029,6 @@ class Wire(Shape, Mixin1D):
         :param radius: floating point radius of the circle, must be > 0
         :param center: vector representing the center of the circle
         :param normal: vector representing the direction of the plane the circle should lie in
-        :return: Wire
         """
 
         circle_edge = Edge.makeCircle(radius, center, normal)
@@ -2060,7 +2058,6 @@ class Wire(Shape, Mixin1D):
         :param angle1: start angle of arc
         :param angle2: end angle of arc
         :param rotation_angle: angle to rotate the created ellipse / arc
-        :return: Wire
         """
 
         ellipse_edge = Edge.makeEllipse(
@@ -2217,7 +2214,7 @@ class Face(Shape):
         """
         Computes the normal vector at the desired location on the face.
 
-        :returns: a  vector representing the direction
+        :returns: a vector representing the direction
         :param locationVector: the location to compute the normal at. If none, the center of the face is used.
         :type locationVector: a vector that lies on the surface.
         """
@@ -2275,33 +2272,23 @@ class Face(Shape):
         maxSegments: int = 9,
     ) -> "Face":
         """
-        Returns a surface enclosed by a closed polygon defined by 'edges' and going through 'points'.
+        Returns a surface enclosed by a closed polygon defined by 'edges' and 'constraints'.
 
-        :param edges:
-        :type edges: list of Edge
-        :param constraints:
-        :param continuity: =GeomAbs_C0
-        :type continuity: OCC.Core.GeomAbs continuity condition
-        :param degree: = 3 (OCCT default)
-        :type degree: Integer >= 2
-        :param nbPtsOnCur: = 15 (OCCT default)
-        :type nbPtsOnCur: Integer >= 15
-        :param nbIter: = 2 (OCCT default)
-        :type nbIter: Integer >= 2
-        :param anisotropy: = False (OCCT default)
-        :type anisotropy: Boolean
-        :param tol2d: = 0.00001 (OCCT default)
-        :type tol2d: float > 0
-        :param tol3d: = 0.0001 (OCCT default)
-        :type tol3d: Real: float > 0
-        :param tolAng: = 0.01 (OCCT default)
-        :type tolAng: Real: float > 0
-        :param tolCurv: = 0.1 (OCCT default)
-        :type tolCurv: Real: float > 0
-        :param maxDeg: = 8 (OCCT default)
-        :type maxDeg: Integer: Integer >= 2 (?)
-        :param maxSegments: = 9 (OCCT default)
-        :type maxSegments: Integer >= 2 (?)
+        :param edges: edges
+        :type edges: list of edges or wires
+        :param constraints: constraints
+        :type constraints: list of points or edges
+        :param continuity: OCC.Core.GeomAbs continuity condition
+        :param degree: >=2
+        :param nbPtsOnCur: number of points on curve >= 15
+        :param nbIter: number of iterations >= 2
+        :param anisotropy: bool Anisotropy
+        :param tol2d: 2D tolerance >0
+        :param tol3d: 3D tolerance >0
+        :param tolAng: angular tolerance
+        :param tolCurv: tolerance for curvature >0
+        :param maxDeg: highest polynomial degree >= 2
+        :param maxSegments: greatest number of segments >= 2
         """
 
         n_sided = BRepOffsetAPI_MakeFilling(
@@ -2383,7 +2370,7 @@ class Face(Shape):
     @classmethod
     def makeRuledSurface(cls, edgeOrWire1, edgeOrWire2):
         """
-        'makeRuledSurface(Edge|Wire,Edge|Wire) -- Make a ruled surface
+        makeRuledSurface(Edge|Wire,Edge|Wire) -- Make a ruled surface
         Create a ruled surface out of two edges or wires. If wires are used then
         these must have the same number of edges
         """
@@ -2449,7 +2436,6 @@ class Face(Shape):
         :param smoothing: optional tuple of 3 weights use for variational smoothing (default: None)
         :param minDeg: minimum spline degree. Enforced only when smothing is None (default: 1)
         :param maxDeg: maximum spline degree (default: 6)
-        :return: an Face
         """
         points_ = TColgp_HArray2OfPnt(1, len(points), 1, len(points[0]))
 
@@ -2804,34 +2790,23 @@ class Solid(Shape, Mixin3D):
         maxSegments=9,
     ) -> Union["Solid", Face]:
         """
-        Returns a plate surface that is 'thickness' thick, enclosed by 'surf_edge_pts' points,  and going through 'surf_pts' points.
+        Returns a plate surface that is 'thickness' thick, enclosed by 'surf_edge_pts' points, and going through 'surf_pts' points.
 
-        :param surf_edges: list of [x,y,z] float ordered coordinates, or list of ordered or unordered CadQuery wires
-        :type surf_edges:
-        :param surf_pts: = [] (uses only edges if [])
-        :type surf_pts: list of [x,y,z] float coordinates
-        :param thickness: = 0 (returns 2D surface if 0)
-        :type thickness: float (may be negative or positive depending on thickening direction)
-        :param degree: = 3 (OCCT default)
-        :type degree: Integer >= 2
-        :param nbPtsOnCur: = 15 (OCCT default)
-        :type nbPtsOnCur: Integer >= 15
-        :param nbIter: = 2 (OCCT default)
-        :type nbIter: >= 2
-        :param anisotropy: = False (OCCT default)
-        :type anisotropy: Boolean
-        :param tol2d: = 0.00001 (OCCT default)
-        :type tol2d: float > 0
-        :param tol3d: = 0.0001 (OCCT default)
-        :type tol3d: float > 0
-        :param tolAng: = 0.01 (OCCT default)
-        :type tolAng: float > 0
-        :param tolCurv: = 0.1 (OCCT default)
-        :type tolCurv: float > 0
-        :param maxDeg: = 8 (OCCT default)
-        :type maxDeg: Integer >= 2 (?)
-        :param maxSegments: = 9 (OCCT default)
-        :type maxSegments: Integer >= 2 (?)
+        :param surf_edges:
+            list of [x,y,z] float ordered coordinates
+            or list of ordered or unordered wires
+        :param surf_pts: list of [x,y,z] float coordinates (uses only edges if [])
+        :param thickness: thickness may be negative or positive depending on direction, (returns 2D surface if 0)
+        :param degree: >=2
+        :param nbPtsOnCur: number of points on curve >= 15
+        :param nbIter: number of iterations >= 2
+        :param anisotropy: bool Anisotropy
+        :param tol2d: 2D tolerance >0
+        :param tol3d: 3D tolerance >0
+        :param tolAng: angular tolerance
+        :param tolCurv: tolerance for curvature >0
+        :param maxDeg: highest polynomial degree >= 2
+        :param maxSegments: greatest number of segments >= 2
         """
 
         # POINTS CONSTRAINTS: list of (x,y,z) points, optional.
@@ -2910,7 +2885,7 @@ class Solid(Shape, Mixin3D):
     ) -> "Solid":
         """
         makeBox(length,width,height,[pnt,dir]) -- Make a box located in pnt with the dimensions (length,width,height)
-        By default pnt=Vector(0,0,0) and dir=Vector(0,0,1)'
+        By default pnt=Vector(0,0,0) and dir=Vector(0,0,1)
         """
         return cls(
             BRepPrimAPI_MakeBox(
@@ -2931,7 +2906,7 @@ class Solid(Shape, Mixin3D):
         """
         Make a cone with given radii and height
         By default pnt=Vector(0,0,0),
-        dir=Vector(0,0,1) and angle=360'
+        dir=Vector(0,0,1) and angle=360
         """
         return cls(
             BRepPrimAPI_MakeCone(
@@ -2955,7 +2930,7 @@ class Solid(Shape, Mixin3D):
         """
         makeCylinder(radius,height,[pnt,dir,angle]) --
         Make a cylinder with a given radius and height
-        By default pnt=Vector(0,0,0),dir=Vector(0,0,1) and angle=360'
+        By default pnt=Vector(0,0,0),dir=Vector(0,0,1) and angle=360
         """
         return cls(
             BRepPrimAPI_MakeCylinder(
@@ -2980,7 +2955,7 @@ class Solid(Shape, Mixin3D):
         makeTorus(radius1,radius2,[pnt,dir,angle1,angle2,angle]) --
         Make a torus with a given radii and angles
         By default pnt=Vector(0,0,0),dir=Vector(0,0,1),angle1=0
-        ,angle1=360 and angle=360'
+        ,angle1=360 and angle=360
         """
         return cls(
             BRepPrimAPI_MakeTorus(
@@ -3096,18 +3071,19 @@ class Solid(Shape, Mixin3D):
         construction methods used here are different enough that they should be separate.
 
         At a high level, the steps followed are:
+
         (1) accept a set of wires
         (2) create another set of wires like this one, but which are transformed and rotated
         (3) create a ruledSurface between the sets of wires
         (4) create a shell and compute the resulting object
 
-        :param outerWire: the outermost wire, a cad.Wire
-        :param innerWires: a list of inner wires, a list of cad.Wire
+        :param outerWire: the outermost wire
+        :param innerWires: a list of inner wires
         :param vecCenter: the center point about which to rotate.  the axis of rotation is defined by
-               vecNormal, located at vecCenter. ( a cad.Vector )
-        :param vecNormal: a vector along which to extrude the wires ( a cad.Vector )
+            vecNormal, located at vecCenter.
+        :param vecNormal: a vector along which to extrude the wires
         :param angleDegrees: the angle to rotate through while extruding
-        :return: a cad.Solid object
+        :return: a Solid object
         """
         # make straight spine
         straight_spine_e = Edge.makeLine(vecCenter, vecCenter.add(vecNormal))
@@ -3160,7 +3136,7 @@ class Solid(Shape, Mixin3D):
         taper: Real = 0,
     ) -> "Solid":
         """
-        Attempt to extrude the list of wires  into a prismatic solid in the provided direction
+        Attempt to extrude the list of wires into a prismatic solid in the provided direction
 
         :param outerWire: the outermost wire
         :param innerWires: a list of inner wires
@@ -3309,14 +3285,14 @@ class Solid(Shape, Mixin3D):
         transitionMode: Literal["transformed", "round", "right"] = "transformed",
     ) -> "Shape":
         """
-        Attempt to sweep the list of wires  into a prismatic solid along the provided path
+        Attempt to sweep the list of wires into a prismatic solid along the provided path
 
         :param outerWire: the outermost wire
         :param innerWires: a list of inner wires
         :param path: The wire to sweep the face resulting from the wires over
-        :param boolean makeSolid: return Solid or Shell (default True)
-        :param boolean isFrenet: Frenet mode (default False)
-        :param mode: additional sweep mode parameters.
+        :param makeSolid: return Solid or Shell (default True)
+        :param isFrenet: Frenet mode (default False)
+        :param mode: additional sweep mode parameters
         :param transitionMode:
             handling of profile orientation at C1 path discontinuities.
             Possible values are {'transformed','round', 'right'} (default: 'right').

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -478,7 +478,7 @@ class Shape(object):
         :param write_pcurves: Enable or disable writing parametric curves to the STEP file. Default True.
 
             If False, writes STEP file without pcurves. This decreases the size of the resulting STEP file.
-        :type write_pcurves: boolean
+        :type write_pcurves: bool
         :param precision_mode: Controls the uncertainty value for STEP entities. Specify -1, 0, or 1. Default 0.
             See OCCT documentation.
         :type precision_mode: int
@@ -603,8 +603,8 @@ class Shape(object):
         """
         Create a bounding box for this Shape.
 
-        :param tolerance: Tolerance value passed to :py:class:`BoundBox`
-        :returns: A :py:class:`BoundBox` object for this Shape
+        :param tolerance: Tolerance value passed to :class:`BoundBox`
+        :returns: A :class:`BoundBox` object for this Shape
         """
         return BoundBox._fromTopoDS(self.wrapped, tol=tolerance)
 
@@ -3201,9 +3201,7 @@ class Solid(Shape, Mixin3D):
         :param angleDegrees: the angle to revolve through.
         :type angleDegrees: float, anything less than 360 degrees will leave the shape open
         :param axisStart: the start point of the axis of rotation
-        :type axisStart: tuple, a two tuple
         :param axisEnd: the end point of the axis of rotation
-        :type axisEnd: tuple, a two tuple
         :return: a Solid object
 
         The wires must not intersect

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -62,6 +62,7 @@ class Selector(object):
         Filter the provided list.
 
         The default implementation returns the original list unfiltered.
+
         :param objectList: list to filter
         :type objectList: list of OCCT primitives
         :return: filtered list


### PR DESCRIPTION
Fix rst syntax errors that result in errors in the HTML docs, or generate Sphinx errors/warnings during sphinx build.

Update documented parameters for `Workplane.interpPlate` and `Solid.interpPlate` to match method definitions.