### PR TITLE
Fix Python version info in pip installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ mamba install -c conda-forge -c cadquery cadquery=master
 
 ### CadQuery Installation Via Pip
 
-CadQuery has a complex set of dependencies including OCP, which is our set of bindings to the OpenCASCADE CAD kernel. OCP is distributed as binary wheels for Linux, MacOS and Windows. However, there are some limitations. Only Python 3.8 through 3.10 are currently supported, and some older Linux distributions such as Ubuntu 18.04 are not supported. If the pip installation method does not work for your system, you can try the conda installation method.
+CadQuery has a complex set of dependencies including OCP, which is our set of bindings to the OpenCASCADE CAD kernel. OCP is distributed as binary wheels for Linux, MacOS and Windows. However, there are some limitations. Only Python 3.9 through 3.12 are currently supported, and some older Linux distributions such as Ubuntu 18.04 are not supported. If the pip installation method does not work for your system, you can try the conda installation method.
 
 It is highly recommended that a virtual environment is used when installing CadQuery, although it is not strictly required. Installing CadQuery via pip requires a up-to-date version of pip, which can be obtained with the following command line (or a slight variation thereof).
 ```

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -86,7 +86,7 @@ Add the *conda-forge* channel explicitly to the install command if needed (not u
 Install via pip
 ---------------
 
-CadQuery can be installed via pip on Linux, MacOS and Windows. Python versions 3.8 and newer are supported by CadQuery, however a bleeding-edge Python installation may be broken due to lagging support in CadQuery's complex set of dependencies. If the pip installation method does not work for your system, you can try the conda installation method above.
+CadQuery can be installed via pip on Linux, MacOS and Windows. Python versions 3.9 and newer are supported by CadQuery, however a bleeding-edge Python installation may be broken due to lagging support in CadQuery's complex set of dependencies. If the pip installation method does not work for your system, you can try the conda installation method above.
 
 It is highly recommended that a virtual environment is used when installing CadQuery, although it is not strictly required. Installing CadQuery via pip requires an up-to-date version of pip, which can be obtained with the following command line (or a slight variation thereof).:
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -86,7 +86,7 @@ Add the *conda-forge* channel explicitly to the install command if needed (not u
 Install via pip
 ---------------
 
-CadQuery has a complex set of dependencies including OCP, which is our set of bindings to the OpenCASCADE CAD kernel. OCP is distributed as binary wheels for Linux, MacOS and Windows. However, there are some limitations. Only Python 3.8 through 3.10 are currently supported, and some older Linux distributions such as Ubuntu 18.04 are not supported. If the pip installation method does not work for your system, you can try the conda installation method.
+CadQuery can be installed via pip on Linux, MacOS and Windows. Python versions 3.8 and newer are supported by CadQuery, however a bleeding-edge Python installation may be broken due to lagging support in CadQuery's complex set of dependencies. If the pip installation method does not work for your system, you can try the conda installation method above.
 
 It is highly recommended that a virtual environment is used when installing CadQuery, although it is not strictly required. Installing CadQuery via pip requires an up-to-date version of pip, which can be obtained with the following command line (or a slight variation thereof).:
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cadquery
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8,<=3.12
+  - python>=3.9,<=3.12
   - ipython
   - ocp=7.7.2
   - vtk=*=qt*

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests",)),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     setup_requires=setup_reqs,
     install_requires=reqs,
     extras_require={


### PR DESCRIPTION
Documentation fix for suggestion in #1462 

Specific comment is [here](https://github.com/CadQuery/cadquery/issues/1462#issuecomment-1866657149).