### PR TITLE
SVG export enhancements

### DIFF
--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -111,7 +111,7 @@ class TestCadQuery(BaseTest):
         """
         r = Workplane("XY").rect(5, 5).extrude(5)
 
-        r_str = r.toSvg()
+        r_str = r.toSvg({"projectionDir": (-1.75, 1.1, 5)})
 
         # Make sure that a couple of sections from the SVG output make sense
         self.assertTrue(r_str.index('path d="M') > 0)


### PR DESCRIPTION
Add option to set scaling based on model dimension instead of autoscale. 
Change default projection to match cq-editor.
Add option and set default "up" direction so it does not flip with changes to projectionDir. 
Remove margin from autoscale calculation when autoscale enabled.  This allows margins to be edited without affecting scale.

Resolves #729, resolves #730.