### PR TITLE
Update Shape.geomType __doc__

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -545,8 +545,10 @@ class Shape(object):
         The return values depend on the type of the shape:
 
         | Vertex:  always 'Vertex'
-        | Edge:   LINE, ARC, CIRCLE, SPLINE
-        | Face:   PLANE, SPHERE, CONE
+        | Edge:   LINE, CIRCLE, ELLIPSE, HYPERBOLA, PARABOLA, BEZIER, 
+        |         BSPLINE, OFFSET, OTHER
+        | Face:   PLANE, CYLINDER, CONE, SPHERE, TORUS, BEZIER, BSPLINE, 
+        |         REVOLUTION, EXTRUSION, OFFSET, OTHER
         | Solid:  'Solid'
         | Shell:  'Shell'
         | Compound: 'Compound'


### PR DESCRIPTION
The description was based on  [CQ1 implementation](https://github.com/CadQuery/cadquery/blob/ceecbf690502625f91b9f1c0f96e5d2b8cd22835/cadquery/occ_impl/shapes.py#L422). The return type annotation seems to be correct. 