### PR TITLE
Added argument handling for ASCII export of assemblies to GLTF and STL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,10 @@ nested.xml
 nested.zip
 nested.stl
 nested.bin
-nested_ascii.bin
-nested_ascii.gltf
-nested_ascii.stl
+nested_*.bin
+nested_*.gltf
+nested_*.glb
+nested_*.stl
 out1.3mf
 out2.3mf
 out3.3mf

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ nested.wrl
 nested.xml
 nested.zip
 nested.stl
+nested.bin
 nested_ascii.bin
 nested_ascii.gltf
 nested_ascii.stl

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ nested.wrl
 nested.xml
 nested.zip
 nested.stl
+nested_ascii.bin
+nested_ascii.gltf
+nested_ascii.stl
 out1.3mf
 out2.3mf
 out3.3mf

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -468,8 +468,6 @@ class Assembly(object):
         :param angularTolerance: the angular tolerance, in radians. Only used for GLTF, VRML. Default 0.1.
         :param \**kwargs: Additional keyword arguments.  Only used for STEP, GLTF and STL.
             See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
-        :param binary: GLTF only - Sets whether or not GTLF export should be text (.gltf) or binary (.glb)
-        :type binary: bool
         :param ascii: STL only - Sets whether or not STL export should be text or binary
         :type ascii: bool
         """
@@ -494,8 +492,9 @@ class Assembly(object):
         elif exportType == "GLTF":
             # Handle the binary option for GLTF export
             binary = True
-            if "binary" in kwargs:
-                binary = bool(kwargs.get("binary"))
+            path_parts = path.split(".")
+            if len(path_parts) > 0 and path_parts[-1] == "gltf":
+                binary = False
 
             exportGLTF(self, path, binary, tolerance, angularTolerance)
         elif exportType == "VTKJS":

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -464,9 +464,9 @@ class Assembly(object):
 
         :param path: Path and filename for writing.
         :param exportType: export format (default: None, results in format being inferred form the path)
-        :param tolerance: the deflection tolerance, in model units. Only used for GLTF, VRML. Default 0.1.
-        :param angularTolerance: the angular tolerance, in radians. Only used for GLTF, VRML. Default 0.1.
-        :param \**kwargs: Additional keyword arguments.  Only used for STEP, GLTF and STL.
+        :param tolerance: the deflection tolerance, in model units. Only used for glTF, VRML. Default 0.1.
+        :param angularTolerance: the angular tolerance, in radians. Only used for glTF, VRML. Default 0.1.
+        :param \**kwargs: Additional keyword arguments.  Only used for STEP, glTF and STL.
             See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
         :param ascii: STL only - Sets whether or not STL export should be text or binary
         :type ascii: bool
@@ -478,7 +478,7 @@ class Assembly(object):
 
         if exportType is None:
             t = path.split(".")[-1].upper()
-            if t in ("STEP", "XML", "VRML", "VTKJS", "GLTF", "STL"):
+            if t in ("STEP", "XML", "VRML", "VTKJS", "GLTF", "GLB", "STL"):
                 exportType = cast(ExportLiterals, t)
             else:
                 raise ValueError("Unknown extension, specify export type explicitly")
@@ -489,7 +489,7 @@ class Assembly(object):
             exportCAF(self, path)
         elif exportType == "VRML":
             exportVRML(self, path, tolerance, angularTolerance)
-        elif exportType == "GLTF":
+        elif exportType == "GLTF" or exportType == "GLB":
             exportGLTF(self, path, None, tolerance, angularTolerance)
         elif exportType == "VTKJS":
             exportVTKJS(self, path)

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -466,8 +466,12 @@ class Assembly(object):
         :param exportType: export format (default: None, results in format being inferred form the path)
         :param tolerance: the deflection tolerance, in model units. Only used for GLTF, VRML. Default 0.1.
         :param angularTolerance: the angular tolerance, in radians. Only used for GLTF, VRML. Default 0.1.
-        :param \**kwargs: Additional keyword arguments.  Only used for STEP.
+        :param \**kwargs: Additional keyword arguments.  Only used for STEP, GLTF and STL.
             See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
+        :param binary: GLTF only - Sets whether or not GTLF export should be text (.gltf) or binary (.glb)
+        :type binary: bool
+        :param ascii: STL only - Sets whether or not STL export should be text or binary
+        :type ascii: bool
         """
 
         # Make sure the export mode setting is correct
@@ -488,11 +492,23 @@ class Assembly(object):
         elif exportType == "VRML":
             exportVRML(self, path, tolerance, angularTolerance)
         elif exportType == "GLTF":
-            exportGLTF(self, path, True, tolerance, angularTolerance)
+            # Handle the binary option for GLTF export
+            if "binary" in kwargs:
+                binary = kwargs.get("binary")
+            else:
+                binary = True
+
+            exportGLTF(self, path, binary, tolerance, angularTolerance)
         elif exportType == "VTKJS":
             exportVTKJS(self, path)
         elif exportType == "STL":
-            self.toCompound().exportStl(path, tolerance, angularTolerance)
+            # Handle the ascii setting for STL export
+            if "ascii" in kwargs:
+                export_ascii = kwargs.get("ascii")
+            else:
+                export_ascii = False
+
+            self.toCompound().exportStl(path, tolerance, angularTolerance, export_ascii)
         else:
             raise ValueError(f"Unknown format: {exportType}")
 

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -490,13 +490,7 @@ class Assembly(object):
         elif exportType == "VRML":
             exportVRML(self, path, tolerance, angularTolerance)
         elif exportType == "GLTF":
-            # Handle the binary option for GLTF export
-            binary = True
-            path_parts = path.split(".")
-            if len(path_parts) > 0 and path_parts[-1] == "gltf":
-                binary = False
-
-            exportGLTF(self, path, binary, tolerance, angularTolerance)
+            exportGLTF(self, path, None, tolerance, angularTolerance)
         elif exportType == "VTKJS":
             exportVTKJS(self, path)
         elif exportType == "STL":

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -493,20 +493,18 @@ class Assembly(object):
             exportVRML(self, path, tolerance, angularTolerance)
         elif exportType == "GLTF":
             # Handle the binary option for GLTF export
+            binary = True
             if "binary" in kwargs:
-                binary = kwargs.get("binary")
-            else:
-                binary = True
+                binary = bool(kwargs.get("binary"))
 
             exportGLTF(self, path, binary, tolerance, angularTolerance)
         elif exportType == "VTKJS":
             exportVTKJS(self, path)
         elif exportType == "STL":
             # Handle the ascii setting for STL export
+            export_ascii = False
             if "ascii" in kwargs:
-                export_ascii = kwargs.get("ascii")
-            else:
-                export_ascii = False
+                export_ascii = bool(kwargs.get("ascii"))
 
             self.toCompound().exportStl(path, tolerance, angularTolerance, export_ascii)
         else:

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -195,7 +195,7 @@ def exportGLTF(
     """
 
     # If the caller specified the binary option, respect it
-    if binary is None:
+    if binary is None: 
         # Handle the binary option for GLTF export based on file extension
         binary = True
         path_parts = path.split(".")

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -4,6 +4,7 @@ import uuid
 from tempfile import TemporaryDirectory
 from shutil import make_archive
 from itertools import chain
+from typing import Optional
 from typing_extensions import Literal
 
 from vtkmodules.vtkIOExport import vtkJSONSceneExporter, vtkVRMLExporter
@@ -185,13 +186,23 @@ def exportVRML(
 def exportGLTF(
     assy: AssemblyProtocol,
     path: str,
-    binary: bool = True,
+    binary: Optional[bool] = None,
     tolerance: float = 1e-3,
     angularTolerance: float = 0.1,
 ):
     """
     Export an assembly to a gltf file.
     """
+
+    # If the caller specified the binary option, respect it
+    if binary is None:
+        # Handle the binary option for GLTF export based on file extension
+        binary = True
+        path_parts = path.split(".")
+
+        # Binary will be the default if the user specified a non-standard file extension
+        if len(path_parts) > 0 and path_parts[-1] == "gltf":
+            binary = False
 
     # map from CadQuery's right-handed +Z up coordinate system to glTF's right-handed +Y up coordinate system
     # https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units

--- a/cadquery/occ_impl/exporters/assembly.py
+++ b/cadquery/occ_impl/exporters/assembly.py
@@ -195,7 +195,7 @@ def exportGLTF(
     """
 
     # If the caller specified the binary option, respect it
-    if binary is None: 
+    if binary is None:
         # Handle the binary option for GLTF export based on file extension
         binary = True
         path_parts = path.split(".")

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -32,7 +32,7 @@ Export Formats
 * VRML
 * VTP
 * 3MF
-* GLTF
+* glTF
 
 Notes on the Formats
 ---------------------
@@ -43,7 +43,7 @@ Notes on the Formats
 * TJS is short for ThreeJS, and is a JSON mesh format that is useful for displaying 3D models in web browsers. The TJS format is used to display embedded 3D examples within the CadQuery documentation.
 * VRML is a mesh-based format for representing interactive 3D objects in a web browser.
 * VTP is a mesh-based format used by the VTK library.
-* GLTF is a mesh-based format useful for viewing models on the web. Whether the resulting GLTF file is binary (.glb) or text (.gltf) is set by the file extension.
+* glTF is a mesh-based format useful for viewing models on the web. Whether the resulting glTF file is binary (.glb) or text (.gltf) is set by the file extension.
 
 Importing DXF
 ##############

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -32,6 +32,7 @@ Export Formats
 * VRML
 * VTP
 * 3MF
+* GLTF
 
 Notes on the Formats
 ---------------------
@@ -42,6 +43,7 @@ Notes on the Formats
 * TJS is short for ThreeJS, and is a JSON mesh format that is useful for displaying 3D models in web browsers. The TJS format is used to display embedded 3D examples within the CadQuery documentation.
 * VRML is a mesh-based format for representing interactive 3D objects in a web browser.
 * VTP is a mesh-based format used by the VTK library.
+* GLTF is a mesh-based format useful for viewing models on the web. Whether the resulting gltf file is binary (.glb) or text (.gltf) is set by the file extension.
 
 Importing DXF
 ##############

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -43,7 +43,7 @@ Notes on the Formats
 * TJS is short for ThreeJS, and is a JSON mesh format that is useful for displaying 3D models in web browsers. The TJS format is used to display embedded 3D examples within the CadQuery documentation.
 * VRML is a mesh-based format for representing interactive 3D objects in a web browser.
 * VTP is a mesh-based format used by the VTK library.
-* GLTF is a mesh-based format useful for viewing models on the web. Whether the resulting gltf file is binary (.glb) or text (.gltf) is set by the file extension.
+* GLTF is a mesh-based format useful for viewing models on the web. Whether the resulting GLTF file is binary (.glb) or text (.gltf) is set by the file extension.
 
 Importing DXF
 ##############

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -647,11 +647,30 @@ def test_save(extension, args, nested_assy, nested_assy_sphere):
     assert os.path.exists(filename)
 
 
+def test_save_stl_formats(nested_assy_sphere):
+
+     # Binary export
+    nested_assy_sphere.save("nested.stl", "STL", ascii=False)
+    assert os.path.exists("nested.stl")
+    assert os.path.getsize("nested.stl") > 782 * 1024
+
+    # ASCII export
+    nested_assy_sphere.save("nested_ascii.stl", ascii=True)
+    assert os.path.exists("nested_ascii.stl")
+    assert os.path.getsize("nested_ascii.stl") > 3960 * 1024
+
+
 def test_save_gltf(nested_assy_sphere):
 
+    # Binary export
     nested_assy_sphere.save("nested.glb", "GLTF")
     assert os.path.exists("nested.glb")
     assert os.path.getsize("nested.glb") > 50 * 1024
+
+    # ASCII export
+    nested_assy_sphere.save("nested_ascii.gltf", binary=False)
+    assert os.path.exists("nested_ascii.gltf")
+    assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 
 
 def test_save_gltf_boxes2(boxes2_assy, tmpdir, capfd):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -681,12 +681,30 @@ def test_save_gltf(nested_assy_sphere):
     assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 
 
-def test_export_gltf(nested_assy_sphere):
-    # Test exportGLTF function
-    cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested.glb", binary=None)
+def test_exportGLTF(nested_assy_sphere):
+    """Tests the exportGLTF function directly for binary vs ascii export."""
+
+    # Test binary export inferred from file extension
+    cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested_export_gltf.glb")
     with pytest.raises(UnicodeDecodeError) as info:
-        with open("nested.glb", "r") as file:
+        with open("nested_export_gltf.glb", "r") as file:
             file.read()
+
+    # Test explicit binary export
+    cq.exporters.assembly.exportGLTF(
+        nested_assy_sphere, "nested_export_gltf_2.glb", binary=True
+    )
+    with pytest.raises(UnicodeDecodeError) as info:
+        with open("nested_export_gltf_2.glb", "r") as file:
+            file.read()
+
+    # Test explicit ascii export
+    cq.exporters.assembly.exportGLTF(
+        nested_assy_sphere, "nested_export_gltf_3.gltf", binary=False
+    )
+    with open("nested_export_gltf_3.gltf", "r") as file:
+        lines = file.readlines()
+        assert lines[0].startswith('{"accessors"')
 
 
 def test_save_gltf_boxes2(boxes2_assy, tmpdir, capfd):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -680,6 +680,12 @@ def test_save_gltf(nested_assy_sphere):
     assert os.path.exists("nested_ascii.gltf")
     assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 
+    # Test exportGLTF function
+    cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested.glb")
+    with pytest.raises(UnicodeDecodeError) as info:
+        with open("nested.glb", "r") as file:
+            file.read()
+
 
 def test_save_gltf_boxes2(boxes2_assy, tmpdir, capfd):
     """

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -652,7 +652,12 @@ def test_save_stl_formats(nested_assy_sphere):
     # Binary export
     nested_assy_sphere.save("nested.stl", "STL", ascii=False)
     assert os.path.exists("nested.stl")
-    assert os.path.getsize("nested.stl") > 782 * 1024
+
+    # Trying to read a binary file as UTF-8/ASCII should throw an error
+    with pytest.raises(UnicodeDecodeError) as info:
+        with open("nested.stl", "r") as file:
+            file.read()
+    assert "invalid start byte" in str(info.value)
 
     # ASCII export
     nested_assy_sphere.save("nested_ascii.stl", ascii=True)
@@ -665,7 +670,12 @@ def test_save_gltf(nested_assy_sphere):
     # Binary export
     nested_assy_sphere.save("nested.glb", "GLTF")
     assert os.path.exists("nested.glb")
-    assert os.path.getsize("nested.glb") > 50 * 1024
+
+    # Trying to read a binary file as UTF-8/ASCII should throw an error
+    with pytest.raises(UnicodeDecodeError) as info:
+        with open("nested.glb", "r") as file:
+            file.read()
+    assert "invalid start byte" in str(info.value)
 
     # ASCII export
     nested_assy_sphere.save("nested_ascii.gltf")

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -681,7 +681,7 @@ def test_save_gltf(nested_assy_sphere):
     assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 
     # Test exportGLTF function
-    cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested.glb")
+    cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested.glb", binary=None)
     with pytest.raises(UnicodeDecodeError) as info:
         with open("nested.glb", "r") as file:
             file.read()

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -657,7 +657,6 @@ def test_save_stl_formats(nested_assy_sphere):
     with pytest.raises(UnicodeDecodeError) as info:
         with open("nested.stl", "r") as file:
             file.read()
-    assert "invalid start byte" in str(info.value)
 
     # ASCII export
     nested_assy_sphere.save("nested_ascii.stl", ascii=True)
@@ -675,7 +674,6 @@ def test_save_gltf(nested_assy_sphere):
     with pytest.raises(UnicodeDecodeError) as info:
         with open("nested.glb", "r") as file:
             file.read()
-    assert "invalid start byte" in str(info.value)
 
     # ASCII export
     nested_assy_sphere.save("nested_ascii.gltf")

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -649,7 +649,7 @@ def test_save(extension, args, nested_assy, nested_assy_sphere):
 
 def test_save_stl_formats(nested_assy_sphere):
 
-     # Binary export
+    # Binary export
     nested_assy_sphere.save("nested.stl", "STL", ascii=False)
     assert os.path.exists("nested.stl")
     assert os.path.getsize("nested.stl") > 782 * 1024

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -667,7 +667,7 @@ def test_save_stl_formats(nested_assy_sphere):
 def test_save_gltf(nested_assy_sphere):
 
     # Binary export
-    nested_assy_sphere.save("nested.glb", "GLTF")
+    nested_assy_sphere.save("nested.glb")
     assert os.path.exists("nested.glb")
 
     # Trying to read a binary file as UTF-8/ASCII should throw an error

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -668,7 +668,7 @@ def test_save_gltf(nested_assy_sphere):
     assert os.path.getsize("nested.glb") > 50 * 1024
 
     # ASCII export
-    nested_assy_sphere.save("nested_ascii.gltf", binary=False)
+    nested_assy_sphere.save("nested_ascii.gltf")
     assert os.path.exists("nested_ascii.gltf")
     assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -680,6 +680,8 @@ def test_save_gltf(nested_assy_sphere):
     assert os.path.exists("nested_ascii.gltf")
     assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 
+
+def test_export_gltf(nested_assy_sphere):
     # Test exportGLTF function
     cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested.glb", binary=None)
     with pytest.raises(UnicodeDecodeError) as info:


### PR DESCRIPTION
The `binary` option for `occ_impl.exporters.assembly.exportGLTF()` was not getting passed through from the `assembly.save()` call. This PR fixes that and also adds the `ascii` option for STL export as well.