### PR TITLE
Improve text alignment

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -200,6 +200,14 @@ from OCP.Font import (
 )
 
 from OCP.StdPrs import StdPrs_BRepFont, StdPrs_BRepTextBuilder as Font_BRepTextBuilder
+from OCP.Graphic3d import (
+    Graphic3d_HTA_LEFT,
+    Graphic3d_HTA_CENTER,
+    Graphic3d_HTA_RIGHT,
+    Graphic3d_VTA_BOTTOM,
+    Graphic3d_VTA_CENTER,
+    Graphic3d_VTA_TOP,
+)
 
 from OCP.NCollection import NCollection_Utf8String
 
@@ -3649,27 +3657,28 @@ class Compound(Shape, Mixin3D):
             font_kind,
             float(size),
         )
-        text_flat = Shape(builder.Perform(font_i, NCollection_Utf8String(text)))
-
-        bb = text_flat.BoundingBox()
-
-        t = Vector()
-
         if halign == "left":
-            t.x = -bb.xmin
+            theHAlign = Graphic3d_HTA_LEFT
         elif halign == "center":
-            t.x = -(bb.xmin + bb.xlen / 2)
+            theHAlign = Graphic3d_HTA_CENTER
         else:  # halign == "right"
-            t.x = -bb.xmax
+            theHAlign = Graphic3d_HTA_RIGHT
 
         if valign == "bottom":
-            t.y = -bb.ymin
+            theVAlign = Graphic3d_VTA_BOTTOM
         elif valign == "center":
-            t.y = -(bb.ymin + bb.ylen / 2)
-        else:  # valign == "top"
-            t.y = -bb.ymax
+            theVAlign = Graphic3d_VTA_CENTER
+        else:  # valign == "top":
+            theVAlign = Graphic3d_VTA_TOP
 
-        text_flat = text_flat.translate(t)
+        text_flat = Shape(
+            builder.Perform(
+                font_i,
+                NCollection_Utf8String(text),
+                theHAlign=theHAlign,
+                theVAlign=theVAlign,
+            )
+        )
 
         if height != 0:
             vecNormal = text_flat.Faces()[0].normalAt() * height

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3659,14 +3659,14 @@ class Compound(Shape, Mixin3D):
             t.x = -bb.xmin
         elif halign == "center":
             t.x = -(bb.xmin + bb.xlen / 2)
-        elif halign == "right":
+        else:  # halign == "right"
             t.x = -bb.xmax
 
         if valign == "bottom":
             t.y = -bb.ymin
         elif valign == "center":
             t.y = -(bb.ymin + bb.ylen / 2)
-        elif valign == "top":
+        else:  # valign == "top"
             t.y = -bb.ymax
 
         text_flat = text_flat.translate(t)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3655,15 +3655,19 @@ class Compound(Shape, Mixin3D):
 
         t = Vector()
 
-        if halign == "center":
-            t.x = -bb.xlen / 2
+        if halign == "left":
+            t.x = -bb.xmin
+        elif halign == "center":
+            t.x = -(bb.xmin + bb.xlen / 2)
         elif halign == "right":
-            t.x = -bb.xlen
+            t.x = -bb.xmax
 
-        if valign == "center":
-            t.y = -bb.ylen / 2
+        if valign == "bottom":
+            t.y = -bb.ymin
+        elif valign == "center":
+            t.y = -(bb.ymin + bb.ylen / 2)
         elif valign == "top":
-            t.y = -bb.ylen
+            t.y = -bb.ymax
 
         text_flat = text_flat.translate(t)
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3876,26 +3876,20 @@ class TestCadQuery(BaseTest):
         )
 
     def testTextAlignment(self):
-        tolerance = 0.1
+        left_bottom = Workplane().text("I", 10, 0, halign="left", valign="bottom")
+        lb_bb = left_bottom.val().BoundingBox()
+        self.assertGreaterEqual(lb_bb.xmin, 0)
+        self.assertGreaterEqual(lb_bb.ymin, 0)
 
-        left_bottom = Workplane().text(
-            "CQ 2.0", 0.5, 0.05, halign="left", valign="bottom"
-        )
-        bb = left_bottom.val().BoundingBox()
-        self.assertTrue(abs(bb.xmin) < tolerance)
-        self.assertTrue(abs(bb.ymin) < tolerance)
+        centers = Workplane().text("I", 10, 0, halign="center", valign="center")
+        c_bb = centers.val().BoundingBox()
+        self.assertAlmostEqual(c_bb.center.x, 0, places=0)
+        self.assertAlmostEqual(c_bb.center.y, 0, places=0)
 
-        centers = Workplane().text(
-            "CQ 2.0", 0.5, 0.05, halign="center", valign="center"
-        )
-        bb = centers.val().BoundingBox()
-        self.assertTrue(abs(bb.xmax + bb.xmin) < tolerance)
-        self.assertTrue(abs(bb.ymax + bb.ymin) < tolerance)
-
-        right_top = Workplane().text("CQ 2.0", 0.5, 0.05, halign="right", valign="top")
-        bb = right_top.val().BoundingBox()
-        self.assertTrue(abs(bb.xmax) < tolerance)
-        self.assertTrue(abs(bb.ymax) < tolerance)
+        right_top = Workplane().text("I", 10, 0, halign="right", valign="top")
+        rt_bb = right_top.val().BoundingBox()
+        self.assertLessEqual(rt_bb.xmax, 0)
+        self.assertLessEqual(rt_bb.ymax, 0)
 
     def testParametricCurve(self):
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -7,7 +7,6 @@ import math, os.path, time, tempfile
 from random import random
 from random import randrange
 from itertools import product
-from functools import reduce
 
 from pytest import approx, raises
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3889,13 +3889,7 @@ class TestCadQuery(BaseTest):
         bottom_left = (
             box.faces(">Z")
             .workplane()
-            .text(
-                "CQ 2.0",
-                0.5,
-                -0.05,
-                halign="left",
-                valign="bottom",
-            )
+            .text("CQ 2.0", 0.5, -0.05, halign="left", valign="bottom")
         )
 
         bb = getBoundingBoxForText(bottom_left.faces("Z"))
@@ -3905,13 +3899,7 @@ class TestCadQuery(BaseTest):
         centers = (
             box.faces(">Z")
             .workplane()
-            .text(
-                "CQ 2.0",
-                0.5,
-                -0.05,
-                halign="center",
-                valign="center",
-            )
+            .text("CQ 2.0", 0.5, -0.05, halign="center", valign="center")
         )
 
         bb = getBoundingBoxForText(centers.faces("Z"))
@@ -3921,13 +3909,7 @@ class TestCadQuery(BaseTest):
         top_right = (
             box.faces(">Z")
             .workplane()
-            .text(
-                "CQ 2.0",
-                0.5,
-                -0.05,
-                halign="right",
-                valign="top",
-            )
+            .text("CQ 2.0", 0.5, -0.05, halign="right", valign="top")
         )
 
         bb = getBoundingBoxForText(top_right.faces("Z"))

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3877,44 +3877,26 @@ class TestCadQuery(BaseTest):
         )
 
     def testTextAlignment(self):
-        def getBoundingBoxForText(workplane):
-            """Pick the largest face on the stack and return the bounding box of its inner wires"""
-            main_face = max(workplane.vals(), key=lambda f: f.Area())
-            return reduce(
-                lambda a, b: a.add(b),
-                [wire.BoundingBox() for wire in main_face.innerWires()],
-            )
+        tolerance = 0.1
 
-        box = Workplane("XY").box(4, 4, 4)
-        bottom_left = (
-            box.faces(">Z")
-            .workplane()
-            .text("CQ 2.0", 0.5, -0.05, halign="left", valign="bottom")
+        left_bottom = Workplane().text(
+            "CQ 2.0", 0.5, 0.05, halign="left", valign="bottom"
         )
+        bb = left_bottom.val().BoundingBox()
+        self.assertTrue(abs(bb.xmin) < tolerance)
+        self.assertTrue(abs(bb.ymin) < tolerance)
 
-        bb = getBoundingBoxForText(bottom_left.faces("Z"))
-        self.assertAlmostEqual(bb.xmin, 0, places=1)
-        self.assertAlmostEqual(bb.ymin, 0, places=1)
-
-        centers = (
-            box.faces(">Z")
-            .workplane()
-            .text("CQ 2.0", 0.5, -0.05, halign="center", valign="center")
+        centers = Workplane().text(
+            "CQ 2.0", 0.5, 0.05, halign="center", valign="center"
         )
+        bb = centers.val().BoundingBox()
+        self.assertTrue(abs(bb.xmax + bb.xmin) < tolerance)
+        self.assertTrue(abs(bb.ymax + bb.ymin) < tolerance)
 
-        bb = getBoundingBoxForText(centers.faces("Z"))
-        self.assertAlmostEqual(-bb.xmin, bb.xmax, places=1)
-        self.assertAlmostEqual(-bb.ymin, bb.ymax, places=1)
-
-        top_right = (
-            box.faces(">Z")
-            .workplane()
-            .text("CQ 2.0", 0.5, -0.05, halign="right", valign="top")
-        )
-
-        bb = getBoundingBoxForText(top_right.faces("Z"))
-        self.assertAlmostEqual(bb.xmax, 0, places=1)
-        self.assertAlmostEqual(bb.ymax, 0, places=1)
+        right_top = Workplane().text("CQ 2.0", 0.5, 0.05, halign="right", valign="top")
+        bb = right_top.val().BoundingBox()
+        self.assertTrue(abs(bb.xmax) < tolerance)
+        self.assertTrue(abs(bb.ymax) < tolerance)
 
     def testParametricCurve(self):
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -910,7 +910,7 @@ def test_dxf_text(tmpdir, testdatadir):
     s2 = Sketch().importDXF(fname)
     w2 = Workplane("XZ", origin=(0, -0.5, 0)).placeSketch(s2).extrude(-1)
 
-    assert w1.val().Volume() == approx(59.983287, 1e-2)
+    assert w1.val().Volume() == approx(61.669465, 1e-2)
     assert w2.val().Volume() == approx(w1.val().Volume(), 1e-2)
     assert w2.intersect(w1).val().Volume() == approx(w1.val().Volume(), 1e-2)
 


### PR DESCRIPTION
I found some unexpected text alignment results when cutting text into the faces of a cube and took a swing at improving the results.  Here's some code the shows the issue by creating a box and cutting a hole in the center of the `>Z` face for a reference point.  It then cuts the letter "I" into that same face with various alignment options:

``` python
import cadquery as cq
from cadquery import exporters

face = cq.Workplane().box(20, 20, 20).faces(">Z").hole(.5).faces(">Z").workplane()

bottom_left = face.text("I", 20, -2, halign="left", valign="bottom")
centered = face.text("I", 20, -2, halign="center", valign="center")
top_right = face.text("I", 20, -2, halign="right", valign="top")

exporters.export(bottom_left, "bottom_left.svg", opt=dict(projectionDir=(0, 0, 1)))
exporters.export(centered, "centered.svg", opt=dict(projectionDir=(0, 0, 1)))
exporters.export(top_right, "top_right.svg", opt=dict(projectionDir=(0, 0, 1)))
```

Here is the output before and after the proposed change in this PR.

`bottom_left` before:
![bottom_left_before](https://github.com/CadQuery/cadquery/assets/401011/89f8b7b2-e305-4bca-93e8-e322ca5fe6c7)
`bottom_left` after:
![bottom_left_after](https://github.com/CadQuery/cadquery/assets/401011/17fd93c1-fa27-456e-b7e0-1b7a45eb9c87)

`centered` before:
![centered_before](https://github.com/CadQuery/cadquery/assets/401011/ac2fc7d5-1274-4192-8bcd-c12f55faff3a)
`centered` after:
![centered_after](https://github.com/CadQuery/cadquery/assets/401011/9bb95056-9eff-4abd-8e81-e7e70b080c8b)

`top_right` before:
![top_right_before](https://github.com/CadQuery/cadquery/assets/401011/6793d8ae-487a-467f-9b79-0dc17b3a578a)
`top_right` after:
![top_right_after](https://github.com/CadQuery/cadquery/assets/401011/85ba07b2-ff09-4947-abbe-93bdaf843d15)



