### PR TITLE
Add shape and workplane support to the Workplane.eachpoint() function. Issue #1395

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2500,7 +2500,7 @@ class Workplane(object):
         clean: bool = True,
     ) -> T:
         """
-        Same as each(), except arg is translated by the positions on the stack. If arg is the a callback function, then the the function is called for each point on the stack, and the resulting shape is used.
+        Same as each(), except arg is translated by the positions on the stack. If arg is a callback function, then the function is called for each point on the stack, and the resulting shape is used.
         :return: CadQuery object which contains a list of  vectors (points ) on its stack.
 
         :param useLocalCoordinates: should points be in local or global coordinates

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -17,7 +17,6 @@
     License along with this library; If not, see <http://www.gnu.org/licenses/>
 """
 
-from __future__ import annotations
 import math
 from copy import copy
 from itertools import chain
@@ -2495,7 +2494,7 @@ class Workplane(object):
 
     def eachpoint(
         self: T,
-        arg: Shape | Workplane | Callable[[Location], Shape],
+        arg: Union[Shape, Workplane, Callable[[Location], Shape]],
         useLocalCoordinates: bool = False,
         combine: CombineMode = False,
         clean: bool = True,
@@ -2557,7 +2556,7 @@ class Workplane(object):
                 res = [arg.moved(p).move(loc) for p in pnts]
             else:
                 res = [arg.moved(p * loc) for p in pnts]
-        elif hasattr(arg, "__call__"):
+        elif isinstance(arg, Callable):
             if useLocalCoordinates:
                 res = [arg(p).move(loc) for p in pnts]
             else:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2494,7 +2494,7 @@ class Workplane(object):
 
     def eachpoint(
         self: T,
-        arg: Union[Shape, Workplane, Callable[[Location], Shape]],
+        arg: Union[Shape, "Workplane", Callable[[Location], Shape]],
         useLocalCoordinates: bool = False,
         combine: CombineMode = False,
         clean: bool = True,
@@ -2556,13 +2556,13 @@ class Workplane(object):
                 res = [arg.moved(p).move(loc) for p in pnts]
             else:
                 res = [arg.moved(p * loc) for p in pnts]
-        elif isinstance(arg, Callable):
+        elif callable(arg):
             if useLocalCoordinates:
                 res = [arg(p).move(loc) for p in pnts]
             else:
                 res = [arg(p * loc) for p in pnts]
         else:
-            raise RuntimeError("Unknown argument type!")
+            raise ValueError(f"{arg} is not supported")
 
         for r in res:
             if isinstance(r, Wire) and not r.forConstruction:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -132,6 +132,7 @@ class CQContext(object):
         self.pendingWires = []
         return out
 
+
 class Workplane(object):
     """
     Defines a coordinate system in space, in which 2D coordinates can be used.

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5380,7 +5380,7 @@ class TestCadQuery(BaseTest):
         )
 
         # Test that unknown types throw an exception
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaises(ValueError) as cm:
             box.faces().eachpoint(42)  # Integers not allowed
 
     def testSketch(self):

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5355,6 +5355,10 @@ class TestCadQuery(BaseTest):
             r.val().Volume(), box.val().Volume() + 3 * sph.val().Volume()
         )
 
+        # Test that unknown types throw an exception
+        with self.assertRaises(RuntimeError) as cm:
+            box.faces().eachpoint(42)  # Integers not allowed
+
     def testSketch(self):
 
         r1 = (

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5331,6 +5331,31 @@ class TestCadQuery(BaseTest):
         r = ref.vertices().eachpoint(lambda loc: box.moved(loc), combine="cut")
         self.assertGreater(ref.val().Volume(), r.val().Volume())
 
+        # test eachpoint with a wire cutThru()
+        holeRadius = 1
+        wire = Wire.makeCircle(holeRadius, (0, 0, 0), (0, 0, 1))
+        boxHeight = 1
+        ref = Workplane("XY").box(10, 10, boxHeight)
+        r = (
+            ref.faces(">Z")
+            .rect(7, 7, forConstruction=True)
+            .vertices()
+            .eachpoint(wire)
+            .cutThruAll()
+        )
+        holeVolume = math.pi * holeRadius**2 * boxHeight
+        self.assertAlmostEqual(r.val().Volume(), ref.val().Volume() - holeVolume* 4)
+
+        # test eachpoint with a workplane
+        box = Workplane().box(2, 2, 2)
+        sph = Workplane().sphere(1.0)
+        # Place the sphere in the center of each box face
+        r = box.faces().eachpoint(sph, combine=True)
+        self.assertAlmostEqual(
+            r.val().Volume(), box.val().Volume() + 3 * sph.val().Volume()
+        )
+
+
     def testSketch(self):
 
         r1 = (

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5346,11 +5346,35 @@ class TestCadQuery(BaseTest):
         holeVolume = math.pi * holeRadius ** 2 * boxHeight
         self.assertAlmostEqual(r.val().Volume(), ref.val().Volume() - holeVolume * 4)
 
+        # same with useLocalCoordinates, which should give the same result
+        holeRadius = 1
+        wire = Wire.makeCircle(holeRadius, (0, 0, 0), (0, 0, 1))
+        boxHeight = 1
+        ref = Workplane("XY").box(10, 10, boxHeight)
+        r = (
+            ref.faces(">Z")
+            .rect(7, 7, forConstruction=True)
+            .vertices()
+            .eachpoint(wire, useLocalCoordinates=True)
+            .cutThruAll()
+        )
+        holeVolume = math.pi * holeRadius ** 2 * boxHeight
+        self.assertAlmostEqual(r.val().Volume(), ref.val().Volume() - holeVolume * 4)
+
         # test eachpoint with a workplane
         box = Workplane().box(2, 2, 2)
         sph = Workplane().sphere(1.0)
         # Place the sphere in the center of each box face
         r = box.faces().eachpoint(sph, combine=True)
+        self.assertAlmostEqual(
+            r.val().Volume(), box.val().Volume() + 3 * sph.val().Volume()
+        )
+
+        # same with useLocalCoordinates which should give the same result
+        box = Workplane().box(2, 2, 2)
+        sph = Workplane().sphere(1.0)
+        # Place the sphere in the center of each box face
+        r = box.faces().eachpoint(sph, combine=True, useLocalCoordinates=True)
         self.assertAlmostEqual(
             r.val().Volume(), box.val().Volume() + 3 * sph.val().Volume()
         )

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5343,8 +5343,8 @@ class TestCadQuery(BaseTest):
             .eachpoint(wire)
             .cutThruAll()
         )
-        holeVolume = math.pi * holeRadius**2 * boxHeight
-        self.assertAlmostEqual(r.val().Volume(), ref.val().Volume() - holeVolume* 4)
+        holeVolume = math.pi * holeRadius ** 2 * boxHeight
+        self.assertAlmostEqual(r.val().Volume(), ref.val().Volume() - holeVolume * 4)
 
         # test eachpoint with a workplane
         box = Workplane().box(2, 2, 2)
@@ -5354,7 +5354,6 @@ class TestCadQuery(BaseTest):
         self.assertAlmostEqual(
             r.val().Volume(), box.val().Volume() + 3 * sph.val().Volume()
         )
-
 
     def testSketch(self):
 


### PR DESCRIPTION
This PR solves issue #1395 and adds the ability to use the `Workplane.eachpoint()` function with a `Shape` and a `Workplane`.

Here are is an example for using a wire to do a `cutThru()`:

```python
wire = Wire.makeCircle(1, (0, 0, 0), (0, 0, 1))
result = (
    Workplane("XY")
    .box(10, 10, 1)
    .faces(">Z")
    .rect(7, 7, forConstruction=True)
    .vertices()
    .eachpoint(wire)
    .cutThruAll()
)
```

And here is an example for using another workplane, adding a sphere to the center of each face:
```python
box = Workplane().box(2, 2, 2)
sph = Workplane().sphere(1.0)
# Place the sphere in the center of each box face
r = box.faces().eachpoint(sph, combine=True)
```
