### PR TITLE
Shape iterator improvements

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -862,7 +862,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains  the *distinct* vertices of *all* objects on the
+        :return: a CQ object whose stack contains  the *distinct* vertices of *all* objects on the
             current stack, after being filtered by the selector, if provided
 
         If there are no vertices for any objects on the current stack, an empty CQ object
@@ -896,7 +896,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains all of the *distinct* faces of *all* objects on
+        :return: a CQ object whose stack contains all of the *distinct* faces of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no faces for any objects on the current stack, an empty CQ object
@@ -931,7 +931,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains all of the *distinct* edges of *all* objects on
+        :return: a CQ object whose stack contains all of the *distinct* edges of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no edges for any objects on the current stack, an empty CQ object is returned
@@ -965,7 +965,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains all of the *distinct* wires of *all* objects on
+        :return: a CQ object whose stack contains all of the *distinct* wires of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no wires for any objects on the current stack, an empty CQ object is returned
@@ -991,7 +991,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains all of the *distinct* solids of *all* objects on
+        :return: a CQ object whose stack contains all of the *distinct* solids of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no solids for any objects on the current stack, an empty CQ object is returned
@@ -1020,7 +1020,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains all of the *distinct* shells of *all* objects on
+        :return: a CQ object whose stack contains all of the *distinct* shells of *all* objects on
             the current stack, filtered by the provided selector.
 
         If there are no shells for any objects on the current stack, an empty CQ object is returned
@@ -1043,7 +1043,7 @@ class Workplane(object):
         :param selector: optional Selector object, or string selector expression
             (see :class:`StringSyntaxSelector`)
         :param tag: if set, search the tagged object instead of self
-        :return: a CQ object who's stack contains all of the *distinct* compounds of *all* objects on
+        :return: a CQ object whose stack contains all of the *distinct* compounds of *all* objects on
             the current stack, filtered by the provided selector.
 
         A compound contains multiple CAD primitives that resulted from a single operation, such as

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -243,7 +243,8 @@ class Workplane(object):
         on it.  This is meant to be a reference to the most recently modified version
         of the context solid, whatever it is.
         """
-        rv = set()
+        rv: Dict[CQObject, Any] = {}  # used as an ordered set
+
         for o in self.objects:
 
             # tricky-- if an object is a compound of solids,
@@ -254,12 +255,14 @@ class Workplane(object):
                 and isinstance(o, Solid)
                 and o.ShapeType() == "Compound"
             ):
-                rv.update(getattr(o, "Compounds")())
+                for k in getattr(o, "Compounds")():
+                    rv[k] = None
             else:
                 if hasattr(o, propName):
-                    rv.update(getattr(o, propName)())
+                    for k in getattr(o, propName)():
+                        rv[k] = None
 
-        return list(rv)
+        return list(rv.keys())
 
     @overload
     def split(self: T, keepTop: bool = False, keepBottom: bool = False) -> T:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1053,11 +1053,11 @@ class Workplane(object):
 
     def ancestors(self: T, kind: Shapes, tag: Optional[str] = None) -> T:
         """
-        Iterate over ancestors.
+        Select topological ancestors.
 
         :param kind: kind of ancestor, e.g. "Face" or "Edge"
         :param tag: if set, search the tagged object instead of self
-        :return: a Workplane object who's stack contains all ancestors.
+        :return: a Workplane object whose stack contains selected ancestors.
 
 
         """
@@ -1072,12 +1072,12 @@ class Workplane(object):
 
     def siblings(self: T, kind: Shapes, level: int = 1, tag: Optional[str] = None) -> T:
         """
-        Iterate over siblings.
+        Select topological siblings.
 
         :param kind: kind of linking element, e.g. "Vertex" or "Edge"
         :param level: level of relation - how many elements of kind are in the link
         :param tag: if set, search the tagged object instead of self
-        :return: a Workplane object who's stack contains all ancestors.
+        :return: a Workplane object whose stack contains selected siblings.
 
         """
         ctx_solid = self.findSolid()

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1062,7 +1062,7 @@ class Workplane(object):
             el.ancestors(ctx_solid, kind) for el in objects if isinstance(el, Shape)
         ]
 
-        return self.newObject(el for res in results for el in res)
+        return self.newObject(set(el for res in results for el in res))
 
     def siblings(self: T, kind, level: int = 1, tag: Optional[str] = None) -> T:
         """
@@ -1071,14 +1071,11 @@ class Workplane(object):
         """
         ctx_solid = self.findSolid()
         objects = self._getTagged(tag).objects if tag else self.objects
+        shapes = [el for el in objects if isinstance(el, Shape)]
 
-        results = [
-            el.siblings(ctx_solid, kind, level)
-            for el in objects
-            if isinstance(el, Shape)
-        ]
+        results = [el.siblings(ctx_solid, kind, level) for el in shapes]
 
-        return self.newObject(el for res in results for el in res)
+        return self.newObject(set(el for res in results for el in res) - set(shapes))
 
     def toSvg(self, opts: Any = None) -> str:
         """

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -47,6 +47,7 @@ from .occ_impl.shapes import (
     Solid,
     Compound,
     wiresToFaces,
+    Shapes,
 )
 
 from .occ_impl.exporters.svg import getSVG, exportSVG
@@ -1050,9 +1051,14 @@ class Workplane(object):
         """
         return self._selectObjects("Compounds", selector, tag)
 
-    def ancestors(self: T, kind, tag: Optional[str] = None) -> T:
+    def ancestors(self: T, kind: Shapes, tag: Optional[str] = None) -> T:
         """
         Iterate over ancestors.
+
+        :param kind: kind of ancestor, e.g. "Face" or "Edge"
+        :param tag: if set, search the tagged object instead of self
+        :return: a Workplane object who's stack contains all ancestors.
+
 
         """
         ctx_solid = self.findSolid()
@@ -1064,9 +1070,14 @@ class Workplane(object):
 
         return self.newObject(set(el for res in results for el in res))
 
-    def siblings(self: T, kind, level: int = 1, tag: Optional[str] = None) -> T:
+    def siblings(self: T, kind: Shapes, level: int = 1, tag: Optional[str] = None) -> T:
         """
         Iterate over siblings.
+
+        :param kind: kind of linking element, e.g. "Vertex" or "Edge"
+        :param level: level of relation - how many elements of kind are in the link
+        :param tag: if set, search the tagged object instead of self
+        :return: a Workplane object who's stack contains all ancestors.
 
         """
         ctx_solid = self.findSolid()

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 
 from ...cq import Face, Plane, Workplane
 from ...units import RAD2DEG
-from ..shapes import Edge
+from ..shapes import Edge, Shape, Compound
 from .utils import toCompound
 
 ApproxOptions = Literal["spline", "arc"]
@@ -139,7 +139,8 @@ class DxfDocument:
 
         if self.approx == "spline":
             edges = [
-                e.toSplines() if e.geomType() == "BSPLINE" else e for e in shape.Edges()
+                e.toSplines() if e.geomType() == "BSPLINE" else e
+                for e in self._ordered_edges(shape)
             ]
 
         elif self.approx == "arc":
@@ -147,10 +148,12 @@ class DxfDocument:
 
             # this is needed to handle free wires
             for el in shape.Wires():
-                edges.extend(Face.makeFromWires(el).toArcs(self.tolerance).Edges())
+                edges.extend(
+                    self._ordered_edges(Face.makeFromWires(el).toArcs(self.tolerance))
+                )
 
         else:
-            edges = shape.Edges()
+            edges = self._ordered_edges(shape)
 
         for edge in edges:
             converter = self._DISPATCH_MAP.get(edge.geomType(), None)
@@ -171,6 +174,21 @@ class DxfDocument:
         zoom.extents(self.msp)
 
         return self
+
+    @staticmethod
+    def _ordered_edges(s: Shape) -> List[Edge]:
+
+        rv: List[Edge] = []
+
+        # iterato over wires and then edges
+        for w in s.Wires():
+            rv.extend(w)
+
+        # add free edges
+        if isinstance(s, Compound):
+            rv.extend(e for e in s if isinstance(e, Edge))
+
+        return rv
 
     @staticmethod
     def _dxf_line(edge: Edge) -> DxfEntityAttributes:

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -181,7 +181,7 @@ class DxfDocument:
 
         rv: List[Edge] = []
 
-        # iterato over wires and then edges
+        # iterate over wires and then edges
         for w in s.Wires():
             rv.extend(w)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3723,14 +3723,15 @@ class Compound(Shape, Mixin3D):
         """
 
         shape_map = TopTools_IndexedDataMapOfShapeListOfShape()
+        shapetypes = set(shapetype(ch.wrapped) for ch in self)
 
-        for ch in self:
+        for t in shapetypes:
             TopExp.MapShapesAndAncestors_s(
-                shape.wrapped, shapetype(ch.wrapped), inverse_shape_LUT[kind], shape_map
+                shape.wrapped, t, inverse_shape_LUT[kind], shape_map
             )
 
         return Compound.makeCompound(
-            Shape.cast(s) for s in shape_map.FindFromKey(self.wrapped)
+            Shape.cast(a) for s in self for a in shape_map.FindFromKey(s.wrapped)
         )
 
     def siblings(self, shape: "Shape", kind: Shapes, level: int = 1) -> "Compound":
@@ -3740,13 +3741,13 @@ class Compound(Shape, Mixin3D):
         """
 
         shape_map = TopTools_IndexedDataMapOfShapeListOfShape()
+        shapetypes = set(shapetype(ch.wrapped) for ch in self)
 
-        TopExp.MapShapesAndAncestors_s(
-            shape.wrapped,
-            inverse_shape_LUT[kind],
-            shapetype(next(iter(self)).wrapped),
-            shape_map,
-        )
+        for t in shapetypes:
+            TopExp.MapShapesAndAncestors_s(
+                shape.wrapped, inverse_shape_LUT[kind], t, shape_map,
+            )
+
         exclude = TopTools_MapOfShape()
 
         def _siblings(shapes, level):
@@ -3757,7 +3758,6 @@ class Compound(Shape, Mixin3D):
                 exclude.Add(s.wrapped)
 
             for s in shapes:
-
                 rv.update(
                     Shape.cast(el)
                     for child in s._entities(kind)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -162,7 +162,6 @@ from OCP.TopTools import (
     TopTools_MapOfShape,
 )
 
-from OCP.TopExp import TopExp
 
 from OCP.ShapeFix import ShapeFix_Shape, ShapeFix_Solid, ShapeFix_Face
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1376,34 +1376,34 @@ class Shape(object):
 
     def ancestors(self, shape: "Shape", kind: Shapes) -> Iterator["Shape"]:
         """
-        Iterate over ancestors, i.e. shapes of kind within self that contain shape.
+        Iterate over ancestors, i.e. shapes of same kind within shape that contain self.
 
         """
 
         shape_map = TopTools_IndexedDataMapOfShapeListOfShape()
 
         TopExp.MapShapesAndAncestors_s(
-            self.wrapped, shapetype(shape.wrapped), inverse_shape_LUT[kind], shape_map
+            shape.wrapped, shapetype(self.wrapped), inverse_shape_LUT[kind], shape_map
         )
 
-        for s in shape_map.FindFromKey(shape.wrapped):
+        for s in shape_map.FindFromKey(self.wrapped):
             yield Shape.cast(s)
 
     def siblings(self, shape: "Shape", kind: Shapes) -> Iterator["Shape"]:
         """
-        Iterate over siblings, i.e. shapes within self that share subshapes of kind with shape.
+        Iterate over siblings, i.e. shapes within shape that share subshapes of kind with self.
 
         """
 
         shape_map = TopTools_IndexedDataMapOfShapeListOfShape()
 
         TopExp.MapShapesAndAncestors_s(
-            self.wrapped, inverse_shape_LUT[kind], shapetype(shape.wrapped), shape_map
+            shape.wrapped, inverse_shape_LUT[kind], shapetype(self.wrapped), shape_map
         )
 
-        for child in shape._entities(kind):
+        for child in self._entities(kind):
             for s in shape_map.FindFromKey(child):
-                if not shape.wrapped.IsSame(s):
+                if not self.wrapped.IsSame(s):
                     yield Shape.cast(s)
 
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -173,7 +173,7 @@ from OCP.StlAPI import StlAPI_Writer
 
 from OCP.ShapeUpgrade import ShapeUpgrade_UnifySameDomain
 
-from OCP.BRepTools import BRepTools
+from OCP.BRepTools import BRepTools, BRepTools_WireExplorer
 
 from OCP.LocOpe import LocOpe_DPrism
 
@@ -545,9 +545,9 @@ class Shape(object):
         The return values depend on the type of the shape:
 
         | Vertex:  always 'Vertex'
-        | Edge:   LINE, CIRCLE, ELLIPSE, HYPERBOLA, PARABOLA, BEZIER, 
+        | Edge:   LINE, CIRCLE, ELLIPSE, HYPERBOLA, PARABOLA, BEZIER,
         |         BSPLINE, OFFSET, OTHER
-        | Face:   PLANE, CYLINDER, CONE, SPHERE, TORUS, BEZIER, BSPLINE, 
+        | Face:   PLANE, CYLINDER, CONE, SPHERE, TORUS, BEZIER, BSPLINE,
         |         REVOLUTION, EXTRUSION, OFFSET, OTHER
         | Solid:  'Solid'
         | Shell:  'Shell'
@@ -1056,7 +1056,7 @@ class Shape(object):
     def cut(self, *toCut: "Shape", tol: Optional[float] = None) -> "Shape":
         """
         Remove the positional arguments from this Shape.
-        
+
         :param tol: Fuzzy mode tolerance
         """
 
@@ -1091,7 +1091,7 @@ class Shape(object):
     def intersect(self, *toIntersect: "Shape", tol: Optional[float] = None) -> "Shape":
         """
         Intersection of the positional arguments and this Shape.
-        
+
         :param tol: Fuzzy mode tolerance
         """
 
@@ -2251,6 +2251,18 @@ class Wire(Shape, Mixin1D):
         f = Face.makeFromWires(self)
 
         return f.chamfer2D(d, vertices).outerWire()
+
+    def __iter__(self) -> Iterator[Edge]:
+        """
+        Iterate over subshapes.
+
+        """
+
+        exp = BRepTools_WireExplorer(self.wrapped)
+
+        while exp.Current():
+            yield Edge(exp.Current())
+            exp.Next()
 
 
 class Face(Shape):
@@ -3595,7 +3607,7 @@ class Compound(Shape, Mixin3D):
     def cut(self, *toCut: "Shape", tol: Optional[float] = None) -> "Compound":
         """
         Remove the positional arguments from this Shape.
-        
+
         :param tol: Fuzzy mode tolerance
         """
 
@@ -3636,7 +3648,7 @@ class Compound(Shape, Mixin3D):
     ) -> "Compound":
         """
         Intersection of the positional arguments and this Shape.
-        
+
         :param tol: Fuzzy mode tolerance
         """
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1353,6 +1353,18 @@ class Shape(object):
 
         return display(self)._repr_javascript_()
 
+    def __iter__(self) -> Iterator["Shape"]:
+        """
+        Iterate over subshapes.
+
+        """
+
+        it = TopoDS_Iterator(self.wrapped)
+
+        while it.More():
+            yield Shape.cast(it.Value())
+            it.Next()
+
 
 class ShapeProtocol(Protocol):
     @property
@@ -3584,18 +3596,6 @@ class Compound(Shape, Mixin3D):
             rv = text_flat.transformShape(position.rG)
 
         return rv
-
-    def __iter__(self) -> Iterator[Shape]:
-        """
-        Iterate over subshapes.
-
-        """
-
-        it = TopoDS_Iterator(self.wrapped)
-
-        while it.More():
-            yield Shape.cast(it.Value())
-            it.Next()
 
     def __bool__(self) -> bool:
         """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3740,8 +3740,12 @@ class Compound(Shape, Mixin3D):
         """
 
         shape_map = TopTools_IndexedDataMapOfShapeListOfShape()
+
         TopExp.MapShapesAndAncestors_s(
-            shape.wrapped, inverse_shape_LUT[kind], shapetype(self.wrapped), shape_map,
+            shape.wrapped,
+            inverse_shape_LUT[kind],
+            shapetype(next(iter(self)).wrapped),
+            shape_map,
         )
         exclude = TopTools_MapOfShape()
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1403,7 +1403,8 @@ class Shape(object):
 
         for child in shape._entities(kind):
             for s in shape_map.FindFromKey(child):
-                yield Shape.cast(s)
+                if not shape.wrapped.IsSame(s):
+                    yield Shape.cast(s)
 
 
 class ShapeProtocol(Protocol):

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2254,7 +2254,7 @@ class Wire(Shape, Mixin1D):
 
     def __iter__(self) -> Iterator[Edge]:
         """
-        Iterate over subshapes.
+        Iterate over edges in an ordered way.
 
         """
 

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -154,7 +154,7 @@ class Sketch(object):
             res = Face.makeFromWires(b)
         elif isinstance(b, (Sketch, Compound)):
             res = b
-        elif isinstance(b, Iterable):
+        elif isinstance(b, Iterable) and not isinstance(b, Shape):
             wires = edgesToWires(tcast(Iterable[Edge], b))
             res = Face.makeFromWires(*(wires[0], wires[1:]))
         else:

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -142,7 +142,7 @@ It is possible to use user defined vectors as a basis for the selectors. For exa
     result = cq.Workplane("XY").box(10, 10, 10)
 
     # chamfer only one edge
-    result = result.edges('>(-1, 1, 0)').chamfer(1)
+    result = result.edges(">(-1, 1, 0)").chamfer(1)
 
 
 Topological Selectors

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -1,7 +1,7 @@
 .. _selector_reference:
 
-String Selectors Reference
-=============================
+Selectors Reference
+===================
 
 
 CadQuery selector strings allow filtering various types of object lists. Most commonly, Edges, Faces, and Vertices are
@@ -148,3 +148,30 @@ It is possible to use user defined vectors as a basis for the selectors. For exa
 
     # chamfer only one edge
     result = result.edges('>(-1, 1, 0)').chamfer(1)
+
+
+Topological Selectors
+---------------------
+
+Is is also possible to use topological relations to select objects. Currently
+the following methods are supported:
+
+    * :py:meth:`cadquery.Workplane.ancestors`
+    * :py:meth:`cadquery.Workplane.siblings`
+
+Ancestors allows to select all objects containing currently selected object.
+
+.. cadquery::
+
+    result = cq.Workplane("XY").box(10, 10, 10).faces(">Z").edges("<Y")
+
+    result = result.ancestors("Face")
+
+Siblings allows to select all objects of the same type as selection that are connected
+via the specfied kind of elements.
+
+.. cadquery::
+
+    result = cq.Workplane("XY").box(10, 10, 10).faces(">Z")
+
+    result = result.siblings("Edge")

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5563,16 +5563,21 @@ class TestCadQuery(BaseTest):
         # check ancestors
         res1 = list(s.Edges()[0].ancestors(s, "Face"))
         assert len(res1) == 2
+        assert w.faces(">Z").edges(">X").ancestors("Face").size() == 2
+        assert w.faces(">Z").edges(">X or <X").ancestors("Face").size() == 3
 
         # check siblings
         res2 = list(f.siblings(s, "Edge"))
         assert len(res2) == 4
+        assert w.faces(">Z").siblings("Edge").size() == 4
 
         res3 = list(f.siblings(s, "Edge", 2))
         assert len(res3) == 1
+        assert w.faces(">Z").siblings("Edge", 2).size() == 1
 
         res4 = list(f.siblings(s, "Edge").siblings(s, "Edge"))
         assert len(res4) == 2
+        assert w.faces(">Z").siblings("Edge").siblings("Edge").size() == 2
 
         # check regular iterator
         res5 = list(s)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5578,3 +5578,14 @@ class TestCadQuery(BaseTest):
 
         for e1, e2 in zip(edges, edges[1:]):
             assert (e2.startPoint() - e1.endPoint()).Length == approx(0.0)
+
+        # check ancestors on a compound
+        w = Workplane().pushPoints([(0, 0), (2, 0)]).box(1, 1, 1)
+        c = w.val()
+        fs = w.faces(">Z").combine().val()
+
+        res6 = list(fs.ancestors(c, "Solid"))
+        assert len(res6) == 2
+
+        res7 = list(fs.siblings(c, "Edge", 2))
+        assert len(res7) == 2

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5546,3 +5546,27 @@ class TestCadQuery(BaseTest):
 
         assert isinstance(vtk, vtkPolyData)
         assert vtk.GetNumberOfPolys() == 2
+
+    def test_iterators(self):
+
+        s = Workplane().box(1, 1, 1).val()
+
+        # check ancestors
+        res1 = list(s.ancestors(s.Edges()[0], "Face"))
+        assert len(res1) == 2
+
+        # check siblings
+        res2 = list(s.siblings(s.Faces()[0], "Edge"))
+        assert len(res2) == 4
+
+        # check regular iterator
+        res3 = list(s)
+        assert len(res3) == 1
+        assert isinstance(res3[0], Shell)
+
+        # check ordered iteration for wires
+        w = Workplane().polygon(5, 1).val()
+        edges = list(w)
+
+        for e1, e2 in zip(edges, edges[1:]):
+            assert (e2.startPoint() - e1.endPoint()).Length == approx(0.0)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5549,20 +5549,28 @@ class TestCadQuery(BaseTest):
 
     def test_iterators(self):
 
-        s = Workplane().box(1, 1, 1).val()
+        w = Workplane().box(1, 1, 1)
+        s = w.val()
+        f = w.faces(">Z").val()
 
         # check ancestors
         res1 = list(s.Edges()[0].ancestors(s, "Face"))
         assert len(res1) == 2
 
         # check siblings
-        res2 = list(s.Faces()[0].siblings(s, "Edge"))
+        res2 = list(f.siblings(s, "Edge"))
         assert len(res2) == 4
 
-        # check regular iterator
-        res3 = list(s)
+        res3 = list(f.siblings(s, "Edge", 2))
         assert len(res3) == 1
-        assert isinstance(res3[0], Shell)
+
+        res4 = list(f.siblings(s, "Edge").siblings(s, "Edge"))
+        assert len(res4) == 2
+
+        # check regular iterator
+        res5 = list(s)
+        assert len(res5) == 1
+        assert isinstance(res5[0], Shell)
 
         # check ordered iteration for wires
         w = Workplane().polygon(5, 1).val()

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -877,14 +877,14 @@ class TestCadQuery(BaseTest):
                 r1, r2, startAtCurrent=False, angle1=a1, angle2=a2, rotation_angle=ra
             )
         )
-        start = ellipseArc1.vertices().objects[0]
-        end = ellipseArc1.vertices().objects[1]
+        start = ellipseArc1.val().startPoint()
+        end = ellipseArc1.val().endPoint()
 
         self.assertTupleAlmostEquals(
-            (start.X, start.Y), (p0[0] + sx_rot, p0[1] + sy_rot), 3
+            (start.x, start.y), (p0[0] + sx_rot, p0[1] + sy_rot), 3
         )
         self.assertTupleAlmostEquals(
-            (end.X, end.Y), (p0[0] + ex_rot, p0[1] + ey_rot), 3
+            (end.x, end.y), (p0[0] + ex_rot, p0[1] + ey_rot), 3
         )
 
         # startAtCurrent=True, sense = 1
@@ -895,14 +895,14 @@ class TestCadQuery(BaseTest):
                 r1, r2, startAtCurrent=True, angle1=a1, angle2=a2, rotation_angle=ra
             )
         )
-        start = ellipseArc2.vertices().objects[0]
-        end = ellipseArc2.vertices().objects[1]
+        start = ellipseArc2.val().startPoint()
+        end = ellipseArc2.val().endPoint()
 
         self.assertTupleAlmostEquals(
-            (start.X, start.Y), (p0[0] + sx_rot - sx_rot, p0[1] + sy_rot - sy_rot), 3
+            (start.x, start.y), (p0[0] + sx_rot - sx_rot, p0[1] + sy_rot - sy_rot), 3
         )
         self.assertTupleAlmostEquals(
-            (end.X, end.Y), (p0[0] + ex_rot - sx_rot, p0[1] + ey_rot - sy_rot), 3
+            (end.x, end.y), (p0[0] + ex_rot - sx_rot, p0[1] + ey_rot - sy_rot), 3
         )
 
         # startAtCurrent=False, sense = -1
@@ -919,15 +919,15 @@ class TestCadQuery(BaseTest):
                 sense=-1,
             )
         )
-        start = ellipseArc3.vertices().objects[0]
-        end = ellipseArc3.vertices().objects[1]
+        start = ellipseArc3.val().startPoint()
+        end = ellipseArc3.val().endPoint()
 
         # swap start and end points for comparison due to different sense
         self.assertTupleAlmostEquals(
-            (start.X, start.Y), (p0[0] + ex_rot, p0[1] + ey_rot), 3
+            (start.x, start.y), (p0[0] + ex_rot, p0[1] + ey_rot), 3
         )
         self.assertTupleAlmostEquals(
-            (end.X, end.Y), (p0[0] + sx_rot, p0[1] + sy_rot), 3
+            (end.x, end.y), (p0[0] + sx_rot, p0[1] + sy_rot), 3
         )
 
         # startAtCurrent=True, sense = -1
@@ -948,15 +948,15 @@ class TestCadQuery(BaseTest):
 
         self.assertEqual(len(ellipseArc4.ctx.pendingWires), 1)
 
-        start = ellipseArc4.vertices().objects[0]
-        end = ellipseArc4.vertices().objects[1]
+        start = ellipseArc4.val().startPoint()
+        end = ellipseArc4.val().endPoint()
 
         # swap start and end points for comparison due to different sense
         self.assertTupleAlmostEquals(
-            (start.X, start.Y), (p0[0] + ex_rot - ex_rot, p0[1] + ey_rot - ey_rot), 3
+            (start.x, start.y), (p0[0] + ex_rot - ex_rot, p0[1] + ey_rot - ey_rot), 3
         )
         self.assertTupleAlmostEquals(
-            (end.X, end.Y), (p0[0] + sx_rot - ex_rot, p0[1] + sy_rot - ey_rot), 3
+            (end.x, end.y), (p0[0] + sx_rot - ex_rot, p0[1] + sy_rot - ey_rot), 3
         )
 
     def testEllipseArcsClockwise(self):
@@ -5333,33 +5333,40 @@ class TestCadQuery(BaseTest):
 
         a = 1
         # Test triangle
-        vs = Workplane("XY").polygon(3, 2 * a, circumscribed=True).vertices().vals()
+        w = Workplane("XY").polygon(3, 2 * a, circumscribed=True)
+        vs = w.vertices().vals()
+
         self.assertEqual(3, len(vs))
+
         R = circumradius(3, a)
-        self.assertEqual(
-            vs[0].toTuple(), approx((a, a * math.tan(math.radians(60)), 0))
-        )
-        self.assertEqual(vs[1].toTuple(), approx((-R, 0, 0)))
-        self.assertEqual(
-            vs[2].toTuple(), approx((a, -a * math.tan(math.radians(60)), 0))
-        )
+
+        vs0 = w.vertices(">X").vertices(">Y").val()
+        vs1 = w.vertices("<X").val()
+        vs2 = w.vertices(">X").vertices("<Y").val()
+
+        self.assertEqual(vs0.toTuple(), approx((a, a * math.tan(math.radians(60)), 0)))
+        self.assertEqual(vs1.toTuple(), approx((-R, 0, 0)))
+        self.assertEqual(vs2.toTuple(), approx((a, -a * math.tan(math.radians(60)), 0)))
 
         # Test square
-        vs = Workplane("XY").polygon(4, 2 * a, circumscribed=True).vertices().vals()
+        w = Workplane("XY").polygon(4, 2 * a, circumscribed=True)
+        vs = w.vertices().vals()
+
         self.assertEqual(4, len(vs))
+
         R = circumradius(4, a)
+
+        vs0 = w.vertices(">X").vertices(">Y").val()
+        vs1 = w.vertices("<X").vertices(">Y").val()
+        vs2 = w.vertices("<X").vertices("<Y").val()
+        vs3 = w.vertices(">X").vertices("<Y").val()
+
+        self.assertEqual(vs0.toTuple(), approx((a, a * math.tan(math.radians(45)), 0)))
+        self.assertEqual(vs1.toTuple(), approx((-a, a * math.tan(math.radians(45)), 0)))
         self.assertEqual(
-            vs[0].toTuple(), approx((a, a * math.tan(math.radians(45)), 0))
+            vs2.toTuple(), approx((-a, -a * math.tan(math.radians(45)), 0))
         )
-        self.assertEqual(
-            vs[1].toTuple(), approx((-a, a * math.tan(math.radians(45)), 0))
-        )
-        self.assertEqual(
-            vs[2].toTuple(), approx((-a, -a * math.tan(math.radians(45)), 0))
-        )
-        self.assertEqual(
-            vs[3].toTuple(), approx((a, -a * math.tan(math.radians(45)), 0))
-        )
+        self.assertEqual(vs3.toTuple(), approx((a, -a * math.tan(math.radians(45)), 0)))
 
     def test_combineWithBase(self):
         # Test the helper mehod _combinewith

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5552,11 +5552,11 @@ class TestCadQuery(BaseTest):
         s = Workplane().box(1, 1, 1).val()
 
         # check ancestors
-        res1 = list(s.ancestors(s.Edges()[0], "Face"))
+        res1 = list(s.Edges()[0].ancestors(s, "Face"))
         assert len(res1) == 2
 
         # check siblings
-        res2 = list(s.siblings(s.Faces()[0], "Edge"))
+        res2 = list(s.Faces()[0].siblings(s, "Edge"))
         assert len(res2) == 4
 
         # check regular iterator


### PR DESCRIPTION
Closes #1231 and  #565 

- [x] adds an `__iter__` method to Shape (specialized for Wire)
- [x] ancestors iterator
- [x] siblings iterator
- [x] ancestors/siblings for workplane
- [x] tests
- [x] docs
 