### PR TITLE
Svg update

### DIFF
--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -247,6 +247,12 @@ def getSVG(shape, opts=None):
         else:
             width = height * (bb.xlen / bb.ylen)
 
+        image_width = width + (marginLeft * 2.0)
+        image_height = height + (marginTop * 2.0)
+    else:
+        image_width = width
+        image_height = height
+
     # width pixels for x, height pixels for y
     unitScale = min(width / bb.xlen * bb_scale, height / bb.ylen * bb_scale)
 
@@ -290,8 +296,8 @@ def getSVG(shape, opts=None):
             "visibleContent": visibleContent,
             "xTranslate": str(xTranslate),
             "yTranslate": str(yTranslate),
-            "width": str(width),
-            "height": str(height),
+            "width": str(image_width),
+            "height": str(image_height),
             "textboxY": str(height - 30),
             "uom": str(uom),
             "axesIndicator": axesIndicator,

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -133,8 +133,8 @@ def getSVG(shape, opts=None):
     :type Shape: Vertex, Edge, Wire, Face, Shell, Solid, or Compound.
     :param opts: An options dictionary that influences the SVG that is output.
     :type opts: Dictionary, keys are as follows:
-        width: Width of the resulting image (-1 to fit based on height).
-        height: Height of the resulting image (-1 to fit based on width).
+        width: Width of the resulting image (None to fit based on height).
+        height: Height of the resulting image (None to fit based on width).
         marginLeft: Inset margin from the left side of the document.
         marginTop: Inset margin from the top side of the document.
         projectionDir: Direction the camera will view the shape from.
@@ -169,8 +169,13 @@ def getSVG(shape, opts=None):
     # need to guess the scale and the coordinate center
     uom = guessUnitOfMeasure(shape)
 
-    width = float(d["width"])
-    height = float(d["height"])
+    # Handle the case where the height or width are None
+    width = d["width"]
+    if width != None:
+        width = float(d["width"])
+    height = d["height"]
+    if d["height"] != None:
+        height = float(d["height"])
     marginLeft = float(d["marginLeft"])
     marginTop = float(d["marginTop"])
     projectionDir = tuple(d["projectionDir"])
@@ -236,9 +241,9 @@ def getSVG(shape, opts=None):
     bb = Compound.makeCompound(hidden + visible).BoundingBox()
 
     # Determine whether the user wants to fit the drawing to the bounding box
-    if width <= 0 or height <= 0:
+    if width == None or height == None:
         # Fit image to specified width (or height)
-        if width <= 0:
+        if width == None:
             width = (height - (2.0 * marginTop)) * (
                 bb.xlen / bb.ylen
             ) + 2.0 * marginLeft

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -240,8 +240,12 @@ def getSVG(shape, opts=None):
     bb_scale = 0.75
     if fitView:
         bb_scale = 1.0
-        width = bb.xlen
-        height = bb.ylen
+
+        # Figure out which dimension to base the adjusted image size on
+        if width / bb.xlen < height / bb.ylen:
+            height = width * (bb.ylen / bb.xlen)
+        else:
+            width = height * (bb.xlen / bb.ylen)
 
     # width pixels for x, height pixels for y
     unitScale = min(width / bb.xlen * bb_scale, height / bb.ylen * bb_scale)

--- a/cadquery/occ_impl/exporters/svg.py
+++ b/cadquery/occ_impl/exporters/svg.py
@@ -180,6 +180,7 @@ def getSVG(shape, opts=None):
     hiddenColor = tuple(d["hiddenColor"])
     showHidden = bool(d["showHidden"])
     focus = float(d["focus"]) if d.get("focus") else None
+    fitView = bool(d["fitView"]) if d.get("fitView") else None
 
     hlr = HLRBRep_Algo()
     hlr.Add(shape.wrapped)
@@ -235,8 +236,15 @@ def getSVG(shape, opts=None):
     # get bounding box -- these are all in 2D space
     bb = Compound.makeCompound(hidden + visible).BoundingBox()
 
+    # Determine whether the user wants to fit the drawing to the bounding box
+    bb_scale = 0.75
+    if fitView:
+        bb_scale = 1.0
+        width = bb.xlen
+        height = bb.ylen
+
     # width pixels for x, height pixels for y
-    unitScale = min(width / bb.xlen * 0.75, height / bb.ylen * 0.75)
+    unitScale = min(width / bb.xlen * bb_scale, height / bb.ylen * bb_scale)
 
     # compute amount to translate-- move the top left into view
     (xTranslate, yTranslate) = (

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -216,6 +216,7 @@ options are as follows.
 * *hiddenColor* - Color of the line that hidden edges are drawn with.
 * *showHidden* - Whether or not to show hidden lines.
 * *focus* - If specified, creates a perspective SVG with the projector at the distance specified.
+* *fitView* - If specified, will attempt to fit the height and width of the image to the contents. The ``marginLeft`` and ``marginTop`` options should be set to 0 or the object will fall outside the viewport. The ``width`` and ``height`` options that were specified will be overridden, which can cause unexpected final image sizes.
 
 The options are passed to the exporter in a dictionary, and can be left out to force the SVG to be created with default options. 
 Below are examples with and without options set.

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -205,8 +205,8 @@ Exporting SVG
 The SVG exporter has several options which can be useful for achieving the desired final output. Those 
 options are as follows.
 
-* *width* - Document width of the resulting image.
-* *height* - Document height of the resulting image.
+* *width* - Width of the resulting image (None to fit based on height).
+* *height* - Height of the resulting image (None to fit based on width).
 * *marginLeft* - Inset margin from the left side of the document.
 * *marginTop* - Inset margin from the top side of the document.
 * *projectionDir* - Direction the camera will view the shape from.
@@ -216,7 +216,6 @@ options are as follows.
 * *hiddenColor* - Color of the line that hidden edges are drawn with.
 * *showHidden* - Whether or not to show hidden lines.
 * *focus* - If specified, creates a perspective SVG with the projector at the distance specified.
-* *fitView* - If specified, will attempt to fit the height and width of the image to the contents. The ``marginLeft`` and ``marginTop`` options  will be respected and will add to the total image size so that the margin can be duplicated at the bottom right. The ``width`` or ``height`` options that were specified will be overridden, but the largest dimension should be preserved except when margins are used.
 
 The options are passed to the exporter in a dictionary, and can be left out to force the SVG to be created with default options. 
 Below are examples with and without options set.

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -216,7 +216,7 @@ options are as follows.
 * *hiddenColor* - Color of the line that hidden edges are drawn with.
 * *showHidden* - Whether or not to show hidden lines.
 * *focus* - If specified, creates a perspective SVG with the projector at the distance specified.
-* *fitView* - If specified, will attempt to fit the height and width of the image to the contents. The ``marginLeft`` and ``marginTop`` options should be set to 0 or the object will fall outside the viewport. The ``width`` and ``height`` options that were specified will be overridden, which can cause unexpected final image sizes.
+* *fitView* - If specified, will attempt to fit the height and width of the image to the contents. The ``marginLeft`` and ``marginTop`` options should be set to 0 or the object will fall outside the viewport. The ``width`` or ``height`` options that were specified will be overridden, but the largest dimension should be preserved.
 
 The options are passed to the exporter in a dictionary, and can be left out to force the SVG to be created with default options. 
 Below are examples with and without options set.

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -216,7 +216,7 @@ options are as follows.
 * *hiddenColor* - Color of the line that hidden edges are drawn with.
 * *showHidden* - Whether or not to show hidden lines.
 * *focus* - If specified, creates a perspective SVG with the projector at the distance specified.
-* *fitView* - If specified, will attempt to fit the height and width of the image to the contents. The ``marginLeft`` and ``marginTop`` options should be set to 0 or the object will fall outside the viewport. The ``width`` or ``height`` options that were specified will be overridden, but the largest dimension should be preserved.
+* *fitView* - If specified, will attempt to fit the height and width of the image to the contents. The ``marginLeft`` and ``marginTop`` options  will be respected and will add to the total image size so that the margin can be duplicated at the bottom right. The ``width`` or ``height`` options that were specified will be overridden, but the largest dimension should be preserved except when margins are used.
 
 The options are passed to the exporter in a dictionary, and can be left out to force the SVG to be created with default options. 
 Below are examples with and without options set.

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -552,6 +552,25 @@ class TestExporters(BaseTest):
             "out.svg",
             opt={
                 "width": 100,
+                "height": 50,
+                "marginLeft": 10,
+                "marginTop": 10,
+                "showAxes": False,
+                "projectionDir": (0, 0, 1),
+                "strokeWidth": 0.25,
+                "strokeColor": (255, 0, 0),
+                "hiddenColor": (0, 0, 255),
+                "showHidden": True,
+                "focus": 4,
+                "fitView": True,
+            },
+        )
+
+        exporters.export(
+            self._box(),
+            "out.svg",
+            opt={
+                "width": 50,
                 "height": 100,
                 "marginLeft": 10,
                 "marginTop": 10,

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -562,6 +562,7 @@ class TestExporters(BaseTest):
                 "hiddenColor": (0, 0, 255),
                 "showHidden": True,
                 "focus": 4,
+                "fitView": True,
             },
         )
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -552,7 +552,7 @@ class TestExporters(BaseTest):
             "out.svg",
             opt={
                 "width": 100,
-                "height": 50,
+                "height": None,
                 "marginLeft": 10,
                 "marginTop": 10,
                 "showAxes": False,
@@ -562,7 +562,6 @@ class TestExporters(BaseTest):
                 "hiddenColor": (0, 0, 255),
                 "showHidden": True,
                 "focus": 4,
-                "fitView": True,
             },
         )
 
@@ -570,7 +569,7 @@ class TestExporters(BaseTest):
             self._box(),
             "out.svg",
             opt={
-                "width": 50,
+                "width": None,
                 "height": 100,
                 "marginLeft": 10,
                 "marginTop": 10,
@@ -581,7 +580,6 @@ class TestExporters(BaseTest):
                 "hiddenColor": (0, 0, 255),
                 "showHidden": True,
                 "focus": 4,
-                "fitView": True,
             },
         )
 


### PR DESCRIPTION
PRs #1277 and #1325 are both open with SVG export changes, but neither one fixed this issue for me. There was an extra bottom-right margin that I could not remove in the resulting SVG, and I wanted my SVGs to fill the image edge to edge for my use case while still respecting the top/left margins. These changes accomplish that.

Below are before and after examples.

Before:
![Screenshot from 2023-06-14 21-38-18](https://github.com/CadQuery/cadquery/assets/1015439/f25eb3fa-f5d3-4f0a-bec8-1191c8fab958)

After:
![Screenshot from 2023-06-14 21-36-17](https://github.com/CadQuery/cadquery/assets/1015439/f800c327-72a3-4640-9900-083cab4b9243)



