### PR TITLE
Switching version info back to the in-between releases scheme

### DIFF
--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -4,7 +4,7 @@ try:
     __version__ = version("cadquery")
 except PackageNotFoundError:
     # package is not installed
-    __version__ = "2.2.0"
+    __version__ = "2.3-dev"
 
 # these items point to the OCC implementation
 from .occ_impl.geom import Plane, BoundBox, Vector, Matrix, Location

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ if not is_rtd and not is_appveyor and not is_azure and not is_conda:
 
 setup(
     name="cadquery",
-    # use_scm_version=True,
-    version="2.2.0",
+    use_scm_version=True,
+    # version="2.3.0",  # Uncomment this for the next release
     url="https://github.com/CadQuery/cadquery",
     license="Apache Public License 2.0",
     author="David Cowden",


### PR DESCRIPTION
@adam-urbanczyk @lorenzncode When we're ready, this will switch the version numbers back to dev versions. We should also figure out how to address #1252 for these periods between releases, although I'm not sure I fully understand why conda is reporting `0.0.0`.