### PR TITLE
Fix line numbers in QuickStart section

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -104,7 +104,7 @@ The code is pretty compact, let's step through it.
 
 **Line 4** adds a new parameter, diameter, for the diameter of the hole
 
-**Line 8**, we're adding the hole.
+**Lines 10-12**, we're adding the hole.
 :py:meth:`cadquery.Workplane.faces` selects the top-most face in the Z direction, and then
 :py:meth:`cadquery.Workplane.workplane` begins a new workplane located on this face. The center of this workplane
 is located at the center of mass of the shape, which in this case is the center of the plate.
@@ -168,7 +168,7 @@ There is quite a bit going on here, so let's break it down a bit.
 
 **Line 5** creates a new padding parameter that decides how far the holes are from the edges of the plate.
 
-**Line 10** selects the top-most face of the block, and creates a workplane on the top of that face, which we'll use to
+**Lines 11-12** selects the top-most face of the block, and creates a workplane on the top of that face, which we'll use to
 define the centers of the holes in the corners.
 
 There are a couple of things to note about this line:
@@ -180,15 +180,15 @@ There are a couple of things to note about this line:
        this case, the center of the top face of the block. So this rectangle will be centered on the face.
 
 
-**Line 11** draws a rectangle 12mm smaller than the overall length and width of the block, which we will use to
+**Line 16** draws a rectangle 12mm smaller than the overall length and width of the block, which we will use to
 locate the corner holes. We'll use the vertices ( corners ) of this rectangle to locate the holes. The rectangle's
 center is at the center of the workplane, which in this case coincides with the center of the bearing hole.
 
-**Line 12** selects the vertices of the rectangle, which we will use for the centers of the holes.
+**Line 17** selects the vertices of the rectangle, which we will use for the centers of the holes.
 The :py:meth:`cadquery.Workplane.vertices` function selects the corners of the rectangle.
 
-**Line 13** uses the cboreHole function to draw the holes.
-The :py:meth:`cadquery.Workplane.cboreHole` function is a handy CadQuery function that makes a counterbored hole. 
+**Line 18** uses the cboreHole function to draw the holes.
+The :py:meth:`cadquery.Workplane.cboreHole` function is a handy CadQuery function that makes a counterbored hole.
 Like most other CadQuery functions, it operates on the values on the stack.  In this case, since we
 selected the four vertices before calling the function, the function operates on each of the four points--
 which results in a counterbore hole at each of the rectangle corners.
@@ -231,7 +231,7 @@ We can do that using the preset dictionaries in the parameter definition:
     # Render the solid
     show_object(result)
 
-**Line 13** fillets the edges using the   :py:meth:`cadquery.Workplane.fillet` method.
+**Line 20** fillets the edges using the :py:meth:`cadquery.Workplane.fillet` method.
 
 To grab the right edges, the :py:meth:`cadquery.Workplane.edges` selects all of the
 edges that are parallel to the Z axis ("\|Z"),
@@ -285,7 +285,7 @@ Done!
 ============
 
 You just made a parametric, model that can generate pretty much any bearing pillow block
-with < 20 lines of code.
+with <30 lines of code.
 
 Want to learn more?
 ====================


### PR DESCRIPTION
Update line numbers in the prose of the QuickStart section. These line numbers changed after formatting the code blocks with black.