### PR TITLE
fix: Transform order in subassembly

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -290,7 +290,8 @@ class Assembly(object):
                 obj = cast(Assembly, obj.parent)
                 name_out = obj.name
 
-            rv = reduce(lambda l1, l2: l1 * l2, locs)
+            # This must reduce in the order of (parent, ..., child)
+            rv = reduce(lambda l1, l2: l2 * l1, locs)
 
         return (rv, name_out)
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1608,3 +1608,27 @@ def test_imprinting(touching_assy, disjoint_assy):
 
     for s in r.Solids():
         assert s in o
+
+def test_order_of_transform():
+    cube = cq.Solid.makeBox(1, 1, 1)
+    inner = (
+        cq.Assembly()
+        .add(cube, name="c1")
+        .add(cube, name="c2", loc=cq.Location((0, 0, 1), (0, 1, 0), 45))
+    )
+    middle = (
+        cq.Assembly()
+        .add(inner, name="inner", loc=cq.Location((0, 1, 0), (0, 0, 1), 30))
+    )
+    outer = (
+        cq.Assembly()
+        .add(middle, name="middle", loc=cq.Location((0,0,0)))
+    )
+
+
+    name, _ = middle._query("inner/c2")
+    loc1, _ = middle._subloc(name)
+
+    name, _ = outer._query("middle/inner/c2")
+    loc2, _ = outer._subloc(name)
+    assert loc1.toTuple() == loc2.toTuple()

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1638,7 +1638,7 @@ def test_order_of_transform():
     assy2.constrain("marker2", "assy1/assy0/part1?vtag", "Point")
     assy2.solve()
 
-    # marker1 and marer2 should coincide
+    # marker1 and marker2 should coincide
     m1, m2 = assy2.toCompound().Solids()
 
     assert (m1.Center() - m2.Center()).Length == approx(0)

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1609,6 +1609,7 @@ def test_imprinting(touching_assy, disjoint_assy):
     for s in r.Solids():
         assert s in o
 
+
 def test_order_of_transform():
 
     part = cq.Workplane().box(1, 1, 1).faces(">Z").vertices("<XY").tag("vtag")

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -5,6 +5,7 @@ from math import degrees
 import copy
 from pathlib import Path, PurePath
 import re
+from pytest import approx
 
 import cadquery as cq
 from cadquery.occ_impl.exporters.assembly import (

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1631,4 +1631,8 @@ def test_order_of_transform():
 
     name, _ = outer._query("middle/inner/c2")
     loc2, _ = outer._subloc(name)
-    assert loc1.toTuple() == loc2.toTuple()
+
+    loc1_trans, loc1_rot = loc1.toTuple()
+    loc2_trans, loc2_rot = loc2.toTuple()
+    assert loc1_trans == approx(loc2_trans)
+    assert loc1_rot == approx(loc2_rot)


### PR DESCRIPTION
Fixes https://github.com/CadQuery/cadquery/issues/1628

Ideally I want to add some unit tests but I don't know the best way to approach this. Maybe test for the intersection volume of the black and white arrows?