### PR TITLE
Fix example documentation typos

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -526,7 +526,7 @@ An existing CQ object can copy a workplane from another CQ object.
 
 .. topic:: API References
 
-    .. hlist:
+    .. hlist::
         :columns: 2
 
         * :py:meth:`Workplane.copyWorkplane` **!**

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -199,7 +199,7 @@ like :py:meth:`Workplane.circle` and :py:meth:`Workplane.rect`, will operate on 
     .. hlist::
         :columns: 2
 
-        * :py:meth:`Workplane.points` **!**
+        * :py:meth:`Workplane.pushPoints` **!**
         * :py:meth:`Workplane`
         * :py:meth:`Workplane.circle`
         * :py:meth:`Workplane.extrude`


### PR DESCRIPTION
Two typos are fixes in this pull request:

- In the example "Using Point Lists" the `pushPoints` method is used. That method should be referenced in the "API reference" section instead of the `points`.
- In the "Copying Workplanes" example there is a missing ":" in the "API reference" hlist that make the section look empty