### PR TITLE
Fix DXF export with text

### DIFF
--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -79,7 +79,7 @@ def _dxf_spline(e: Edge, msp: ezdxf.layouts.Modelspace, plane: Plane):
     )
 
     # need to apply the transform on the geometry level
-    spline.Transform(plane.fG.wrapped.Trsf())
+    spline.Transform(adaptor.Trsf())
 
     order = spline.Degree() + 1
     knots = list(spline.KnotSequence())


### PR DESCRIPTION
- Add a test of DXF export with text

To resolve #1263.

Testing with commas as it results in only 7 edges and includes types line, bspline.