### PR TITLE
Updated setup.py for CQ black fork

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,12 @@ setup(
     setup_requires=setup_reqs,
     install_requires=reqs,
     extras_require={
-        "dev": ["docutils", "ipython", "pytest", "black@git+https://github.com/cadquery/black.git@cq",],
+        "dev": [
+            "docutils",
+            "ipython",
+            "pytest",
+            "black@git+https://github.com/cadquery/black.git@cq",
+        ],
         "ipython": ["ipython",],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     setup_requires=setup_reqs,
     install_requires=reqs,
     extras_require={
-        "dev": ["docutils", "ipython", "pytest", "black==19.10b0", "click==8.0.4",],
+        "dev": ["docutils", "ipython", "pytest", "black@git+https://github.com/cadquery/black.git@cq",],
         "ipython": ["ipython",],
     },
     include_package_data=True,


### PR DESCRIPTION
We do not use the stock version of black anymore.