### PR TITLE
correcting typos and duplicate ipython

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -44,7 +44,7 @@ ExportLiterals = Literal["STEP", "XML", "GLTF", "VTKJS", "VRML", "STL"]
 
 PATH_DELIM = "/"
 
-# entity selector grammar definiiton
+# entity selector grammar definition
 def _define_grammar():
 
     from pyparsing import (
@@ -385,7 +385,7 @@ class Assembly(object):
                 ] not in locked:
                     locked.append(ents[name])
 
-        # Lock the first occuring entity if needed.
+        # Lock the first occurring entity if needed.
         if not locked:
             unary_objects = [
                 c.objects[0]
@@ -402,7 +402,7 @@ class Assembly(object):
                     locked.append(ents[b])
                     break
 
-        # Lock the first occuring entity if needed.
+        # Lock the first occurring entity if needed.
         if not locked:
             locked.append(0)
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3461,7 +3461,7 @@ class Workplane(object):
         # Handling of `until` passed values
         s: Union[Compound, Solid, Shape]
         if isinstance(both, float) and taper == None:
-            # Because inserting a new paramater "both" in front of "taper",
+            # Because inserting a new parameter "both" in front of "taper",
             # existing code calling this function with position arguments will
             # pass the taper argument (float) to the "both" argument. This
             # warning is to catch that.
@@ -3592,7 +3592,7 @@ class Workplane(object):
         Make a prismatic solid from the existing set of pending wires.
 
         :param distance: distance to extrude
-        :param both: extrude in both directions symetrically
+        :param both: extrude in both directions symmetrically
         :param upToFace: if specified, extrude up to a face: 0 for the next, -1 for the last face
         :param additive: specify if extruding or cutting, required param for uptoface algorithm
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - pytest
   - pytest-cov
   - ezdxf
-  - ipython
   - typing_extensions
   - nptyping=2.0.1
   - nlopt


### PR DESCRIPTION
Many thanks for making Cadquery,

I noticed a few tiny typos while browsing and ```ipython``` occurs twice in the environment.yml file