### PR TITLE
Fixed font-related test error on some platforms

### DIFF
--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3891,7 +3891,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="left",
             valign="bottom",
-            fontPath="tests/testdata/OpenSans-Regular.ttf",
+            fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
         )
         lb_bb = left_bottom.val().BoundingBox()
         self.assertGreaterEqual(lb_bb.xmin, 0)
@@ -3903,7 +3903,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="center",
             valign="center",
-            fontPath="tests/testdata/OpenSans-Regular.ttf",
+            fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
         )
         c_bb = centers.val().BoundingBox()
         self.assertAlmostEqual(c_bb.center.x, 0, places=0)
@@ -3915,7 +3915,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="right",
             valign="top",
-            fontPath="tests/testdata/OpenSans-Regular.ttf",
+            fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
         )
         rt_bb = right_top.val().BoundingBox()
         self.assertLessEqual(rt_bb.xmax, 0)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3885,17 +3885,38 @@ class TestCadQuery(BaseTest):
         )
 
     def testTextAlignment(self):
-        left_bottom = Workplane().text("I", 10, 0, halign="left", valign="bottom")
+        left_bottom = Workplane().text(
+            "I",
+            10,
+            0,
+            halign="left",
+            valign="bottom",
+            fontPath="./doc/_static/logo/Roboto_Font/Roboto-Bold.ttf",
+        )
         lb_bb = left_bottom.val().BoundingBox()
         self.assertGreaterEqual(lb_bb.xmin, 0)
         self.assertGreaterEqual(lb_bb.ymin, 0)
 
-        centers = Workplane().text("I", 10, 0, halign="center", valign="center")
+        centers = Workplane().text(
+            "I",
+            10,
+            0,
+            halign="center",
+            valign="center",
+            fontPath="./doc/_static/logo/Roboto_Font/Roboto-Bold.ttf",
+        )
         c_bb = centers.val().BoundingBox()
         self.assertAlmostEqual(c_bb.center.x, 0, places=0)
         self.assertAlmostEqual(c_bb.center.y, 0, places=0)
 
-        right_top = Workplane().text("I", 10, 0, halign="right", valign="top")
+        right_top = Workplane().text(
+            "I",
+            10,
+            0,
+            halign="right",
+            valign="top",
+            fontPath="./doc/_static/logo/Roboto_Font/Roboto-Bold.ttf",
+        )
         rt_bb = right_top.val().BoundingBox()
         self.assertLessEqual(rt_bb.xmax, 0)
         self.assertLessEqual(rt_bb.ymax, 0)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3891,7 +3891,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="left",
             valign="bottom",
-            fontPath="./doc/_static/logo/Roboto_Font/Roboto-Bold.ttf",
+            fontPath="tests/testdata/OpenSans-Regular.ttf",
         )
         lb_bb = left_bottom.val().BoundingBox()
         self.assertGreaterEqual(lb_bb.xmin, 0)
@@ -3903,7 +3903,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="center",
             valign="center",
-            fontPath="./doc/_static/logo/Roboto_Font/Roboto-Bold.ttf",
+            fontPath="tests/testdata/OpenSans-Regular.ttf",
         )
         c_bb = centers.val().BoundingBox()
         self.assertAlmostEqual(c_bb.center.x, 0, places=0)
@@ -3915,7 +3915,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="right",
             valign="top",
-            fontPath="./doc/_static/logo/Roboto_Font/Roboto-Bold.ttf",
+            fontPath="tests/testdata/OpenSans-Regular.ttf",
         )
         rt_bb = right_top.val().BoundingBox()
         self.assertLessEqual(rt_bb.xmax, 0)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3888,36 +3888,21 @@ class TestCadQuery(BaseTest):
 
     def testTextAlignment(self):
         left_bottom = Workplane().text(
-            "I",
-            10,
-            0,
-            halign="left",
-            valign="bottom",
-            fontPath=testFont,
+            "I", 10, 0, halign="left", valign="bottom", fontPath=testFont,
         )
         lb_bb = left_bottom.val().BoundingBox()
         self.assertGreaterEqual(lb_bb.xmin, 0)
         self.assertGreaterEqual(lb_bb.ymin, 0)
 
         centers = Workplane().text(
-            "I",
-            10,
-            0,
-            halign="center",
-            valign="center",
-            fontPath=testFont,
+            "I", 10, 0, halign="center", valign="center", fontPath=testFont,
         )
         c_bb = centers.val().BoundingBox()
         self.assertAlmostEqual(c_bb.center.x, 0, places=0)
         self.assertAlmostEqual(c_bb.center.y, 0, places=0)
 
         right_top = Workplane().text(
-            "I",
-            10,
-            0,
-            halign="right",
-            valign="top",
-            fontPath=testFont,
+            "I", 10, 0, halign="right", valign="top", fontPath=testFont,
         )
         rt_bb = right_top.val().BoundingBox()
         self.assertLessEqual(rt_bb.xmax, 0)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -25,7 +25,7 @@ from tests import (
 )
 
 # test data directory
-testdataDir = Path(os.path.dirname(__file__), "testdata")
+testdataDir = Path(__file__).parent.joinpath("testdata")
 testFont = str(testdataDir / "OpenSans-Regular.ttf")
 
 # where unit test output will be saved

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -4,6 +4,7 @@
 """
 # system modules
 import math, os.path, time, tempfile
+from pathlib import Path
 from random import random
 from random import randrange
 from itertools import product
@@ -24,7 +25,8 @@ from tests import (
 )
 
 # test data directory
-testdataDir = os.path.join(os.path.dirname(__file__), "testdata")
+testdataDir = Path(os.path.dirname(__file__), "testdata")
+testFont = str(testdataDir / "OpenSans-Regular.ttf")
 
 # where unit test output will be saved
 OUTDIR = tempfile.gettempdir()
@@ -3843,7 +3845,7 @@ class TestCadQuery(BaseTest):
                 "CQ 2.0",
                 0.5,
                 0.05,
-                fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
+                fontPath=testFont,
                 cut=False,
                 combine=False,
                 halign="right",
@@ -3863,7 +3865,7 @@ class TestCadQuery(BaseTest):
                 "CQ 2.0",
                 0.5,
                 0.05,
-                fontPath=os.path.join(testdataDir, "OpenSans-Irregular.ttf"),
+                fontPath=testFont,
                 cut=False,
                 combine=False,
                 halign="right",
@@ -3891,7 +3893,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="left",
             valign="bottom",
-            fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
+            fontPath=testFont,
         )
         lb_bb = left_bottom.val().BoundingBox()
         self.assertGreaterEqual(lb_bb.xmin, 0)
@@ -3903,7 +3905,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="center",
             valign="center",
-            fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
+            fontPath=testFont,
         )
         c_bb = centers.val().BoundingBox()
         self.assertAlmostEqual(c_bb.center.x, 0, places=0)
@@ -3915,7 +3917,7 @@ class TestCadQuery(BaseTest):
             0,
             halign="right",
             valign="top",
-            fontPath=os.path.join(testdataDir, "OpenSans-Regular.ttf"),
+            fontPath=testFont,
         )
         rt_bb = right_top.val().BoundingBox()
         self.assertLessEqual(rt_bb.xmax, 0)


### PR DESCRIPTION
Uses the logo that is embedded in the repo for CadQuery's logo in order to prevent text alignment test failures across platforms.

Closes #1569 and #187 