### PR TITLE
Create `parallel` parameter in `_bool_op()` to access `SetRunParallel()`

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1032,9 +1032,12 @@ class Shape(object):
         args: Iterable["Shape"],
         tools: Iterable["Shape"],
         op: Union[BRepAlgoAPI_BooleanOperation, BRepAlgoAPI_Splitter],
+        parallel: bool = True,
     ) -> "Shape":
         """
         Generic boolean operation
+
+        :param parallel: Sets the SetRunParallel flag, which enables parallel execution of boolean operations in OCC kernel
         """
 
         arg = TopTools_ListOfShape()
@@ -1048,7 +1051,7 @@ class Shape(object):
         op.SetArguments(arg)
         op.SetTools(tool)
 
-        op.SetRunParallel(True)
+        op.SetRunParallel(parallel)
         op.Build()
 
         return Shape.cast(op.Shape())


### PR DESCRIPTION
Following discussion with  @adam-urbanczyk in #1345, I added the `parallel` parameter to `_bool_op()` in `shapes.py`  to make `SetRunParallel()` easily manageable by `gin_config`.
When `cadquery` is used inside a python script that is using multiprocessing, it can be needed to set the `SetRunParallel()` flag to `False` in order to avoid hanged execution issues.