### PR TITLE
Moved back to version scheme for development

### DIFF
--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -4,7 +4,7 @@ try:
     __version__ = version("cadquery")
 except PackageNotFoundError:
     # package is not installed
-    __version__ = "2.3.1"
+    __version__ = "2.4-dev"
 
 # these items point to the OCC implementation
 from .occ_impl.geom import Plane, BoundBox, Vector, Matrix, Location

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,7 @@ Changes
 =======
 
 2.3.1 (latest release)
+------
 
 This was an incremental release to fix a broken PyPI package.
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if not is_rtd and not is_appveyor and not is_azure and not is_conda:
 
 setup(
     name="cadquery",
-    version="2.3.1",  # Update this for the next release
+    version="2.4.0dev",  # Update this for the next release
     url="https://github.com/CadQuery/cadquery",
     license="Apache Public License 2.0",
     author="David Cowden",


### PR DESCRIPTION
This moves us back to the dev versioning for the next release cycle, and fixes the lack of highlighting of the current version header in the changelog.