### PR TITLE
Update shapes.py to remove unnecessary call to TopTools_IndexedDataMa…

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -734,7 +734,6 @@ class Shape(object):
 
         res = TopTools_IndexedDataMapOfShapeListOfShape()
 
-        TopTools_IndexedDataMapOfShapeListOfShape()
         TopExp.MapShapesAndAncestors_s(
             self.wrapped,
             inverse_shape_LUT[child_type],


### PR DESCRIPTION
`_entitiesFrom` seems to have an unnecessary call to `TopTools_IndexedDataMapOfShapeListOfShape()`