### PR TITLE
Remove superfluous info since 2.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Once a current version of pip is installed, CadQuery can be installed using the 
 ```
 pip install cadquery
 ```
-NB: CadQuery has only recently returned to PyPI, and a full release has not happened yet. When the final release of CadQuery 2.2 is published, it will be possible to simply type `pip install cadquery`.
 
 It is also possible to install the very latest changes directly from CadQuery's GitHub repository, with the understanding that sometimes breaking changes can occur. To install from the git repository, run the following command line.
 ```


### PR DESCRIPTION
The v2.2 release has happend on PyPI and works, so this sentence can be removed.