### PR TITLE
radiusArc: due to float looseness the length computation can be sligh…

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2198,7 +2198,11 @@ class Workplane(object):
         # Calculate the sagitta from the radius
         length = endPoint.sub(startPoint).Length / 2.0
         try:
-            sag = abs(radius) - math.sqrt(radius ** 2 - length ** 2)
+            sag = abs(radius)
+            r_2_l_2 = radius ** 2 - length ** 2
+            # Float imprecision can lead slightly negative values: consider them as zeros
+            if abs(r_2_l_2) >= TOL:
+                sag -= math.sqrt(r_2_l_2)
         except ValueError:
             raise ValueError("Arc radius is not large enough to reach the end point.")
 


### PR DESCRIPTION
…tly over radius length, leading to a ValueError exception. Using TOL value in order to remove this issue