### PR TITLE
added documentation for Assembly.save() param mode

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -464,6 +464,7 @@ class Assembly(object):
 
         :param path: Path and filename for writing.
         :param exportType: export format (default: None, results in format being inferred form the path)
+        :param mode: STEP only - See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
         :param tolerance: the deflection tolerance, in model units. Only used for glTF, VRML. Default 0.1.
         :param angularTolerance: the angular tolerance, in radians. Only used for glTF, VRML. Default 0.1.
         :param \**kwargs: Additional keyword arguments.  Only used for STEP, glTF and STL.


### PR DESCRIPTION
mode is only used for STEP files as discussed here 
[https://github.com/CadQuery/cadquery/issues/1457](https://github.com/CadQuery/cadquery/issues/1457)
so I suggest to a line to the comments describing that behaviour