### PR TITLE
Add support for closed path fillet to Wire.fillet()

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ init:
 install:
     - mamba env create -f environment.yml
     - conda activate cadquery
+    - conda list
 
 build: false
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -11,8 +11,9 @@ from typing import (
     overload,
     TypeVar,
     cast as tcast,
+    Literal,
+    Protocol
 )
-from typing_extensions import Literal, Protocol
 
 from io import BytesIO
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2505,15 +2505,18 @@ class Wire(Shape, Mixin1D):
 
         edges = list(self)
         all_vertices = self.Vertices()
+        n_edges = len(edges)
+        n_vertices = len(all_vertices)
+        
         newEdges = []
         currentEdge = edges[0]
 
         verticesSet = set(vertices) if vertices else set()
 
-        for i in range(len(edges)):
-            if i == len(edges) - 1 and not self.IsClosed():
+        for i in range(n_edges):
+            if i == n_edges - 1 and not self.IsClosed():
                 break
-            nextEdge = edges[(i + 1) % len(edges)]
+            nextEdge = edges[(i + 1) % n_edges]
 
             # Create a plane that is spanned by currentEdge and nextEdge
             currentDir = currentEdge.tangentAt(1)
@@ -2524,7 +2527,7 @@ class Wire(Shape, Mixin1D):
             #  1. The edges are parallel
             #  2. The vertex is not in the vertices white list
             if normalDir.Length == 0 or (
-                all_vertices[(i + 1) % len(all_vertices)] not in verticesSet
+                all_vertices[(i + 1) % n_vertices] not in verticesSet
                 and bool(verticesSet)
             ):
                 newEdges.append(currentEdge)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2507,7 +2507,7 @@ class Wire(Shape, Mixin1D):
         all_vertices = self.Vertices()
         n_edges = len(edges)
         n_vertices = len(all_vertices)
-        
+
         newEdges = []
         currentEdge = edges[0]
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -12,7 +12,7 @@ from typing import (
     TypeVar,
     cast as tcast,
     Literal,
-    Protocol
+    Protocol,
 )
 
 from io import BytesIO

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2400,8 +2400,10 @@ class Wire(Shape, Mixin1D):
 
         verticesSet = set(vertices) if vertices else set()
 
-        for i in range(len(edges) - 1):
-            nextEdge = edges[i + 1]
+        for i in range(len(edges)):
+            if i == len(edges) - 1 and not self.IsClosed():
+                break
+            nextEdge = edges[(i + 1) % len(edges)]
 
             # Create a plane that is spanned by currentEdge and nextEdge
             currentDir = currentEdge.tangentAt(1)
@@ -2412,7 +2414,8 @@ class Wire(Shape, Mixin1D):
             #  1. The edges are parallel
             #  2. The vertex is not in the vertices white list
             if normalDir.Length == 0 or (
-                all_vertices[i + 1] not in verticesSet and bool(verticesSet)
+                all_vertices[(i + 1) % len(all_vertices)] not in verticesSet
+                and bool(verticesSet)
             ):
                 newEdges.append(currentEdge)
                 currentEdge = nextEdge
@@ -2441,8 +2444,11 @@ class Wire(Shape, Mixin1D):
 
             currentEdge = nextEdge
 
-        # Add the last edge
-        newEdges.append(currentEdge)
+        # Add the last edge unless we are closed, since then
+        # currentEdge is the first edge, which was already added
+        # (and clipped)
+        if not self.IsClosed():
+            newEdges.append(currentEdge)
 
         return Wire.assembleEdges(newEdges)
 

--- a/cadquery/occ_impl/sketch_solver.py
+++ b/cadquery/occ_impl/sketch_solver.py
@@ -1,5 +1,5 @@
 from typing import Tuple, Union, Any, Callable, List, Optional, Iterable, Dict, Sequence
-from typing_extensions import Literal
+from typing import Literal
 from nptyping import NDArray as Array
 from nptyping import Float
 from itertools import accumulate, chain

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -11,8 +11,8 @@ from typing import (
     Sequence,
     TypeVar,
     cast as tcast,
+    Literal,
 )
-from typing_extensions import Literal
 from math import tan, sin, cos, pi, radians, remainder
 from itertools import product, chain
 from multimethod import multimethod

--- a/tests/test_cad_objects.py
+++ b/tests/test_cad_objects.py
@@ -766,6 +766,17 @@ class TestCadObjects(BaseTest):
         with self.assertRaises(ValueError):
             wfillet = wire.fillet(radius=1.0)
 
+        # Test a closed fillet
+        points = [[0, 0, 0], [5, 4, 0], [8, 3, 1], [10, 0, 0]]
+
+        wire = Wire.makePolygon(points, close=True)
+        wfillet = wire.fillet(radius=0.5)
+        assert len(wfillet.Edges()) == 2 * len(points)
+
+        # Fillet a single vertex
+        wfillet = wire.fillet(radius=0.5, vertices=wire.Vertices()[0:1])
+        assert len(wfillet.Edges()) == len(points) + 1
+
 
 @pytest.mark.parametrize(
     "points, close, expected_edges",


### PR DESCRIPTION
This PR adds support for fillet of a closed wire to the `Wire.fillet()` method, by adding a fillet arc between the last and the first segments