### PR TITLE
Describing the units of the result

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -646,6 +646,7 @@ class Shape(object):
     def matrixOfInertia(obj: "Shape") -> List[List[float]]:
         """
         Calculates the matrix of inertia of an object.
+        Since the part's density is unknown, this result is inertia/density with units of [1/length].
         :param obj: Compute the matrix of inertia of this object
         """
         Properties = GProp_GProps()


### PR DESCRIPTION
Since CQ does not know the material density, the result of cq.Shape.matrixOfInertia() is a specific inertia which needs to be multiplied by density to get the correct result.