### PR TITLE
Modify STL export to enable non-relative tolerancing and speed up export.

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -434,7 +434,9 @@ class Shape(object):
             Setting this value to True may be problematic for parts with a wide range of feature sizes, as large features will be very faceted, or small features will be very dense.
         """
         # The constructor used here automatically calls mesh.Perform(). https://dev.opencascade.org/doc/refman/html/class_b_rep_mesh___incremental_mesh.html#a3a383b3afe164161a3aa59a492180ac6
-        BRepMesh_IncrementalMesh(self.wrapped, tolerance, isToleranceRelative, angularTolerance, isParallel)
+        BRepMesh_IncrementalMesh(
+            self.wrapped, tolerance, isToleranceRelative, angularTolerance, isParallel
+        )
 
         writer = StlAPI_Writer()
         writer.ASCIIMode = bool(ascii)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -418,7 +418,7 @@ class Shape(object):
         angularTolerance: float = 0.1,
         ascii: bool = False,
         isToleranceRelative: bool = True,
-        isParallel: bool = False,
+        parallel: bool = True,
     ) -> bool:
         """
         Exports a shape to a specified STL file.
@@ -430,12 +430,13 @@ class Shape(object):
             Default is 1e-3, which is a good starting point for a range of cases.
         :param angularTolerance: Angular deflection setting which limits the angle between subsequent segments in a polyline. Default is 0.1.
         :param ascii: Export the file as ASCII (True) or binary (False) STL format.  Default is binary.
-        :param isToleranceRelative: If True, deflection used for discretization of each edge will be <tolerance> * <size of="" edge>="">. Deflection used for the faces will be the maximum deflection of their edges.
-            Setting this value to True may be problematic for parts with a wide range of feature sizes, as large features will be very faceted, or small features will be very dense.
+        :param isToleranceRelative: If True, tolerance will be scaled by the size of the edge being meshed. Default is True.
+            Setting this value to True may cause large features to become faceted, or small features dense.
+        :param parallel: If True, OCCT will use parallel processing to mesh the shape. Default is True.
         """
         # The constructor used here automatically calls mesh.Perform(). https://dev.opencascade.org/doc/refman/html/class_b_rep_mesh___incremental_mesh.html#a3a383b3afe164161a3aa59a492180ac6
         BRepMesh_IncrementalMesh(
-            self.wrapped, tolerance, isToleranceRelative, angularTolerance, isParallel
+            self.wrapped, tolerance, isToleranceRelative, angularTolerance, parallel
         )
 
         writer = StlAPI_Writer()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -439,7 +439,7 @@ class Shape(object):
         )
 
         writer = StlAPI_Writer()
-        writer.ASCIIMode = bool(ascii)
+        writer.ASCIIMode = ascii
 
         return writer.Write(self.wrapped, fileName)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -417,7 +417,7 @@ class Shape(object):
         tolerance: float = 1e-3,
         angularTolerance: float = 0.1,
         ascii: bool = False,
-        isToleranceRelative: bool = True,
+        relative: bool = True,
         parallel: bool = True,
     ) -> bool:
         """
@@ -430,13 +430,13 @@ class Shape(object):
             Default is 1e-3, which is a good starting point for a range of cases.
         :param angularTolerance: Angular deflection setting which limits the angle between subsequent segments in a polyline. Default is 0.1.
         :param ascii: Export the file as ASCII (True) or binary (False) STL format.  Default is binary.
-        :param isToleranceRelative: If True, tolerance will be scaled by the size of the edge being meshed. Default is True.
+        :param relative: If True, tolerance will be scaled by the size of the edge being meshed. Default is True.
             Setting this value to True may cause large features to become faceted, or small features dense.
         :param parallel: If True, OCCT will use parallel processing to mesh the shape. Default is True.
         """
         # The constructor used here automatically calls mesh.Perform(). https://dev.opencascade.org/doc/refman/html/class_b_rep_mesh___incremental_mesh.html#a3a383b3afe164161a3aa59a492180ac6
         BRepMesh_IncrementalMesh(
-            self.wrapped, tolerance, isToleranceRelative, angularTolerance, parallel
+            self.wrapped, tolerance, relative, angularTolerance, parallel
         )
 
         writer = StlAPI_Writer()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -417,6 +417,8 @@ class Shape(object):
         tolerance: float = 1e-3,
         angularTolerance: float = 0.1,
         ascii: bool = False,
+        isToleranceRelative: bool = True,
+        isParallel: bool = False,
     ) -> bool:
         """
         Exports a shape to a specified STL file.
@@ -428,9 +430,11 @@ class Shape(object):
             Default is 1e-3, which is a good starting point for a range of cases.
         :param angularTolerance: Angular deflection setting which limits the angle between subsequent segments in a polyline. Default is 0.1.
         :param ascii: Export the file as ASCII (True) or binary (False) STL format.  Default is binary.
+        :param isToleranceRelative: If True, deflection used for discretization of each edge will be <tolerance> * <size of="" edge>="">. Deflection used for the faces will be the maximum deflection of their edges.
+            Setting this value to True may be problematic for parts with a wide range of feature sizes, as large features will be very faceted, or small features will be very dense.
         """
 
-        mesh = BRepMesh_IncrementalMesh(self.wrapped, tolerance, True, angularTolerance)
+        mesh = BRepMesh_IncrementalMesh(self.wrapped, tolerance, isToleranceRelative, angularTolerance, isParallel)
         mesh.Perform()
 
         writer = StlAPI_Writer()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -433,16 +433,11 @@ class Shape(object):
         :param isToleranceRelative: If True, deflection used for discretization of each edge will be <tolerance> * <size of="" edge>="">. Deflection used for the faces will be the maximum deflection of their edges.
             Setting this value to True may be problematic for parts with a wide range of feature sizes, as large features will be very faceted, or small features will be very dense.
         """
-
-        mesh = BRepMesh_IncrementalMesh(self.wrapped, tolerance, isToleranceRelative, angularTolerance, isParallel)
-        mesh.Perform()
+        # The constructor used here automatically calls mesh.Perform(). https://dev.opencascade.org/doc/refman/html/class_b_rep_mesh___incremental_mesh.html#a3a383b3afe164161a3aa59a492180ac6
+        BRepMesh_IncrementalMesh(self.wrapped, tolerance, isToleranceRelative, angularTolerance, isParallel)
 
         writer = StlAPI_Writer()
-
-        if ascii:
-            writer.ASCIIMode = True
-        else:
-            writer.ASCIIMode = False
+        writer.ASCIIMode = bool(ascii)
 
         return writer.Write(self.wrapped, fileName)
 


### PR DESCRIPTION
First off, thank you for building this tool - it's been awesome to get to know! Greatly appreciate the API and the comments contained throughout, and it has saved me a lot of headache!

In the event that a model has very large and very small geometries, relative sizing for the mesh results in one of those scales being severely over- or under-resolved. For example, a dodecagon might be sufficient for a small hole, but a large hole requires many more facets to be properly represented. With relative sizing, getting the large hole up to a sufficient resolution results in the small hole meshing down to sizes that approach floating point errors and result in geometry collapses. 

Also, the docs explicitly state that mesh.Perform() is called by the constructor, so calling it again doubles runtime with no change in the result (that I've been able to observe)

None of the changes here modify the existing default behavior.

This PR is ready for review ✔️ 