### PR TITLE
docs(cheatsheet): add intersect to boolean operations

### DIFF
--- a/doc/_static/cadquery_cheatsheet.html
+++ b/doc/_static/cadquery_cheatsheet.html
@@ -159,7 +159,7 @@
 							<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.shell">shell</a><br><small>(thickness)</small></td>
 						</tr> 
 					<tr>
-						<td rowspan="2"><small>^ quickly perform ^ <br> +/- boolean ops with<br><span style="white-space: nowrap;">(..., combine="a/s")</span><br>or use <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.union">union</a>/<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cut">cut</a>(shape)</small></td>
+						<td rowspan="2"><small>^ quickly perform ^ <br> +/-/& boolean ops with<br><span style="white-space: nowrap;">(..., combine="a/s/i")</span><br>or use <a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.union">union</a>/<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.cut">cut</a>/<a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.intersect">intersect</a>(shape)</small></td>
 						<td rowspan="1"></td>
 						<td><a target="_blank" href="https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.Workplane.fillet">fillet</a><br><small>(radius)</small></td>
 					</tr> 


### PR DESCRIPTION
Adds the `intersect` function to the `boolean operations` cheat sheet table cell.