### PR TITLE
Add Tuple support to CQGI

### DIFF
--- a/cadquery/cqgi.py
+++ b/cadquery/cqgi.py
@@ -313,7 +313,7 @@ class InputParameter:
             self.ast_node.elts = [
                 ast.Constant(value=new_value[0]),
                 ast.Constant(value=new_value[1]),
-                ast.Constant(value=new_value[2])
+                ast.Constant(value=new_value[2]),
             ]
             ast.fix_missing_locations(self.ast_node)
         else:
@@ -517,10 +517,10 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
                     )
             elif type(value_node) == ast.Tuple:
                 self.cqModel.add_script_parameter(
-                        InputParameter.create(
-                            value_node, var_name, TupleParameterType, (0, 0, 0)
-                        )
+                    InputParameter.create(
+                        value_node, var_name, TupleParameterType, (0, 0, 0)
                     )
+                )
             elif hasattr(ast, "NameConstant") and type(value_node) == ast.NameConstant:
                 if value_node.value == True:
                     self.cqModel.add_script_parameter(

--- a/cadquery/cqgi.py
+++ b/cadquery/cqgi.py
@@ -520,14 +520,11 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
                 # Handle multi-length tuples
                 tup = ()
                 for entry in value_node.elts:
-                    tup = tup + (entry.value, )
+                    tup = tup + (entry.value,)
 
                 self.cqModel.add_script_parameter(
                     InputParameter.create(
-                        value_node,
-                        var_name,
-                        TupleParameterType,
-                        tup,
+                        value_node, var_name, TupleParameterType, tup,
                     )
                 )
             elif hasattr(ast, "NameConstant") and type(value_node) == ast.NameConstant:

--- a/cadquery/cqgi.py
+++ b/cadquery/cqgi.py
@@ -518,7 +518,14 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
             elif type(value_node) == ast.Tuple:
                 self.cqModel.add_script_parameter(
                     InputParameter.create(
-                        value_node, var_name, TupleParameterType, (0, 0, 0)
+                        value_node,
+                        var_name,
+                        TupleParameterType,
+                        (
+                            value_node.elts[0].value,
+                            value_node.elts[1].value,
+                            value_node.elts[2].value,
+                        ),
                     )
                 )
             elif hasattr(ast, "NameConstant") and type(value_node) == ast.NameConstant:

--- a/cadquery/cqgi.py
+++ b/cadquery/cqgi.py
@@ -219,6 +219,10 @@ class BooleanParameterType(ParameterType):
     pass
 
 
+class TupleParameterType(ParameterType):
+    pass
+
+
 class InputParameter:
     """
     Defines a parameter that can be supplied when the model is executed.
@@ -304,6 +308,14 @@ class InputParameter:
                     self.ast_node.value = False
                 else:
                     self.ast_node.id = "False"
+        elif self.varType == TupleParameterType:
+            self.ast_node.n = new_value
+            self.ast_node.elts = [
+                ast.Constant(value=new_value[0]),
+                ast.Constant(value=new_value[1]),
+                ast.Constant(value=new_value[2])
+            ]
+            ast.fix_missing_locations(self.ast_node)
         else:
             raise ValueError("Unknown Type of var: ", str(self.varType))
 
@@ -478,7 +490,6 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
 
     def handle_assignment(self, var_name, value_node):
         try:
-
             if type(value_node) == ast.Num:
                 self.cqModel.add_script_parameter(
                     InputParameter.create(
@@ -504,6 +515,12 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
                             value_node, var_name, BooleanParameterType, False
                         )
                     )
+            elif type(value_node) == ast.Tuple:
+                self.cqModel.add_script_parameter(
+                        InputParameter.create(
+                            value_node, var_name, TupleParameterType, (0, 0, 0)
+                        )
+                    )
             elif hasattr(ast, "NameConstant") and type(value_node) == ast.NameConstant:
                 if value_node.value == True:
                     self.cqModel.add_script_parameter(
@@ -525,6 +542,7 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
                     str: StringParameterType,
                     float: NumberParameterType,
                     int: NumberParameterType,
+                    tuple: TupleParameterType,
                 }
 
                 self.cqModel.add_script_parameter(
@@ -561,8 +579,7 @@ class ConstantAssignmentFinder(ast.NodeTransformer):
                 self.handle_assignment(left_side.id, node.value)
             elif type(node.value) == ast.Tuple:
                 if isinstance(left_side, ast.Name):
-                    # skip unsupported parameter type
-                    pass
+                    self.handle_assignment(left_side.id, node.value)
                 else:
                     # we have a multi-value assignment
                     for n, v in zip(left_side.elts, node.value.elts):

--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -16,9 +16,10 @@ TESTSCRIPT = textwrap.dedent(
         height=2.0
         width=3.0
         (a,b) = (1.0,1.0)
+        o = (2, 2, 0)
         foo="bar"
 
-        result =  "%s|%s|%s|%s" % ( str(height) , str(width) , foo , str(a) )
+        result =  "%s|%s|%s|%s|%s" % ( str(height) , str(width) , foo , str(a) , str(o) )
         show_object(result)
     """
 )
@@ -28,9 +29,10 @@ TEST_DEBUG_SCRIPT = textwrap.dedent(
         height=2.0
         width=3.0
         (a,b) = (1.0,1.0)
+        o = (2, 2, 0)
         foo="bar"
         debug(foo, { "color": 'yellow' } )
-        result =  "%s|%s|%s|%s" % ( str(height) , str(width) , foo , str(a) )
+        result =  "%s|%s|%s|%s|%s" % ( str(height) , str(width) , foo , str(a) , str(o) )
         show_object(result)
         debug(height )
     """
@@ -41,9 +43,8 @@ class TestCQGI(BaseTest):
     def test_parser(self):
         model = cqgi.CQModel(TESTSCRIPT)
         metadata = model.metadata
-
         self.assertEqual(
-            set(metadata.parameters.keys()), {"height", "width", "a", "b", "foo"}
+            set(metadata.parameters.keys()), {"height", "width", "a", "b", "foo", "o"}
         )
 
     def test_build_with_debug(self):
@@ -62,12 +63,13 @@ class TestCQGI(BaseTest):
 
         self.assertTrue(result.success)
         self.assertTrue(len(result.results) == 1)
-        self.assertTrue(result.results[0].shape == "2.0|3.0|bar|1.0")
+        self.assertTrue(result.results[0].shape == "2.0|3.0|bar|1.0|(2, 2, 0)")
 
     def test_build_with_different_params(self):
         model = cqgi.CQModel(TESTSCRIPT)
-        result = model.build({"height": 3.0})
-        self.assertTrue(result.results[0].shape == "3.0|3.0|bar|1.0")
+        result = model.build({"height": 3.0, "o": (3, 3, 1)})
+        print(result.results[0].shape)
+        self.assertTrue(result.results[0].shape == "3.0|3.0|bar|1.0|(3, 3, 1)")
 
     def test_describe_parameters(self):
         script = textwrap.dedent(

--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -7,6 +7,7 @@
        defining a build_object function to return results
 """
 
+import pytest
 from cadquery import cqgi
 from tests import BaseTest
 import textwrap
@@ -230,3 +231,20 @@ class TestCQGI(BaseTest):
         model = cqgi.parse(script)
 
         self.assertEqual(2, len(model.metadata.parameters))
+
+
+    def test_invalid_parameter_type(self):
+        """Contrived test in case a parameter type that is not valid for InputParameter sneaks through."""
+
+        # Made up parameter class
+        class UnknowParameter:
+            def __init__():
+                return 1
+
+        # Set up the most basic InputParameter object that is possible
+        p = cqgi.InputParameter()
+        p.varType = UnknowParameter
+
+        # Setting the parameter should throw an unknown parameter type error
+        with pytest.raises(ValueError) as info:
+            p.set_value(2)

--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -71,6 +71,12 @@ class TestCQGI(BaseTest):
         print(result.results[0].shape)
         self.assertTrue(result.results[0].shape == "3.0|3.0|bar|1.0|(3, 3)")
 
+    def test_build_with_nested_tuple_params(self):
+        model = cqgi.CQModel(TESTSCRIPT)
+        result = model.build({"height": 3.0, "o": ((2, 2), (3, 3))})
+        print(result.results[0].shape)
+        self.assertTrue(result.results[0].shape == "3.0|3.0|bar|1.0|((2, 2), (3, 3))")
+
     def test_describe_parameters(self):
         script = textwrap.dedent(
             """

--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -67,9 +67,9 @@ class TestCQGI(BaseTest):
 
     def test_build_with_different_params(self):
         model = cqgi.CQModel(TESTSCRIPT)
-        result = model.build({"height": 3.0, "o": (3, 3, 1)})
+        result = model.build({"height": 3.0, "o": (3, 3)})
         print(result.results[0].shape)
-        self.assertTrue(result.results[0].shape == "3.0|3.0|bar|1.0|(3, 3, 1)")
+        self.assertTrue(result.results[0].shape == "3.0|3.0|bar|1.0|(3, 3)")
 
     def test_describe_parameters(self):
         script = textwrap.dedent(

--- a/tests/test_cqgi.py
+++ b/tests/test_cqgi.py
@@ -232,7 +232,6 @@ class TestCQGI(BaseTest):
 
         self.assertEqual(2, len(model.metadata.parameters))
 
-
     def test_invalid_parameter_type(self):
         """Contrived test in case a parameter type that is not valid for InputParameter sneaks through."""
 


### PR DESCRIPTION
Closes #1370 

Missing Tuple support was mentioned in [this commit](https://github.com/CadQuery/cadquery/pull/1367/commits/57d815a6ac8db983237627a060124c1e9d49468e). @lorenzncode Are there changes that need to be made in this PR to recapture your original intent from #1367 ?