### PR TITLE
Fix lineTo to do nothing instead of raising error when 0 length

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1622,6 +1622,9 @@ class Workplane(object):
 
         endPoint = self.plane.toWorldCoords((x, y))
 
+        if startPoint == endPoint:
+            return self
+        
         p = Edge.makeLine(startPoint, endPoint)
 
         if not forConstruction:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1624,7 +1624,7 @@ class Workplane(object):
 
         if startPoint == endPoint:
             return self
-        
+
         p = Edge.makeLine(startPoint, endPoint)
 
         if not forConstruction:


### PR DESCRIPTION
Before the change it raised an error when startPoint and endPoint were equal