### PR TITLE
VTK-based show_object

### DIFF
--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -1,5 +1,6 @@
-from . import Shape, Workplane, Assembly, Sketch, Compound
+from . import Shape, Workplane, Assembly, Sketch, Compound, Color
 from .occ_impl.exporters.assembly import _vtkRenderWindow
+from .occ_impl.jupyter_tools import DEFAULT_COLOR
 
 from typing import Union
 
@@ -13,7 +14,7 @@ from vtkmodules.vtkRenderingCore import vtkMapper, vtkRenderWindowInteractor
 
 def _to_assy(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> Assembly:
 
-    assy = Assembly()
+    assy = Assembly(color=Color(*DEFAULT_COLOR))
 
     for obj in objs:
         if isinstance(obj, (Shape, Workplane, Assembly)):
@@ -56,8 +57,6 @@ def show(*objs: Union[Shape, Workplane, Assembly, Sketch]):
 
     # construct an axes indicator
     axes = vtkAxesActor()
-    axes.SetNormalizedShaftLength(1, 1, 1)
-    axes.SetTotalLength(10, 10, 10)
     axes.SetDragable(0)
 
     tp = axes.GetXAxisCaptionActor2D().GetCaptionTextProperty()
@@ -75,9 +74,20 @@ def show(*objs: Union[Shape, Workplane, Assembly, Sketch]):
     orient_widget.EnabledOn()
     orient_widget.InteractiveOff()
 
-    # set sie, show and return
+    # use gradient background
+    renderer = win.GetRenderers().GetFirstRenderer()
+    renderer.GradientBackgroundOn()
+
+    # set size and camera
     win.SetSize(*win.GetScreenSize())
     win.SetPosition(-10, 0)
+
+    camera = renderer.GetActiveCamera()
+    camera.Roll(-35)
+    camera.Elevation(-45)
+    camera.SetClippingRange(0.1, 100)
+
+    # show and return
     inter.Initialize()
     win.Render()
     inter.Start()

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -1,0 +1,93 @@
+from . import Shape, Workplane, Assembly, Sketch, Compound
+from .occ_impl.exporters.assembly import _vtkRenderWindow
+
+from typing import Union
+
+from OCP.TopoDS import TopoDS_Shape
+
+from vtkmodules.vtkInteractionWidgets import vtkOrientationMarkerWidget
+from vtkmodules.vtkRenderingAnnotation import vtkAxesActor
+from vtkmodules.vtkInteractionStyle import vtkInteractorStyleTrackballCamera
+from vtkmodules.vtkRenderingCore import (
+    vtkMapper,
+    vtkRenderWindowInteractor,
+    vtkRenderWindow,
+)
+
+
+def _to_assy(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> Assembly:
+
+    assy = Assembly()
+
+    for obj in objs:
+        if isinstance(obj, (Shape, Workplane, Assembly)):
+            assy.add(obj)
+        elif isinstance(obj, Sketch):
+            assy.add(obj._faces)
+            assy.add(Compound.makeCompound(obj._edges))
+            assy.add(Compound.makeCompound(obj._wires))
+        elif isinstance(obj, TopoDS_Shape):
+            assy.add(Shape(obj))
+        else:
+            raise ValueError(f"{obj} has unsupported type {type(obj)}")
+
+    return assy
+
+
+def show(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> vtkRenderWindow:
+    """
+    Show CQ objects using VTK
+    """
+
+    # construct the assy
+    assy = _to_assy(*objs)
+
+    # create a VTK window
+    win = _vtkRenderWindow(assy)
+
+    win.SetWindowName("CQ viewer")
+
+    # rendering related settings
+    win.SetMultiSamples(16)
+    vtkMapper.SetResolveCoincidentTopologyToPolygonOffset()
+    vtkMapper.SetResolveCoincidentTopologyPolygonOffsetParameters(1, 0)
+    vtkMapper.SetResolveCoincidentTopologyLineOffsetParameters(-1, 0)
+
+    # create a VTK interactor
+    inter = vtkRenderWindowInteractor()
+    inter.SetInteractorStyle(vtkInteractorStyleTrackballCamera())
+    inter.SetRenderWindow(win)
+
+    # construct an axes indicator
+    axes = vtkAxesActor()
+    axes.SetNormalizedShaftLength(1, 1, 1)
+    axes.SetTotalLength(10, 10, 10)
+    axes.SetDragable(0)
+
+    tp = axes.GetXAxisCaptionActor2D().GetCaptionTextProperty()
+    tp.SetColor(0, 0, 0)
+
+    axes.GetYAxisCaptionActor2D().GetCaptionTextProperty().ShallowCopy(tp)
+    axes.GetZAxisCaptionActor2D().GetCaptionTextProperty().ShallowCopy(tp)
+
+    # add to an orientation widget
+    orient_widget = vtkOrientationMarkerWidget()
+    orient_widget.SetOrientationMarker(axes)
+    orient_widget.SetViewport(0.9, 0.0, 1.0, 0.2)
+    orient_widget.SetZoom(1.1)
+    orient_widget.SetInteractor(inter)
+    orient_widget.EnabledOn()
+    orient_widget.InteractiveOff()
+
+    # set sie, show and return
+    win.SetSize(*win.GetScreenSize())
+    win.SetPosition(-10, 0)
+    inter.Initialize()
+    win.Render()
+    inter.Start()
+
+    return win
+
+
+# alias
+show_object = show

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -8,11 +8,7 @@ from OCP.TopoDS import TopoDS_Shape
 from vtkmodules.vtkInteractionWidgets import vtkOrientationMarkerWidget
 from vtkmodules.vtkRenderingAnnotation import vtkAxesActor
 from vtkmodules.vtkInteractionStyle import vtkInteractorStyleTrackballCamera
-from vtkmodules.vtkRenderingCore import (
-    vtkMapper,
-    vtkRenderWindowInteractor,
-    vtkRenderWindow,
-)
+from vtkmodules.vtkRenderingCore import vtkMapper, vtkRenderWindowInteractor
 
 
 def _to_assy(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> Assembly:

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -85,7 +85,7 @@ def show(*objs: Union[Shape, Workplane, Assembly, Sketch]):
     camera = renderer.GetActiveCamera()
     camera.Roll(-35)
     camera.Elevation(-45)
-    camera.SetClippingRange(0.1, 100)
+    renderer.ResetCamera()
 
     # show and return
     inter.Initialize()

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -34,7 +34,7 @@ def _to_assy(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> Assembly:
     return assy
 
 
-def show(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> vtkRenderWindow:
+def show(*objs: Union[Shape, Workplane, Assembly, Sketch]):
     """
     Show CQ objects using VTK
     """
@@ -85,8 +85,6 @@ def show(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> vtkRenderWindow:
     inter.Initialize()
     win.Render()
     inter.Start()
-
-    return win
 
 
 # alias

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,7 +1,10 @@
 from cadquery import Workplane, Assembly, Sketch
 from cadquery.vis import show, show_object
 
+import cadquery.occ_impl.exporters.assembly as assembly
 import cadquery.vis as vis
+
+from vtkmodules.vtkRenderingCore import vtkRenderWindow, vtkRenderWindowInteractor
 
 from pytest import fixture, raises
 
@@ -24,12 +27,8 @@ def sk():
     return Sketch().circle(1.0)
 
 
-class FakeInteractor:
-    def SetInteractorStyle(self, x):
-
-        pass
-
-    def SetRenderWindow(self, x):
+class FakeInteractor(vtkRenderWindowInteractor):
+    def Start(self):
 
         pass
 
@@ -37,33 +36,9 @@ class FakeInteractor:
 
         pass
 
-    def Start(self):
 
-        pass
-
-
-class FakeOrientationWidget:
-    def SetOrientationMarker(*args):
-
-        pass
-
-    def SetViewport(*args):
-
-        pass
-
-    def SetZoom(*args):
-
-        pass
-
-    def SetInteractor(*args):
-
-        pass
-
-    def EnabledOn(*args):
-
-        pass
-
-    def InteractiveOff(*args):
+class FakeWindow(vtkRenderWindow):
+    def Render(*args):
 
         pass
 
@@ -72,7 +47,7 @@ def test_show(wp, assy, sk, monkeypatch):
 
     # use some dummy vtk objects
     monkeypatch.setattr(vis, "vtkRenderWindowInteractor", FakeInteractor)
-    monkeypatch.setattr(vis, "vtkOrientationMarkerWidget", FakeOrientationWidget)
+    monkeypatch.setattr(assembly, "vtkRenderWindow", FakeWindow)
 
     # simple smoke test
     show(wp)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,0 +1,96 @@
+from cadquery import Workplane, Assembly, Sketch
+from cadquery.vis import show, show_object
+
+import cadquery.vis as vis
+
+from pytest import fixture, raises
+
+
+@fixture
+def wp():
+
+    return Workplane().box(1, 1, 1)
+
+
+@fixture
+def assy(wp):
+
+    return Assembly().add(wp)
+
+
+@fixture
+def sk():
+
+    return Sketch().circle(1.0)
+
+
+class FakeInteractor:
+    def SetInteractorStyle(self, x):
+
+        pass
+
+    def SetRenderWindow(self, x):
+
+        pass
+
+    def Initialize(self):
+
+        pass
+
+    def Start(self):
+
+        pass
+
+
+class FakeOrientationWidget:
+    def SetOrientationMarker(*args):
+
+        pass
+
+    def SetViewport(*args):
+
+        pass
+
+    def SetZoom(*args):
+
+        pass
+
+    def SetInteractor(*args):
+
+        pass
+
+    def EnabledOn(*args):
+
+        pass
+
+    def InteractiveOff(*args):
+
+        pass
+
+
+def test_show(wp, assy, sk, monkeypatch):
+
+    # use some dummy vtk objects
+    monkeypatch.setattr(vis, "vtkRenderWindowInteractor", FakeInteractor)
+    monkeypatch.setattr(vis, "vtkOrientationMarkerWidget", FakeOrientationWidget)
+
+    # simple smoke test
+    show(wp)
+    show(wp.val())
+    show(assy)
+    show(sk)
+    show(wp, sk, assy, wp.val())
+    show()
+
+    with raises(ValueError):
+        show(1)
+
+    show_object(wp)
+    show_object(wp.val())
+    show_object(assy)
+    show_object(sk)
+    show_object(wp, sk, assy, wp.val())
+    show_object()
+
+    with raises(ValueError):
+        show_object("a")

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -42,6 +42,18 @@ class FakeWindow(vtkRenderWindow):
 
         pass
 
+    def SetSize(*args):
+
+        pass
+
+    def GetScreenSize(*args):
+
+        return 1, 1
+
+    def SetPosition(*args):
+
+        pass
+
 
 def test_show(wp, assy, sk, monkeypatch):
 


### PR DESCRIPTION
Useful for developing CQ itself, debugging and quick checking. Usage:
```
from cadquery.vis import show

show(cq.Workplane().box(1,1,1)
```

Can display all CQ objects and TopoDS_Shape form OCP.
![afbeelding](https://github.com/CadQuery/cadquery/assets/13981538/8733db51-8d3a-462f-b4d0-ee73a7e10ad9)
