### PR TITLE
filter/map/apply/sort/[]/invoke

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4373,8 +4373,10 @@ class Workplane(object):
 
         if isinstance(item, Iterable):
             rv = self.newObject(self.objects[i] for i in item)
-        else:
+        elif isinstance(item, slice):
             rv = self.newObject(self.objects[item])
+        else:
+            rv = self.newObject([self.objects[item]])
 
         return rv
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4382,36 +4382,36 @@ class Workplane(object):
 
     def filter(self: T, f: Callable[[CQObject], bool]) -> T:
         """
-        TODO
-        :param f:
-        :return:
+        Filter items using a boolean predicate.
+        :param f: Callable to be used for filtering.
+        :return: Workplane object with filtered items.
         """
 
         return self.newObject(filter(f, self.objects))
 
     def map(self: T, f: Callable[[CQObject], CQObject]):
         """
-        TODO
-        :param f: 
-        :return: 
+        Apply a callable to every item separately.
+        :param f: Callable to be applied to every item separately.
+        :return: Workplane object with f applied to all items.
         """
 
         return self.newObject(map(f, self.objects))
 
     def apply(self: T, f: Callable[[Iterable[CQObject]], Iterable[CQObject]]):
         """
-        TODO
-        :param f: 
-        :return: 
+        Apply a callable to all items at once.
+        :param f: Callable to be applied.
+        :return: Workplane object with f applied to all items.
         """
 
         return self.newObject(f(self.objects))
 
     def sort(self: T, key: Callable[[CQObject], Any]) -> T:
         """
-        TODO
-        :param key:
-        :return:
+        Sort items using a callable.
+        :param key: Callable to be used for sorting.
+        :return: Workplane object with items sorted.
         """
 
         return self.newObject(sorted(self.objects, key=key))

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4481,10 +4481,11 @@ class Workplane(object):
         self: T, f: Union[Callable[[T], T], Callable[[T], None], Callable[[], None]]
     ):
         """
-        Invoke a callable mapping Workplane to Workplane, Workplane to None or
-        without any parameters. In the two latter cases self is returned.
+        Invoke a callable mapping Workplane to Workplane or None. Supports also
+        callables that take no arguments such as breakpoint. Returns self if callable
+        returns None.
         :param f: Callable to be invoked.
-        :return: Workplane object
+        :return: Workplane object.
         """
 
         if isbuiltin(f):
@@ -4501,7 +4502,7 @@ class Workplane(object):
             if res is not None:
                 rv = res
         else:
-            raise ValueError("Provided function {f} accepts too many arguemnts")
+            raise ValueError("Provided function {f} accepts too many arguments")
 
         return rv
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -35,7 +35,7 @@ from typing import (
     Dict,
 )
 from typing_extensions import Literal
-from inspect import Parameter, Signature
+from inspect import Parameter, Signature, isbuiltin
 
 
 from .occ_impl.geom import Vector, Plane, Location
@@ -4487,7 +4487,11 @@ class Workplane(object):
         :return: Workplane object
         """
 
-        arity = f.__code__.co_argcount  # NB: this is not understood by mypy
+        if isbuiltin(f):
+            arity = 0  # assume 0 arity for builtins; they cannot be introspected
+        else:
+            arity = f.__code__.co_argcount  # NB: this is not understood by mypy
+
         rv = self
 
         if arity == 0:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4371,7 +4371,7 @@ class Workplane(object):
 
     def __getitem__(self: T, item: Union[int, Sequence[int], slice]) -> T:
 
-        if isiterable(item):
+        if isinstance(item, Iterable):
             rv = self.newObject(self.objects[i] for i in item)
         else:
             rv = self.newObject(self.objects[item])

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4369,77 +4369,51 @@ class Workplane(object):
                 _selectShapes(self.objects)
             )._repr_javascript_()
 
-    def __getitem__(self, item):
-        return self.newObject(self.objects[item])
+    def __getitem__(self: T, item: Union[int, Sequence[int], slice]) -> T:
 
-    def filter_objects(self: T, f: Callable[[CQObject], bool]) -> T:
+        if isiterable(item):
+            rv = self.newObject(self.objects[i] for i in item)
+        else:
+            rv = self.newObject(self.objects[item])
+
+        return rv
+
+    def filter(self: T, f: Callable[[CQObject], bool]) -> T:
         """
         TODO
         :param f:
         :return:
         """
+
         return self.newObject(filter(f, self.objects))
 
-    def map_objects(self: T, f: Callable[[Iterable[CQObject]], Iterable[CQObject]]):
+    def map(self: T, f: Callable[[CQObject], CQObject]):
         """
         TODO
         :param f: 
         :return: 
         """
+
+        return self.newObject(map(f, self.objects))
+
+    def apply(self: T, f: Callable[[Iterable[CQObject]], Iterable[CQObject]]):
+        """
+        TODO
+        :param f: 
+        :return: 
+        """
+
         return self.newObject(f(self.objects))
 
-    def sort_objects(self: T, key: Callable[[CQObject], Any]) -> T:
+    def sort(self: T, key: Callable[[CQObject], Any]) -> T:
         """
         TODO
         :param key:
         :return:
         """
+
         return self.newObject(sorted(self.objects, key=key))
 
 
 # alias for backward compatibility
 CQ = Workplane
-
-
-class Group:
-    def __init__(self, key: Callable[[CQObject], Any], tol=TOL, fixed_width=False):
-        """
-        TODO
-        :param key:
-        :param tol:
-        :param fixed_width:
-        """
-        self.key = key
-        self.tol = tol
-        self.fixed_width = fixed_width
-        self._item = None
-        self._last_value = None
-
-    def __getitem__(self, item):
-        if self._item is None:
-            self._item = item
-            return self
-        raise ValueError("Group must not be indexed or sliced more than once")
-
-    def __call__(self, objs: Iterable[CQObject]) -> Iterable[CQObject]:
-        if self._item is None:
-            raise ValueError("Group must be indexed or sliced before it can be used.")
-
-        objs = sorted(objs, key=self.key)
-        groups = []
-        group = [objs[0]]
-        last_value = self.key(objs[0])
-        for obj in objs[1:]:
-            value = self.key(obj)
-            if value - last_value <= self.tol:
-                group.append(obj)
-                if not self.fixed_width:
-                    last_value = value
-            else:
-                groups.append(group)
-                group = [obj]
-                last_value = value
-
-        groups.append(group)
-
-        return [obj for group in groups[self._item] for obj in group]

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4477,6 +4477,30 @@ class Workplane(object):
 
         return self.newObject(sorted(self.objects, key=key))
 
+    def invoke(
+        self: T, f: Union[Callable[[T], T], Callable[[T], None], Callable[[], None]]
+    ):
+        """
+        Invoke a callable mapping Workplane to Workplane, Workplane to None or
+        without any parameters. In the two latter cases self is returned.
+        :param f: Callable to be invoked.
+        :return: Workplane object
+        """
+
+        arity = f.__code__.co_argcount  # NB: this is not understood by mypy
+        rv = self
+
+        if arity == 0:
+            f()  # type: ignore
+        elif arity == 1:
+            res = f(self)  # type: ignore
+            if res is not None:
+                rv = res
+        else:
+            raise ValueError("Provided function {f} accepts too many arguemnts")
+
+        return rv
+
 
 # alias for backward compatibility
 CQ = Workplane

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -213,7 +213,7 @@ Here is the same plugin rewritten using one of those methods.
 
         from cadquery.occ_impl.shapes import box
 
-        def makeCubes(self, length):
+        def makeCubes(length):
 
             # inner method that creates the cubes
             def callback(wp):

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -163,7 +163,9 @@ This ultra simple plugin makes cubes of the specified size for each stack point.
 
 (The cubes are off-center because the boxes have their lower left corner at the reference points.)
 
-.. code-block:: python
+.. cadquery::
+
+        from cadquery.occ_impl.shapes import box
 
         def makeCubes(self, length):
             # self refers to the CQ or Workplane object
@@ -172,7 +174,7 @@ This ultra simple plugin makes cubes of the specified size for each stack point.
             def _singleCube(loc):
                 # loc is a location in local coordinates
                 # since we're using eachpoint with useLocalCoordinates=True
-                return cq.Solid.makeBox(length, length, length, pnt).locate(loc)
+                return box(length, length, length).locate(loc)
 
             # use CQ utility method to iterate over the stack, call our
             # method, and convert to/from local coordinates.
@@ -193,3 +195,42 @@ This ultra simple plugin makes cubes of the specified size for each stack point.
             .combineSolids()
         )
 
+
+Extending CadQuery: Special Methods
+-----------------------------------
+
+The above-mentioned approach has one drawback, it requires monkey-patching or subclassing. To avoid this
+one can also use the following special methods of :py:class:`cadquery.Workplane`
+and write plugins in a more functional style.
+
+    * :py:meth:`cadquery.Workplane.map`
+    * :py:meth:`cadquery.Workplane.apply`
+    * :py:meth:`cadquery.Workplane.invoke`
+
+Here is the same plugin rewritten using one of those methods.
+
+.. cadquery::
+
+        from cadquery.occ_impl.shapes import box
+
+        def makeCubes(self, length):
+
+            # inner method that creates the cubes
+            def callback(wp):
+
+                return wp.eachpoint(box(length, length, length), True)
+
+            return callback
+
+        # use the plugin
+        result = (
+            cq.Workplane("XY")
+            .box(6.0, 8.0, 0.5)
+            .faces(">Z")
+            .rect(4.0, 4.0, forConstruction=True)
+            .vertices()
+            .invoke(makeCubes(1.0))
+            .combineSolids()
+        )
+
+Such an approach if more friendly for auto-completion and static analysis tools.

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -233,4 +233,4 @@ Here is the same plugin rewritten using one of those methods.
             .combineSolids()
         )
 
-Such an approach if more friendly for auto-completion and static analysis tools.
+Such an approach is more friendly for auto-completion and static analysis tools.

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -185,3 +185,45 @@ objects. This includes chaining and combining.
     # select top and bottom wires
     result = box.faces(">Z or <Z").wires()
 
+
+
+
+Additional special methods
+--------------------------
+
+:py:class:`cadquery.Workplane` provides the following special methods that can be used
+for quick prototyping of selectors when implementing a complete selector via subclassing of
+:py:class:`cadquery.Selector` is not desirable.
+
+    * :py:meth:`cadquery.Workplane.filter`
+    * :py:meth:`cadquery.Workplane.sort`
+    * :py:meth:`cadquery.Workplane.__getitem__`
+
+For example, one could use those methods for selecting objects within a certain range of volumes.
+
+.. cadquery::
+
+    from cadquery.occ_impl.shapes import box
+
+    result = (
+        cq.Workplane()
+        .add([box(1,1,i+1).moved(x=2*i) for i in range(5)])
+    )
+
+    # select boxes with volume <= 3
+    result = result.filter(lambda s: s.Volume() <= 3)
+
+
+The same can be achieved using sorting.
+
+.. cadquery::
+
+    from cadquery.occ_impl.shapes import box
+
+    result = (
+        cq.Workplane()
+        .add([box(1,1,i+1).moved(x=2*i) for i in range(5)])
+    )
+
+    # select boxes with volume <= 3
+    result = result.sort(lambda s: s.Volume())[:3]

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5774,6 +5774,9 @@ class TestCadQuery(BaseTest):
         assert w.invoke(lambda x: None).size() == 5
         # arity 1
         assert w.invoke(lambda x: x.newObject([x.val()])).size() == 1
+        # test exception with wrong arity
+        with raises(ValueError):
+            w.invoke(lambda x, y: 1)
 
     def test_tessellate(self):
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5671,24 +5671,24 @@ class TestCadQuery(BaseTest):
 
         res7 = list(fs.siblings(c, "Edge", 2))
         assert len(res7) == 2
-        
+
     def test_map_apply_filter_sort(self):
 
-        w = Workplane().box(1, 1, 1).moveTo(3,0).box(1, 1, 0)
-        
-        assert w.filter(lambda s: s.Volume()>2).size() == 1
-        assert w.filter(lambda s: s.Volume()>5).size() == 0
+        w = Workplane().box(1, 1, 1).moveTo(3, 0).box(1, 1, 0)
+
+        assert w.filter(lambda s: s.Volume() > 2).size() == 1
+        assert w.filter(lambda s: s.Volume() > 5).size() == 0
 
         assert w.sort(lambda s: -s.Volume())[-1].val().Volume() == approx(1)
 
         assert w.apply(lambda obj: []).size() == 0
 
-        assert w.map(lambda s: s.faces('>Z')).faces().size() == 2
+        assert w.map(lambda s: s.faces(">Z")).faces().size() == 2
 
     def test_getitem(self):
 
-        w = cq.Workplane().rarray(2,1,5,1).box(1,1,1, combine=False)
+        w = cq.Workplane().rarray(2, 1, 5, 1).box(1, 1, 1, combine=False)
 
         assert w[0].solids().size() == 1
         assert w[-2:].solids().size() == 2
-        assert w[[0,1]].solids().size() == 2
+        assert w[[0, 1]].solids().size() == 2

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -1786,7 +1786,7 @@ class TestCadQuery(BaseTest):
 
     def testBoundBoxEnlarge(self):
         """
-        Tests BoundBox.enlarge(). Confirms that the 
+        Tests BoundBox.enlarge(). Confirms that the
         bounding box lengths are all enlarged by the
         correct amount.
         """
@@ -5761,6 +5761,19 @@ class TestCadQuery(BaseTest):
         assert w[0].solids().size() == 1
         assert w[-2:].solids().size() == 2
         assert w[[0, 1]].solids().size() == 2
+
+    def test_invoke(self):
+
+        w = Workplane().rarray(2, 1, 5, 1).box(1, 1, 1, combine=False)
+
+        # builtin
+        assert w.invoke(print).size() == 5
+        # arity 0
+        assert w.invoke(lambda: 1).size() == 5
+        # arity 1 and no return
+        assert w.invoke(lambda x: None).size() == 5
+        # arity 1
+        assert w.invoke(lambda x: x.newObject([x.val()])).size() == 1
 
     def test_tessellate(self):
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5687,7 +5687,7 @@ class TestCadQuery(BaseTest):
 
     def test_getitem(self):
 
-        w = cq.Workplane().rarray(2, 1, 5, 1).box(1, 1, 1, combine=False)
+        w = Workplane().rarray(2, 1, 5, 1).box(1, 1, 1, combine=False)
 
         assert w[0].solids().size() == 1
         assert w[-2:].solids().size() == 2

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5674,7 +5674,7 @@ class TestCadQuery(BaseTest):
 
     def test_map_apply_filter_sort(self):
 
-        w = Workplane().box(1, 1, 1).moveTo(3, 0).box(1, 1, 0)
+        w = Workplane().box(1, 1, 1).moveTo(3, 0).box(1, 1, 3)
 
         assert w.filter(lambda s: s.Volume() > 2).size() == 1
         assert w.filter(lambda s: s.Volume() > 5).size() == 0

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5674,7 +5674,7 @@ class TestCadQuery(BaseTest):
 
     def test_map_apply_filter_sort(self):
 
-        w = Workplane().box(1, 1, 1).moveTo(3, 0).box(1, 1, 3)
+        w = Workplane().box(1, 1, 1).moveTo(3, 0).box(1, 1, 3).solids()
 
         assert w.filter(lambda s: s.Volume() > 2).size() == 1
         assert w.filter(lambda s: s.Volume() > 5).size() == 0

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5671,3 +5671,24 @@ class TestCadQuery(BaseTest):
 
         res7 = list(fs.siblings(c, "Edge", 2))
         assert len(res7) == 2
+        
+    def test_map_apply_filter_sort(self):
+
+        w = Workplane().box(1, 1, 1).moveTo(3,0).box(1, 1, 0)
+        
+        assert w.filter(lambda s: s.Volume()>2).size() == 1
+        assert w.filter(lambda s: s.Volume()>5).size() == 0
+
+        assert w.sort(lambda s: -s.Volume())[-1].val().Volume() == approx(1)
+
+        assert w.apply(lambda obj: []).size() == 0
+
+        assert w.map(lambda s: s.faces('>Z')).faces().size() == 2
+
+    def test_getitem(self):
+
+        w = cq.Workplane().rarray(2,1,5,1).box(1,1,1, combine=False)
+
+        assert w[0].solids().size() == 1
+        assert w[-2:].solids().size() == 2
+        assert w[[0,1]].solids().size() == 2


### PR DESCRIPTION
Some time back I made [cq-filter](https://github.com/voneiden/cq-filter) to allow easier manipulation of workplane objects without breaking out of the fluent API. @adam-urbanczyk  requested in https://github.com/voneiden/cq-filter/issues/1 to merge some features from cq-filter into cadquery, namely:

* __getitem__
* filter
* sort
 
and optionally

* group

----

First off, I've decided to rename `filter`  to `filter_objects` and `sort` to `sort_objects`. I think the verbosity is warranted as `Workplane` is a fairly complex object. 

The cq-filter implementation of  `group` created an intermediary workplane with extra fields to support slicing groups. I never particularly liked doing it this way, so I spent some time thinking how this could be done without the intermediary workplane. One option, used in this PR, is to create a separate Group object that supports slicing. This does require however the ability for the `Group` to iterate through candidate objects independently, so it can not be used with `filter_objects` as it allows the supplied filter function to operate only one one `CQObject` at a time. 

Therefore I needed to introduce another method, currently named as  `map_objects` which hands over the workplane objects to the map function and expects a new list of objects to be returned.

Group supports fixed window groups (x<sub>n</sub> - x<sub>0</sub> <= tol) and moving window groups (x<sub>n</sub> - x<sub>n-1</sub> <= tol)

------

Currently the PR is missing documentation and tests, but I'm opening this to allow discussion of implementation details. I'm flexible regarding the scope of this PR, if it feels like `Group` doesn't belong here then we'll drop it. 

I'm a bit low on free dev time for the time being so this might progress at a snails pace but we'll get there. 