### PR TITLE
Add Workplane.addWire() method for simplifying adding wires to Workplanes

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4396,6 +4396,12 @@ class Workplane(object):
 
         return self.newObject(rv)
 
+    def addWire(self: T, wire: Wire) -> T:
+        """
+        Add a wire for each point on the stack.
+        """
+        return self.eachpoint(lambda v: wire.moved(v))
+
     def _repr_javascript_(self) -> Any:
         """
         Special method for rendering current object in a jupyter notebook

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5680,3 +5680,16 @@ class TestCadQuery(BaseTest):
 
         res7 = list(fs.siblings(c, "Edge", 2))
         assert len(res7) == 2
+
+    def test_addWire(self):
+
+        s = 0.5
+        wire = Wire.makePolygon(
+            [(-s, -s, 0), (s, -s, 0), (s, s, 0), (-s, s, 0)], close=True
+        )
+
+        obj = Workplane("XY").addWire(wire).extrude(s, both=True)
+        bb = obj.val().BoundingBox()
+        self.assertAlmostEqual(bb.xlen, 2 * s, 2)
+        self.assertAlmostEqual(bb.ylen, 2 * s, 2)
+        self.assertAlmostEqual(bb.zlen, 2 * s, 2)


### PR DESCRIPTION
This PR adds th emethod `Workplane.addWire()`, which simplifies adding a wire to each of the points in the Workplane stack.

It simplifies workflows like adding rounded rectangle holes into a baseplate as shown in the example below.

If you think this is better suited as a plugin, please let me know.

```python
def my_closed_wire_generator():
     '''Create a square with rounded corners'''
     s = 1
     points = [(-s,-s,0), (s,-s),(s,s),(-s,s)]
     return cq.Wire.makePolygon(points, close=True).fillet(0.3)
      
wire = my_closed_wire_generator() # Arbitrary routine generating a closed wire

# Create a workplane with four points on the stack
result = cq.Workplane('XY').box(10,10,1).faces('>Z').rect(7, 7, forConstruction=True).vertices()

# Add the wire to each of the points and cut
result =  result.addWire(wire).cutThruAll()

```
Here's the output:

![rounded-square-holes](https://github.com/CadQuery/cadquery/assets/338235/b1746d23-5c4d-45a0-a4df-ff33edfc1845)

