### PR TITLE
Make offset2D act on objects instead of pending wires

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4295,7 +4295,7 @@ class Workplane(object):
         :return: CQ object with resulting wire(s).
         """
 
-        ws = self._consolidateWires()
+        ws = [el for el in self.objects if isinstance(el, Wire)]
         rv = list(chain.from_iterable(w.offset2D(d, kind) for w in ws))
 
         self.ctx.pendingEdges = []
@@ -4304,7 +4304,9 @@ class Workplane(object):
                 wire.forConstruction = True
             self.ctx.pendingWires = []
         else:
-            self.ctx.pendingWires = rv
+            for w in ws:
+                self.ctx.pendingWires.remove(w)
+            self.ctx.pendingWires.extend(rv)
 
         return self.newObject(rv)
 


### PR DESCRIPTION
Hi,

This PR is a bugfix, but I'm not sure this is the desired behavior, or even if this is a bug in the first place.

Here's a script to describe my issue:

```py
    cq.Workplane("XY")
    .rect(5, 5)
    # .offset2D(1)
    .workplane(offset=5)
    .rect(3, 5)
    .workplane(offset=5)
    .rect(10, 20)
    # .offset2D(1)
    .consolidateWires()
    # .loft()
```

This object contains 3 rects on top of each other. Now if I uncomment the `offset2D` calls, I expect them to act on the single `rect` just before each call, so that the bottom and top rects get rounded, and the middle one is left untouched.

What actually happens is that `offset2D` calls `_consolidateWires` and acts on *all* pending wires of all the workplanes on this stack, so the second `offset2D` will add an offset to all 3 rects (the first one will be offset twice).

This patch allows `offset2D` to not act on all pending wires but only on current objects. This gives me the desired result, the middle rect is not offset and has sharp edges:

![image](https://github.com/CadQuery/cadquery/assets/1370530/298440dd-dcc1-44cc-b361-1dfbf725d38f)
![image](https://github.com/CadQuery/cadquery/assets/1370530/e6e49499-efe5-44f4-b872-3c4231069f49)

---

There are a few questions I have about this:

- Is this fix needed, or is there a way to accomplish what I want without it?
- Is this the desired fix for this issue?
- This implementation of `offset2D` acts only on already-consolidated wires. Should it try to consolidate all the edges that are in `self.object` too, to keep a behavior similar to before this patch?

Note that tests are broken, I am waiting for more input about whether this is the right thing to do before trying to fix them.