### PR TITLE
Update Wire fillet docstring

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4444,24 +4444,27 @@ class Workplane(object):
     def filter(self: T, f: Callable[[CQObject], bool]) -> T:
         """
         Filter items using a boolean predicate.
+
         :param f: Callable to be used for filtering.
         :return: Workplane object with filtered items.
         """
 
         return self.newObject(filter(f, self.objects))
 
-    def map(self: T, f: Callable[[CQObject], CQObject]):
+    def map(self: T, f: Callable[[CQObject], CQObject]) -> T:
         """
         Apply a callable to every item separately.
+
         :param f: Callable to be applied to every item separately.
         :return: Workplane object with f applied to all items.
         """
 
         return self.newObject(map(f, self.objects))
 
-    def apply(self: T, f: Callable[[Iterable[CQObject]], Iterable[CQObject]]):
+    def apply(self: T, f: Callable[[Iterable[CQObject]], Iterable[CQObject]]) -> T:
         """
         Apply a callable to all items at once.
+
         :param f: Callable to be applied.
         :return: Workplane object with f applied to all items.
         """
@@ -4471,6 +4474,7 @@ class Workplane(object):
     def sort(self: T, key: Callable[[CQObject], Any]) -> T:
         """
         Sort items using a callable.
+
         :param key: Callable to be used for sorting.
         :return: Workplane object with items sorted.
         """
@@ -4479,11 +4483,12 @@ class Workplane(object):
 
     def invoke(
         self: T, f: Union[Callable[[T], T], Callable[[T], None], Callable[[], None]]
-    ):
+    ) -> T:
         """
         Invoke a callable mapping Workplane to Workplane or None. Supports also
         callables that take no arguments such as breakpoint. Returns self if callable
         returns None.
+
         :param f: Callable to be invoked.
         :return: Workplane object.
         """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2500,7 +2500,7 @@ class Wire(Shape, Mixin1D):
     ) -> "Wire":
         """
         Apply 2D or 3D fillet to a wire
-        :param wire: The input wire to fillet. Currently only open wires are supported
+
         :param radius: the radius of the fillet, must be > zero
         :param vertices: Optional list of vertices to fillet. By default all vertices are fillet.
         :return: A wire with filleted corners


### PR DESCRIPTION
PR #1549 added `fillet` with docstring that says "Currently only open wires are supported". 
PR #1573  added support for closed wires but the docstring was not update. 

There is also corruption of the Sphinx doc summary:

![Screenshot from 2024-07-14 19-54-43](https://github.com/user-attachments/assets/59b47161-94dd-42f2-bb86-69f17ad2453e)
