### PR TITLE
Face sweep for free function API

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -4499,7 +4499,7 @@ def rect(w: float, h: float) -> Shape:
 @multimethod
 def spline(*pts: VectorLike, tol: float = 1e-6, periodic: bool = False) -> Shape:
     """
-    Construct a polygon (closed polyline) from points.
+    Construct a spline from points.
     """
 
     data = _pts_to_harray(pts)
@@ -4928,6 +4928,7 @@ def offset(s: Shape, t: float, cap=True, tol: float = 1e-6) -> Shape:
 def sweep(s: Shape, path: Shape, cap: bool = False) -> Shape:
     """
     Sweep edge, wire or face along a path. For faces cap has no effect.
+    Do not mix faces with other types.
     """
 
     spine = _get_one_wire(path)
@@ -4968,7 +4969,7 @@ def sweep(s: Shape, path: Shape, cap: bool = False) -> Shape:
 def sweep(s: Sequence[Shape], path: Shape, cap: bool = False) -> Shape:
     """
     Sweep edges, wires or faces along a path, multiple sections are supported. 
-    For faces cap has no effect.
+    For faces cap has no effect. Do not mix faces with other types.
     """
 
     spine = _get_one_wire(path)
@@ -5032,7 +5033,7 @@ def sweep(s: Sequence[Shape], path: Shape, cap: bool = False) -> Shape:
 @multimethod
 def loft(s: Sequence[Shape], cap: bool = False, ruled: bool = False) -> Shape:
     """
-    Loft edges, wires or faces. For faces cap has no effect.
+    Loft edges, wires or faces. For faces cap has no effect. Do not mix faces with other types.
     """
 
     results = []
@@ -5073,7 +5074,7 @@ def loft(s: Sequence[Shape], cap: bool = False, ruled: bool = False) -> Shape:
 
         results.append((Shape(builder.Shape()) - compound(inner_parts)).wrapped)
 
-    # otherwise construct usig wires
+    # otherwise construct using wires
     if not results:
         for el in _get_wire_lists(s):
             builder.Init(cap, ruled)

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -4924,7 +4924,6 @@ def offset(s: Shape, t: float, cap=True, tol: float = 1e-6) -> Shape:
     return _compound_or_shape(results)
 
 
-
 @multimethod
 def sweep(s: Shape, path: Shape, cap: bool = False) -> Shape:
     """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -4927,7 +4927,7 @@ def offset(s: Shape, t: float, cap=True, tol: float = 1e-6) -> Shape:
 @multimethod
 def sweep(s: Shape, path: Shape, cap: bool = False) -> Shape:
     """
-    Sweep edge, wire or face along a path.
+    Sweep edge, wire or face along a path. For faces cap has no effect.
     """
 
     spine = _get_one_wire(path)
@@ -4967,7 +4967,8 @@ def sweep(s: Shape, path: Shape, cap: bool = False) -> Shape:
 @sweep.register
 def sweep(s: Sequence[Shape], path: Shape, cap: bool = False) -> Shape:
     """
-    Sweep edges, wires or faces along a path, multiple sections are supported.
+    Sweep edges, wires or faces along a path, multiple sections are supported. 
+    For faces cap has no effect.
     """
 
     spine = _get_one_wire(path)
@@ -5031,7 +5032,7 @@ def sweep(s: Sequence[Shape], path: Shape, cap: bool = False) -> Shape:
 @multimethod
 def loft(s: Sequence[Shape], cap: bool = False, ruled: bool = False) -> Shape:
     """
-    Loft edges or wires.
+    Loft edges, wires or faces. For faces cap has no effect.
     """
 
     results = []

--- a/doc/free-func.rst
+++ b/doc/free-func.rst
@@ -197,26 +197,27 @@ Free function API currently supports :meth:`~cadquery.occ_impl.shapes.extrude`, 
 .. cadquery::
 
     from cadquery.occ_impl.shapes import *
-
+    
     r = rect(1,0.5)
+    f = face(r, circle(0.2).moved(0.2), rect(0.2, 0.4).moved(-0.2))
     c = circle(0.2)
-    p = spline([(0,0,0), (0,1,2)], [(0,0,1), (0,1,1)])
-
+    p = spline([(0,0,0), (0,-1,2)], [(0,0,1), (0,-1,1)])
+    
     # extrude
     s1 = extrude(r, (0,0,2))
     s2 = extrude(fill(r), (0,0,1))
-
+    
     # sweep
     s3 = sweep(r, p)
-    s4 = sweep(r, p, cap=True)
-
+    s4 = sweep(f, p)
+    
     # loft
     s5 = loft(r, c.moved(z=2))
     s6 = loft(r, c.moved(z=1), cap=True)\
-
+    
     # revolve
     s7 = revolve(fill(r), (0.5, 0, 0), (0, 1, 0), 90)
-
+    
     results = (s1, s2, s3, s4, s5, s6, s7)
     result = compound([el.moved(2*i) for i,el in enumerate(results)])
 

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -488,16 +488,22 @@ def test_sweep():
     w1 = rect(1, 1)
     w2 = w1.moved(Location(0, 0, 1))
 
+    f1 = face(rect(1, 1), circle(0.25))
+    f2 = face(rect(2, 1), ellipse(0.9, 0.45)).moved(x=2, z=2, ry=90)
+
     p1 = segment((0, 0, 0), (0, 0, 1))
     p2 = spline((w1.Center(), w2.Center()), ((-0.5, 0, 1), (0.5, 0, 1)))
+    p3 = spline((f1.Center(), f2.Center()), ((0, 0, 1), (1, 0, 0)))
 
-    r1 = sweep(w1, p1)
-    r2 = sweep((w1, w2), p1)
-    r3 = sweep(w1, p1, cap=True)
-    r4 = sweep((w1, w2), p1, cap=True)
-    r5 = sweep((w1, w2), p2, cap=True)
+    r1 = sweep(w1, p1)  # simple sweep
+    r2 = sweep((w1, w2), p1)  # multi-section sweep
+    r3 = sweep(w1, p1, cap=True)  # simple with cap
+    r4 = sweep((w1, w2), p1, cap=True)  # multi-section with cap
+    r5 = sweep((w1, w2), p2, cap=True)  # see above
+    r6 = sweep(f1, p3)  # simple face sweep
+    r7 = sweep((f1, f2), p3)  # multi-section face sweep
 
-    assert_all_valid(r1, r2, r3, r4, r5)
+    assert_all_valid(r1, r2, r3, r4, r5, r6, r7)
 
     assert r1.Area() == approx(4)
     assert r2.Area() == approx(4)
@@ -505,6 +511,8 @@ def test_sweep():
     assert r4.Volume() == approx(1)
     assert r5.Volume() > 0
     assert len(r5.Faces()) == 6
+    assert len(r6.Faces()) == 7
+    assert len(r7.Faces()) == 7
 
 
 def test_loft():
@@ -516,16 +524,23 @@ def test_loft():
     w4 = segment((0, 0), (1, 0))
     w5 = w4.moved(0, 0, 1)
 
+    f1 = face(rect(2, 1), rect(0.5, 0.2).moved(x=0.5), rect(0.5, 0.2).moved(x=-0.5))
+    f2 = face(rect(3, 2), circle(0.5).moved(x=0.7), circle(0.5).moved(x=-0.7)).moved(
+        z=1
+    )
+
     r1 = loft(w1, w2, w3)  # loft
     r2 = loft(w1, w2, w3, ruled=True)  # ruled loft
     r3 = loft([w1, w2, w3])  # overload
     r4 = loft(w1, w2, w3, cap=True)  # capped loft
     r5 = loft(w4, w5)  # loft with open edges
+    r6 = loft(f1, f2)  # loft with faces
 
-    assert_all_valid(r1, r2, r3, r4, r5)
+    assert_all_valid(r1, r2, r3, r4, r5, r6)
 
     assert len(r1.Faces()) == 1
     assert len(r2.Faces()) == 2
     assert len((r1 - r3).Faces()) == 0
     assert r4.Volume() > 0
     assert r5.Area() == approx(1)
+    assert len(r6.Faces()) == 16

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -490,6 +490,7 @@ def test_sweep():
 
     f1 = face(rect(1, 1), circle(0.25))
     f2 = face(rect(2, 1), ellipse(0.9, 0.45)).moved(x=2, z=2, ry=90)
+    f3 = face(rect(1, 1))
 
     p1 = segment((0, 0, 0), (0, 0, 1))
     p2 = spline((w1.Center(), w2.Center()), ((-0.5, 0, 1), (0.5, 0, 1)))
@@ -502,8 +503,9 @@ def test_sweep():
     r5 = sweep((w1, w2), p2, cap=True)  # see above
     r6 = sweep(f1, p3)  # simple face sweep
     r7 = sweep((f1, f2), p3)  # multi-section face sweep
+    r8 = sweep(f3, p3)  # simplest face sweep (no inner wires)
 
-    assert_all_valid(r1, r2, r3, r4, r5, r6, r7)
+    assert_all_valid(r1, r2, r3, r4, r5, r6, r7, r8)
 
     assert r1.Area() == approx(4)
     assert r2.Area() == approx(4)
@@ -513,6 +515,7 @@ def test_sweep():
     assert len(r5.Faces()) == 6
     assert len(r6.Faces()) == 7
     assert len(r7.Faces()) == 7
+    assert len(r8.Faces()) == 4
 
 
 def test_loft():

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -515,7 +515,7 @@ def test_sweep():
     assert len(r5.Faces()) == 6
     assert len(r6.Faces()) == 7
     assert len(r7.Faces()) == 7
-    assert len(r8.Faces()) == 4
+    assert len(r8.Faces()) == 6
 
 
 def test_loft():


### PR DESCRIPTION
Resolves #1621  Now it is possible to do this:
```python
from cadquery.occ_impl.shapes import *

f1 = face(rect(1, 1), circle(0.25))
f2 = face(rect(2, 1), ellipse(0.9, 0.45)).moved(x=2, z=2, ry=90)

p3 = spline(
    (f1.Center(), f2.Center()), ((0, 0, 1), (1, 0, 0))
    )

r8 = sweep((f1, f2), p3)
```
![afbeelding](https://github.com/CadQuery/cadquery/assets/13981538/2fe84bec-d7bd-41d3-8a9f-188aeacbc321)