### PR TITLE
Get rid of nptyping

### DIFF
--- a/cadquery/occ_impl/sketch_solver.py
+++ b/cadquery/occ_impl/sketch_solver.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union, Any, Callable, List, Optional, Iterable, Dict, Sequence
 from typing import Literal
-from nptyping import NDArray as Array
-from nptyping import Float
+from numpy.typing import NDArray as Array
+from numpy import float64 as Float
 from itertools import accumulate, chain
 from math import sin, cos, radians
 
@@ -263,12 +263,12 @@ class SketchConstraintSolver(object):
         self.ixs = [0] + list(accumulate(len(e) for e in self.entities))
 
     def _cost(
-        self, x0: Array[Any, Float]
+        self, x0: Array[Float]
     ) -> Tuple[
-        Callable[[Array[Any, Float]], float],
-        Callable[[Array[Any, Float], Array[Any, Float]], None],
-        Array[Any, Float],
-        Array[Any, Float],
+        Callable[[Array[Float]], float],
+        Callable[[Array[Float], Array[Float]], None],
+        Array[Float],
+        Array[Float],
     ]:
 
         ixs = self.ixs

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - nlopt
     - multimethod >=1.11,<2.0
     - casadi
+    - typish
 
 test:
   requires:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - ezdxf
     - ipython
     - typing_extensions
-    - nptyping >=2.0.1
     - nlopt
     - multimethod >=1.11,<2.0
     - casadi

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - nlopt
   - path
   - casadi
+  - typish
   - multimethod >=1.11,<2.0
   - typed-ast
   - regex

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - pytest-cov
   - ezdxf
   - typing_extensions
-  - nptyping=2.0.1
   - nlopt
   - path
   - casadi

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ if not is_rtd and not is_appveyor and not is_azure and not is_conda:
         "ezdxf",
         "multimethod>=1.11,<2.0",
         "nlopt",
-        "nptyping==2.0.1",
         "typish",
         "casadi",
         "path",


### PR DESCRIPTION
Nptyping does not seem to be actively maintained and is not strictly needed.

Closes #1616 and https://github.com/CadQuery/CQ-editor/issues/442