### PR TITLE
Making all download formats of the RTD documentation available

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,6 @@ build:
 
 conda:
   environment: environment.yml
+
+formats:
+  - all

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,5 +8,4 @@ build:
 conda:
   environment: environment.yml
 
-formats:
-  - all
+formats: all


### PR DESCRIPTION
Closes #1352 

It should make zipped HTML, PDF and epub formats available for download.