### PR TITLE
Added metadata handling to Assembly.add method

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -184,26 +184,6 @@ class Assembly(object):
         loc: Optional[Location] = None,
         name: Optional[str] = None,
         color: Optional[Color] = None,
-    ) -> "Assembly":
-        """
-        Add a subassembly to the current assembly with explicit location and name.
-
-        :param obj: object to be added as a subassembly
-        :param loc: location of the root object (default: None, interpreted as identity
-          transformation)
-        :param name: unique name of the root object (default: None, resulting in an UUID being
-          generated)
-        :param color: color of the added object (default: None)
-        """
-        ...
-
-    @overload
-    def add(
-        self,
-        obj: AssemblyObjects,
-        loc: Optional[Location] = None,
-        name: Optional[str] = None,
-        color: Optional[Color] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> "Assembly":
         """

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -197,6 +197,28 @@ class Assembly(object):
         """
         ...
 
+    @overload
+    def add(
+        self,
+        obj: AssemblyObjects,
+        loc: Optional[Location] = None,
+        name: Optional[str] = None,
+        color: Optional[Color] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "Assembly":
+        """
+        Add a subassembly to the current assembly with explicit location and name.
+
+        :param obj: object to be added as a subassembly
+        :param loc: location of the root object (default: None, interpreted as identity
+          transformation)
+        :param name: unique name of the root object (default: None, resulting in an UUID being
+          generated)
+        :param color: color of the added object (default: None)
+        :param metadata: a store for user-defined metadata (default: None)
+        """
+        ...
+
     def add(self, arg, **kwargs):
         """
         Add a subassembly to the current assembly.
@@ -214,6 +236,9 @@ class Assembly(object):
             subassy.loc = kwargs["loc"] if kwargs.get("loc") else arg.loc
             subassy.name = kwargs["name"] if kwargs.get("name") else arg.name
             subassy.color = kwargs["color"] if kwargs.get("color") else arg.color
+            subassy.metadata = (
+                kwargs["metadata"] if kwargs.get("metadata") else arg.metadata
+            )
             subassy.parent = self
 
             self.children.append(subassy)

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -132,6 +132,17 @@ def metadata_assy():
     )
     assy.add(sub_assy)
 
+    sub_assy2 = cq.Assembly(name="sub2", metadata={"mykey": "sub2-data"})
+    sub_assy2.add(
+        b1, name="sub2-0", loc=cq.Location((1, 0, 0)), metadata={"mykey": "sub2-0-data"}
+    )
+    sub_assy2.add(
+        b1, name="sub2-1", loc=cq.Location((2, 0, 0)), metadata={"mykey": "sub2-1-data"}
+    )
+    assy.add(
+        sub_assy2, metadata={"mykey": "sub2-data-add"}
+    )  # override metadata mykey:sub2-data
+
     return assy
 
 
@@ -488,6 +499,9 @@ def test_metadata(metadata_assy):
     assert len(metadata_assy.metadata) == 2
     # Test that metadata was copied by _copy() during the processing of adding the subassembly
     assert metadata_assy.children[0].metadata["b2"] == "sub-data"
+    assert metadata_assy.children[1].metadata["mykey"] == "sub2-data-add"
+    assert metadata_assy.children[1].children[0].metadata["mykey"] == "sub2-0-data"
+    assert metadata_assy.children[1].children[1].metadata["mykey"] == "sub2-1-data"
 
 
 def solve_result_check(solve_result: dict) -> bool:


### PR DESCRIPTION
I am using the `metadata` Dictionary to create [exploded assembly views](https://codeberg.org/7BIndustries/poc-stereoscope/src/branch/main/stereoscope.py#L177) by including a relative translation with each assembly component. The metadata works fine when adding Workplanes, but when sub-assemblies are added the metadata is not preserved. This PR adds a new `Assembly.add()` overload, along with the relevant code to save the metadata.

Closes #1321