### PR TITLE
Sketch and Workplane improvements 

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -33,10 +33,10 @@ from .occ_impl.exporters.assembly import (
     exportVRML,
     exportGLTF,
     STEPExportModeLiterals,
-    ExportModes,
 )
 
 from .selectors import _expression_grammar as _selector_grammar
+from .utils import deprecate
 
 # type definitions
 AssemblyObjects = Union[Shape, Workplane, None]
@@ -450,7 +450,64 @@ class Assembly(object):
 
         return self
 
+    @deprecate()
     def save(
+        self,
+        path: str,
+        exportType: Optional[ExportLiterals] = None,
+        mode: STEPExportModeLiterals = "default",
+        tolerance: float = 0.1,
+        angularTolerance: float = 0.1,
+        **kwargs,
+    ) -> "Assembly":
+        """
+        Save assembly to a file.
+
+        :param path: Path and filename for writing.
+        :param exportType: export format (default: None, results in format being inferred form the path)
+        :param mode: STEP only - See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
+        :param tolerance: the deflection tolerance, in model units. Only used for glTF, VRML. Default 0.1.
+        :param angularTolerance: the angular tolerance, in radians. Only used for glTF, VRML. Default 0.1.
+        :param \\**kwargs: Additional keyword arguments.  Only used for STEP, glTF and STL.
+            See :meth:`~cadquery.occ_impl.exporters.assembly.exportAssembly`.
+        :param ascii: STL only - Sets whether or not STL export should be text or binary
+        :type ascii: bool
+        """
+
+        # Make sure the export mode setting is correct
+        if mode not in get_args(STEPExportModeLiterals):
+            raise ValueError(f"Unknown assembly export mode {mode} for STEP")
+
+        if exportType is None:
+            t = path.split(".")[-1].upper()
+            if t in ("STEP", "XML", "VRML", "VTKJS", "GLTF", "GLB", "STL"):
+                exportType = cast(ExportLiterals, t)
+            else:
+                raise ValueError("Unknown extension, specify export type explicitly")
+
+        if exportType == "STEP":
+            exportAssembly(self, path, mode, **kwargs)
+        elif exportType == "XML":
+            exportCAF(self, path)
+        elif exportType == "VRML":
+            exportVRML(self, path, tolerance, angularTolerance)
+        elif exportType == "GLTF" or exportType == "GLB":
+            exportGLTF(self, path, None, tolerance, angularTolerance)
+        elif exportType == "VTKJS":
+            exportVTKJS(self, path)
+        elif exportType == "STL":
+            # Handle the ascii setting for STL export
+            export_ascii = False
+            if "ascii" in kwargs:
+                export_ascii = bool(kwargs.get("ascii"))
+
+            self.toCompound().exportStl(path, tolerance, angularTolerance, export_ascii)
+        else:
+            raise ValueError(f"Unknown format: {exportType}")
+
+        return self
+
+    def export(
         self,
         path: str,
         exportType: Optional[ExportLiterals] = None,

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -33,6 +33,7 @@ from typing import (
     List,
     cast,
     Dict,
+    Iterator,
 )
 from typing_extensions import Literal
 from inspect import Parameter, Signature, isbuiltin
@@ -51,6 +52,7 @@ from .occ_impl.shapes import (
 )
 
 from .occ_impl.exporters.svg import getSVG, exportSVG
+from .occ_impl.exporters import export
 
 from .utils import deprecate, deprecate_kwarg_name
 
@@ -4478,7 +4480,7 @@ class Workplane(object):
 
         return rv
 
-    def __iter__(self: T) -> Iterable[Shape]:
+    def __iter__(self: T) -> Iterator[Shape]:
         """
         Special method for iterating over Shapes in objects
         """
@@ -4553,6 +4555,17 @@ class Workplane(object):
             raise ValueError("Provided function {f} accepts too many arguments")
 
         return rv
+
+    def export(self: T, fname: str) -> T:
+        """
+        Export Workplane to file.
+        :param path: Filename.
+        :return: Self.
+        """
+
+        export(self, fname)
+
+        return self
 
 
 # alias for backward compatibility

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3680,6 +3680,10 @@ class Workplane(object):
         for el in self.objects:
             if isinstance(el, Sketch):
                 rv.extend(el)
+            elif isinstance(el, Face):
+                rv.append(el)
+            elif isinstance(el, Compound):
+                rv.extend(subel for subel in el if isinstance(subel, Face))
 
         if not rv:
             rv.extend(wiresToFaces(self.ctx.popPendingWires()))

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -3414,6 +3414,7 @@ class Workplane(object):
 
         return self.newObject([r])
 
+    @deprecate()
     def __or__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
@@ -3522,6 +3523,7 @@ class Workplane(object):
 
         return self.newObject([newS])
 
+    @deprecate()
     def __and__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for intersect.

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1472,8 +1472,8 @@ class Workplane(object):
         If you want to position the array at another point, create another workplane
         that is shifted to the position you would like to use as a reference
 
-        :param xSpacing: spacing between points in the x direction ( must be > 0)
-        :param ySpacing: spacing between points in the y direction ( must be > 0)
+        :param xSpacing: spacing between points in the x direction ( must be >= 0)
+        :param ySpacing: spacing between points in the y direction ( must be >= 0)
         :param xCount: number of points ( > 0 )
         :param yCount: number of points ( > 0 )
         :param center: If True, the array will be centered around the workplane center.
@@ -1483,7 +1483,7 @@ class Workplane(object):
         """
 
         if (xSpacing <= 0 and ySpacing <= 0) or xCount < 1 or yCount < 1:
-            raise ValueError("Spacing and count must be > 0 ")
+            raise ValueError("Spacing and count must be > 0 in at least one direction")
 
         if isinstance(center, bool):
             center = (center, center)
@@ -4569,6 +4569,7 @@ class Workplane(object):
     ) -> T:
         """
         Export Workplane to file.
+        
         :param path: Filename.
         :param tolerance: the deflection tolerance, in model units. Default 0.1.
         :param angularTolerance: the angular tolerance, in radians. Default 0.1.

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4492,7 +4492,9 @@ class Workplane(object):
         """
 
         for el in self.objects:
-            if isinstance(el, Shape):
+            if isinstance(el, Compound):
+                yield from el
+            elif isinstance(el, Shape):
                 yield el
             elif isinstance(el, Sketch):
                 yield from el

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -270,7 +270,7 @@ class Workplane(object):
         ...
 
     @overload
-    def split(self: T, splitter: Union[T, Shape]) -> T:
+    def split(self: T, splitter: Union["Workplane", Shape]) -> T:
         ...
 
     def split(self: T, *args, **kwargs) -> T:
@@ -3414,7 +3414,7 @@ class Workplane(object):
 
         return self.newObject([r])
 
-    def __or__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
+    def __or__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
 
@@ -3426,15 +3426,15 @@ class Workplane(object):
             Sphere = Workplane("XY").sphere(1)
             result = Box | Sphere
         """
-        return self.union(toUnion)
+        return self.union(other)
 
-    def __add__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
+    def __add__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for union.
 
         Notice that :code:`r = a + b` is equivalent to :code:`r = a.union(b)` and :code:`r = a | b`.
         """
-        return self.union(toUnion)
+        return self.union(other)
 
     def cut(
         self: T,
@@ -3472,7 +3472,7 @@ class Workplane(object):
 
         return self.newObject([newS])
 
-    def __sub__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
+    def __sub__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for cut.
 
@@ -3484,7 +3484,7 @@ class Workplane(object):
             Sphere = Workplane("XY").sphere(1)
             result = Box - Sphere
         """
-        return self.cut(toUnion)
+        return self.cut(other)
 
     def intersect(
         self: T,
@@ -3522,7 +3522,7 @@ class Workplane(object):
 
         return self.newObject([newS])
 
-    def __and__(self: T, toUnion: Union["Workplane", Solid, Compound]) -> T:
+    def __and__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
         """
         Syntactic sugar for intersect.
 
@@ -3534,7 +3534,38 @@ class Workplane(object):
             Sphere = Workplane("XY").sphere(1)
             result = Box & Sphere
         """
-        return self.intersect(toUnion)
+
+        return self.intersect(other)
+
+    def __mul__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
+        """
+        Syntactic sugar for intersect.
+
+        Notice that :code:`r = a * b` is equivalent to :code:`r = a.intersect(b)`.
+
+        Example::
+
+            Box = Workplane("XY").box(1, 1, 1, centered=(False, False, False))
+            Sphere = Workplane("XY").sphere(1)
+            result = Box * Sphere
+        """
+
+        return self.intersect(other)
+
+    def __truediv__(self: T, other: Union["Workplane", Solid, Compound]) -> T:
+        """
+        Syntactic sugar for intersect.
+
+        Notice that :code:`r = a / b` is equivalent to :code:`r = a.split(b)`.
+
+        Example::
+
+            Box = Workplane("XY").box(1, 1, 1, centered=(False, False, False))
+            Sphere = Workplane("XY").sphere(1)
+            result = Box / Sphere
+        """
+
+        return self.split(other)
 
     def cutBlind(
         self: T,

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -36,7 +36,7 @@ from typing import (
     Iterator,
 )
 from typing_extensions import Literal
-from inspect import Parameter, Signature, isbuiltin
+from inspect import Parameter, Signature
 
 
 from .occ_impl.geom import Vector, Plane, Location
@@ -54,7 +54,7 @@ from .occ_impl.shapes import (
 from .occ_impl.exporters.svg import getSVG, exportSVG
 from .occ_impl.exporters import export
 
-from .utils import deprecate, deprecate_kwarg_name
+from .utils import deprecate, deprecate_kwarg_name, get_arity
 
 from .selectors import (
     Selector,
@@ -4544,11 +4544,7 @@ class Workplane(object):
         :return: Workplane object.
         """
 
-        if isbuiltin(f):
-            arity = 0  # assume 0 arity for builtins; they cannot be introspected
-        else:
-            arity = f.__code__.co_argcount  # NB: this is not understood by mypy
-
+        arity = get_arity(f)
         rv = self
 
         if arity == 0:

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1470,7 +1470,7 @@ class Workplane(object):
           centering along each axis.
         """
 
-        if xSpacing <= 0 or ySpacing <= 0 or xCount < 1 or yCount < 1:
+        if (xSpacing <= 0 and ySpacing <= 0) or xCount < 1 or yCount < 1:
             raise ValueError("Spacing and count must be > 0 ")
 
         if isinstance(center, bool):

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4556,14 +4556,25 @@ class Workplane(object):
 
         return rv
 
-    def export(self: T, fname: str) -> T:
+    def export(
+        self: T,
+        fname: str,
+        tolerance: float = 0.1,
+        angularTolerance: float = 0.1,
+        opt: Optional[Dict[str, Any]] = None,
+    ) -> T:
         """
         Export Workplane to file.
         :param path: Filename.
+        :param tolerance: the deflection tolerance, in model units. Default 0.1.
+        :param angularTolerance: the angular tolerance, in radians. Default 0.1.
+        :param opt: additional options passed to the specific exporter. Default None.
         :return: Self.
         """
 
-        export(self, fname)
+        export(
+            self, fname, tolerance=tolerance, angularTolerance=angularTolerance, opt=opt
+        )
 
         return self
 

--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -4478,6 +4478,17 @@ class Workplane(object):
 
         return rv
 
+    def __iter__(self: T) -> Iterable[Shape]:
+        """
+        Special method for iterating over Shapes in objects
+        """
+
+        for el in self.objects:
+            if isinstance(el, Shape):
+                yield el
+            elif isinstance(el, Sketch):
+                yield from el
+
     def filter(self: T, f: Callable[[CQObject], bool]) -> T:
         """
         Filter items using a boolean predicate.

--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -28,10 +28,11 @@ class ExportTypes:
     VRML = "VRML"
     VTP = "VTP"
     THREEMF = "3MF"
+    BREP = "BREP"
 
 
 ExportLiterals = Literal[
-    "STL", "STEP", "AMF", "SVG", "TJS", "DXF", "VRML", "VTP", "3MF"
+    "STL", "STEP", "AMF", "SVG", "TJS", "DXF", "VRML", "VTP", "3MF", "BREP"
 ]
 
 
@@ -123,6 +124,9 @@ def export(
 
     elif exportType == ExportTypes.VTP:
         exportVTP(shape, fname, tolerance, angularTolerance)
+
+    elif exportType == ExportTypes.BREP:
+        shape.exportBrep(fname)
 
     else:
         raise ValueError("Unknown export type")

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -149,7 +149,7 @@ class DxfDocument:
     def add_shape(self, shape: Union[WorkplaneLike, Shape], layer: str = "") -> Self:
         """Add CadQuery shape to a DXF layer.
 
-        :param s: CadQuery Workplane or shape
+        :param s: CadQuery Workplane or Shape
         :param layer: layer definition name
         """
 

--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -135,7 +135,7 @@ class DxfDocument:
         if isinstance(shape, Workplane):
             plane = shape.plane
             shape_ = toCompound(shape).transformShape(plane.fG)
-        elif isinstance(shape, Shape):
+        else:
             shape_ = shape
 
         general_attributes = {}

--- a/cadquery/occ_impl/exporters/threemf.py
+++ b/cadquery/occ_impl/exporters/threemf.py
@@ -4,7 +4,7 @@ import xml.etree.cElementTree as ET
 from typing import IO, List, Literal, Tuple, Union
 from zipfile import ZipFile, ZIP_DEFLATED, ZIP_STORED
 
-from ...cq import Compound, Shape, Vector
+from ..shapes import Compound, Shape, Vector
 
 
 class CONTENT_TYPES(object):
@@ -48,8 +48,8 @@ class ThreeMFWriter(object):
     def write3mf(
         self, outfile: Union[PathLike, str, IO[bytes]],
     ):
-        """ 
-        Write to the given file. 
+        """
+        Write to the given file.
         """
 
         try:

--- a/cadquery/occ_impl/exporters/utils.py
+++ b/cadquery/occ_impl/exporters/utils.py
@@ -1,7 +1,0 @@
-from ...cq import Workplane
-from ..shapes import Compound, Shape
-
-
-def toCompound(shape: Workplane) -> Compound:
-
-    return Compound.makeCompound(val for val in shape.vals() if isinstance(val, Shape))

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1576,14 +1576,22 @@ class Shape(object):
 
         return split(self, other)
 
-    def export(self, fname: str):
+    def export(
+        self: T,
+        fname: str,
+        tolerance: float = 0.1,
+        angularTolerance: float = 0.1,
+        opt: Optional[Dict[str, Any]] = None,
+    ):
         """
         Export Shape to file.
         """
 
         from .exporters import export  # imported here to prevent circular imports
 
-        export(self, fname)
+        export(
+            self, fname, tolerance=tolerance, angularTolerance=angularTolerance, opt=opt
+        )
 
 
 class ShapeProtocol(Protocol):

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1576,6 +1576,15 @@ class Shape(object):
 
         return split(self, other)
 
+    def export(self, fname: str):
+        """
+        Export Shape to file.
+        """
+
+        from .exporters import export  # imported here to prevent circular imports
+
+        export(self, fname)
+
 
 class ShapeProtocol(Protocol):
     @property
@@ -4968,7 +4977,7 @@ def sweep(s: Shape, path: Shape, cap: bool = False) -> Shape:
 @sweep.register
 def sweep(s: Sequence[Shape], path: Shape, cap: bool = False) -> Shape:
     """
-    Sweep edges, wires or faces along a path, multiple sections are supported. 
+    Sweep edges, wires or faces along a path, multiple sections are supported.
     For faces cap has no effect. Do not mix faces with other types.
     """
 

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -1265,13 +1265,24 @@ class Sketch(object):
 
         return rv
 
-    def export(self: T, fname: str) -> T:
+    def export(
+        self: T,
+        fname: str,
+        tolerance: float = 0.1,
+        angularTolerance: float = 0.1,
+        opt: Optional[Dict[str, Any]] = None,
+    ) -> T:
         """
         Export Sketch to file.
         :param path: Filename.
+        :param tolerance: the deflection tolerance, in model units. Default 0.1.
+        :param angularTolerance: the angular tolerance, in radians. Default 0.1.
+        :param opt: additional options passed to the specific exporter. Default None.
         :return: Self.
         """
 
-        export(self, fname)
+        export(
+            self, fname, tolerance=tolerance, angularTolerance=angularTolerance, opt=opt
+        )
 
         return self

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -17,13 +17,13 @@ from typing import (
 
 from math import tan, sin, cos, pi, radians, remainder
 from itertools import product, chain
-from inspect import isbuiltin
 from multimethod import multimethod
 from typish import instance_of, get_type
 
 from .hull import find_hull
 from .selectors import StringSyntaxSelector, Selector
 from .types import Real
+from .utils import get_arity
 
 from .occ_impl.shapes import (
     Shape,
@@ -1286,11 +1286,7 @@ class Sketch(object):
         :return: Workplane object.
         """
 
-        if isbuiltin(f):
-            arity = 0  # assume 0 arity for builtins; they cannot be introspected
-        else:
-            arity = f.__code__.co_argcount  # NB: this is not understood by mypy
-
+        arity = get_arity(f)
         rv = self
 
         if arity == 0:

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -47,7 +47,7 @@ from .occ_impl.sketch_solver import (
 
 #%% types
 
-Modes = Literal["a", "s", "i", "c"]  # add, subtract, intersect, construct
+Modes = Literal["a", "s", "i", "c", "r"]  # add, subtract, intersect, construct, replace
 Point = Union[Vector, Tuple[Real, Real]]
 TOL = 1e-6
 
@@ -537,6 +537,8 @@ class Sketch(object):
             self._faces = self._faces.cut(*res)
         elif mode == "i":
             self._faces = self._faces.intersect(*res)
+        elif mode == "r":
+            self._faces = compound(res)
         elif mode == "c":
             if not tag:
                 raise ValueError("No tag specified - the geometry will be unreachable")
@@ -1112,6 +1114,33 @@ class Sketch(object):
             rv = list(self._faces)
 
         return rv
+
+    def add(self: T) -> T:
+        """
+        Add selection to the underlying faces.
+        """
+
+        self._faces += compound(self._selection).faces()
+
+        return self
+
+    def subtract(self: T) -> T:
+        """
+        Subtract selection from the underlying faces.
+        """
+
+        self._faces -= compound(self._selection).faces()
+
+        return self
+
+    def replace(self: T) -> T:
+        """
+        Replace the underlying faces with the selection.
+        """
+
+        self._faces = compound(self._selection).faces()
+
+        return self
 
     def __add__(self: T, other: T) -> T:
         """

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -12,7 +12,9 @@ from typing import (
     TypeVar,
     cast as tcast,
     Literal,
+    overload,
 )
+
 from math import tan, sin, cos, pi, radians, remainder
 from itertools import product, chain
 from inspect import isbuiltin
@@ -32,6 +34,7 @@ from .occ_impl.shapes import (
     Vertex,
     edgesToWires,
     compound,
+    VectorLike,
 )
 from .occ_impl.geom import Location, Vector
 from .occ_impl.exporters import export
@@ -1059,13 +1062,49 @@ class Sketch(object):
 
         return rv
 
+    @overload
     def moved(self: T, loc: Location) -> T:
+        ...
+
+    @overload
+    def moved(self: T, loc1: Location, loc2: Location, *locs: Location) -> T:
+        ...
+
+    @overload
+    def moved(self: T, locs: Sequence[Location]) -> T:
+        ...
+
+    @overload
+    def moved(
+        self: T,
+        x: Real = 0,
+        y: Real = 0,
+        z: Real = 0,
+        rx: Real = 0,
+        ry: Real = 0,
+        rz: Real = 0,
+    ) -> T:
+        ...
+
+    @overload
+    def moved(self: T, loc: VectorLike) -> T:
+        ...
+
+    @overload
+    def moved(self: T, loc1: VectorLike, loc2: VectorLike, *locs: VectorLike) -> T:
+        ...
+
+    @overload
+    def moved(self: T, loc: Sequence[VectorLike]) -> T:
+        ...
+
+    def moved(self: T, *args, **kwargs) -> T:
         """
         Create a partial copy of the sketch with moved _faces.
         """
 
         rv = self.__class__()
-        rv._faces = self._faces.moved(loc)
+        rv._faces = self._faces.moved(*args, **kwargs)
 
         return rv
 

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -1142,7 +1142,7 @@ class Sketch(object):
 
         return self
 
-    def __add__(self: T, other: T) -> T:
+    def __add__(self: T, other: "Sketch") -> T:
         """
         Fuse self and other.
         """
@@ -1151,7 +1151,7 @@ class Sketch(object):
 
         return self.__class__(obj=_to_compound(res))
 
-    def __sub__(self: T, other: T) -> T:
+    def __sub__(self: T, other: "Sketch") -> T:
         """
         Subtract other from self.
         """
@@ -1160,7 +1160,7 @@ class Sketch(object):
 
         return self.__class__(obj=_to_compound(res))
 
-    def __mul__(self: T, other: T) -> T:
+    def __mul__(self: T, other: "Sketch") -> T:
         """
         Intersect self and other.
         """
@@ -1169,7 +1169,7 @@ class Sketch(object):
 
         return self.__class__(obj=_to_compound(res))
 
-    def __truediv__(self: T, other: T) -> T:
+    def __truediv__(self: T, other: "Sketch") -> T:
         """
         Split self with other.
         """

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -759,6 +759,8 @@ class Sketch(object):
                     self._faces.remove(obj)
                 elif isinstance(obj, Edge):
                     self._edges.remove(obj)
+                else:
+                    raise ValueError(f"Deletion of {obj} not supported")
         else:
             raise ValueError("Selection is needed to delete")
 

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -1252,8 +1252,9 @@ class Sketch(object):
     def filter(self: T, f: Callable[[SketchVal], bool]) -> T:
         """
         Filter items using a boolean predicate.
+        
         :param f: Callable to be used for filtering.
-        :return: Workplane object with filtered items.
+        :return: Sketch object with filtered items.
         """
 
         self._selection = list(filter(f, self.vals()))
@@ -1263,8 +1264,9 @@ class Sketch(object):
     def map(self: T, f: Callable[[SketchVal], SketchVal]):
         """
         Apply a callable to every item separately.
+        
         :param f: Callable to be applied to every item separately.
-        :return: Workplane object with f applied to all items.
+        :return: Sketch object with f applied to all items.
         """
 
         self._selection = list(map(f, self.vals()))
@@ -1274,8 +1276,9 @@ class Sketch(object):
     def apply(self: T, f: Callable[[Iterable[SketchVal]], Iterable[SketchVal]]):
         """
         Apply a callable to all items at once.
+        
         :param f: Callable to be applied.
-        :return: Workplane object with f applied to all items.
+        :return: Sketch object with f applied to all items.
         """
 
         self._selection = list(f(self.vals()))
@@ -1285,8 +1288,9 @@ class Sketch(object):
     def sort(self: T, key: Callable[[SketchVal], Any]) -> T:
         """
         Sort items using a callable.
+        
         :param key: Callable to be used for sorting.
-        :return: Workplane object with items sorted.
+        :return: Sketch object with items sorted.
         """
 
         self._selection = list(sorted(self.vals(), key=key))
@@ -1297,11 +1301,12 @@ class Sketch(object):
         self: T, f: Union[Callable[[T], T], Callable[[T], None], Callable[[], None]]
     ):
         """
-        Invoke a callable mapping Workplane to Workplane or None. Supports also
+        Invoke a callable mapping Sketch to Sketch or None. Supports also
         callables that take no arguments such as breakpoint. Returns self if callable
         returns None.
+        
         :param f: Callable to be invoked.
-        :return: Workplane object.
+        :return: Sketch object.
         """
 
         arity = get_arity(f)
@@ -1327,6 +1332,7 @@ class Sketch(object):
     ) -> T:
         """
         Export Sketch to file.
+        
         :param path: Filename.
         :param tolerance: the deflection tolerance, in model units. Default 0.1.
         :param angularTolerance: the angular tolerance, in radians. Default 0.1.

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -34,6 +34,7 @@ from .occ_impl.shapes import (
     compound,
 )
 from .occ_impl.geom import Location, Vector
+from .occ_impl.exporters import export
 from .occ_impl.importers.dxf import _importDXF
 from .occ_impl.sketch_solver import (
     SketchConstraintSolver,
@@ -1263,3 +1264,14 @@ class Sketch(object):
             raise ValueError("Provided function {f} accepts too many arguments")
 
         return rv
+
+    def export(self: T, fname: str) -> T:
+        """
+        Export Sketch to file.
+        :param path: Filename.
+        :return: Self.
+        """
+
+        export(self, fname)
+
+        return self

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -1070,11 +1070,11 @@ class Sketch(object):
         rv: List[SketchVal]
 
         if self._selection:
-            rv = list(*self._selection)
+            rv = list(self._selection)
         elif not self._faces and self._edges:
-            rv = list(*self._edges)
+            rv = list(self._edges)
         else:
-            rv = list(*self._faces)
+            rv = list(self._faces)
 
         return rv
 

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -1113,41 +1113,41 @@ class Sketch(object):
 
         return rv
 
-    def __add__(self, other: "Sketch") -> "Sketch":
+    def __add__(self: T, other: T) -> T:
         """
         Fuse self and other.
         """
 
         res = _sanitize_for_bool(self.val()) + _sanitize_for_bool(other.val())
 
-        return Sketch(obj=_to_compound(res))
+        return self.__class__(obj=_to_compound(res))
 
-    def __sub__(self, other: "Sketch") -> "Sketch":
+    def __sub__(self: T, other: T) -> T:
         """
         Subtract other from self.
         """
 
         res = _sanitize_for_bool(self.val()) - _sanitize_for_bool(other.val())
 
-        return Sketch(obj=_to_compound(res))
+        return self.__class__(obj=_to_compound(res))
 
-    def __mul__(self, other: "Sketch") -> "Sketch":
+    def __mul__(self: T, other: T) -> T:
         """
         Intersect self and other.
         """
 
         res = _sanitize_for_bool(self.val()) * _sanitize_for_bool(other.val())
 
-        return Sketch(obj=_to_compound(res))
+        return self.__class__(obj=_to_compound(res))
 
-    def __truediv__(self, other: "Sketch") -> "Sketch":
+    def __truediv__(self: T, other: T) -> T:
         """
         Split self with other.
         """
 
         res = _sanitize_for_bool(self.val()) / _sanitize_for_bool(other.val())
 
-        return Sketch(obj=_to_compound(res))
+        return self.__class__(obj=_to_compound(res))
 
     def __getitem__(self: T, item: Union[int, Sequence[int], slice]) -> T:
 

--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from inspect import signature
+from inspect import signature, isbuiltin
 from typing import TypeVar, Callable, cast
 from warnings import warn
 
@@ -71,3 +71,15 @@ class deprecate_kwarg_name:
             return f(*args, **kwargs)
 
         return wrapped
+
+
+def get_arity(f: TCallable) -> int:
+
+    if isbuiltin(f):
+        rv = 0  # assume 0 arity for builtins; they cannot be introspected
+    else:
+        # NB: this is not understood by mypy
+        n_defaults = len(f.__defaults__) if f.__defaults__ else 0
+        rv = f.__code__.co_argcount - n_defaults
+
+    return rv

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -21,9 +21,7 @@ def _to_assy(*objs: Union[Shape, Workplane, Assembly, Sketch]) -> Assembly:
         if isinstance(obj, (Shape, Workplane, Assembly)):
             assy.add(obj)
         elif isinstance(obj, Sketch):
-            assy.add(obj._faces)
-            assy.add(Compound.makeCompound(obj._edges))
-            assy.add(Compound.makeCompound(obj._wires))
+            assy.add(Compound.makeCompound(obj))
         elif isinstance(obj, TopoDS_Shape):
             assy.add(Shape(obj))
         else:

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -200,12 +200,15 @@ Extending CadQuery: Special Methods
 -----------------------------------
 
 The above-mentioned approach has one drawback, it requires monkey-patching or subclassing. To avoid this
-one can also use the following special methods of :py:class:`cadquery.Workplane`
+one can also use the following special methods of :py:class:`cadquery.Workplane` and :py:class:`cadquery.Sketch`
 and write plugins in a more functional style.
 
     * :py:meth:`cadquery.Workplane.map`
     * :py:meth:`cadquery.Workplane.apply`
     * :py:meth:`cadquery.Workplane.invoke`
+    * :py:meth:`cadquery.Sketch.map`
+    * :py:meth:`cadquery.Sketch.apply`
+    * :py:meth:`cadquery.Sketch.invoke`
 
 Here is the same plugin rewritten using one of those methods.
 

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -8,10 +8,10 @@ Importing and Exporting Files
 Introduction
 #############
 
-The purpose of this section is to explain how to import external file formats into CadQuery, and export files from 
-it as well. While the external file formats can be used to interchange CAD model data with other software, CadQuery 
-does not support any formats that carry parametric data with them at this time. The only format that is fully 
-parametric is CadQuery's own Python format. Below are lists of the import and export file formats that CadQuery 
+The purpose of this section is to explain how to import external file formats into CadQuery, and export files from
+it as well. While the external file formats can be used to interchange CAD model data with other software, CadQuery
+does not support any formats that carry parametric data with them at this time. The only format that is fully
+parametric is CadQuery's own Python format. Below are lists of the import and export file formats that CadQuery
 supports.
 
 Import Formats
@@ -64,7 +64,7 @@ Importing a DXF profile with default settings and using it within a CadQuery scr
     )
 
 Note the use of the :meth:`Workplane.wires` and :meth:`Workplane.toPending` methods to make the DXF profile
-ready for use during subsequent operations. Calling ``toPending()`` tells CadQuery to make the edges/wires available 
+ready for use during subsequent operations. Calling ``toPending()`` tells CadQuery to make the edges/wires available
 to the next modelling operation that is called in the chain.
 
 Importing STEP
@@ -96,7 +96,7 @@ since it will be determined from the file extension. Below is an example.
     box = cq.Workplane().box(10, 10, 10)
 
     # Export the box
-    cq.exporters.export(box, "/path/to/step/box.step")
+    box.export("/path/to/step/box.step")
 
 Non-Default File Extensions
 ----------------------------
@@ -110,10 +110,10 @@ not recognize the file extension. In that case the export type has to be specifi
     box = cq.Workplane().box(10, 10, 10)
 
     # Export the box
-    cq.exporters.export(box, "/path/to/step/box.stp", cq.exporters.ExportTypes.STEP)
+    box.export("/path/to/step/box.stp", cq.exporters.ExportTypes.STEP)
 
     # The export type may also be specified as a literal
-    cq.exporters.export(box, "/path/to/step/box2.stp", "STEP")
+    box.export("/path/to/step/box2.stp", "STEP")
 
 Setting Extra Options
 ----------------------
@@ -128,10 +128,10 @@ or the :meth:`Assembly.exportAssembly`` method.
     box = cq.Workplane().box(10, 10, 10)
 
     # Export the box, provide additional options with the opt dict
-    cq.exporters.export(box, "/path/to/step/box.step", opt={"write_pcurves": False})
+    box.export("/path/to/step/box.step", opt={"write_pcurves": False})
 
     # or equivalently when exporting a lower level Shape object
-    box.val().exportStep("/path/to/step/box2.step", write_pcurves=False)
+    box.val().export("/path/to/step/box2.step", opt={"write_pcurves": False})
 
 
 Exporting Assemblies to STEP
@@ -159,7 +159,7 @@ export with all defaults is shown below.
     assy.add(pin, color=cq.Color(0, 1, 0), name="pin")
 
     # Save the assembly to STEP
-    assy.save("out.step")
+    assy.export("out.step")
 
 This will produce a STEP file that is nested with auto-generated object names. The colors of each assembly object will be
 preserved, but the names that were set for each will not.
@@ -183,10 +183,10 @@ fused solids.
     assy.add(pin, color=cq.Color(0, 1, 0), name="pin")
 
     # Save the assembly to STEP
-    assy.save("out.stp", "STEP", mode="fused")
+    assy.export("out.stp", "STEP", mode="fused")
 
     # Specify additional options such as glue as keyword arguments
-    assy.save("out_glue.step", mode="fused", glue=True, write_pcurves=False)
+    assy.export("out_glue.step", mode="fused", glue=True, write_pcurves=False)
 
 Naming
 -------
@@ -197,7 +197,7 @@ This is done by setting the name property of the assembly before calling :meth:`
 .. code-block:: python
 
     assy = Assembly(name="my_assembly")
-    assy.save(
+    assy.export(
         "out.stp",
         cq.exporters.ExportTypes.STEP,
         mode=cq.exporters.assembly.ExportModes.FUSED,
@@ -224,13 +224,13 @@ export with all defaults is shown below. To export to a binary glTF file, change
     pin = cq.Workplane().center(2, 2).cylinder(radius=2, height=20)
     assy.add(pin, color=cq.Color(0, 1, 0), name="pin")
 
-    # Save the assembly to STEP
-    assy.save("out.gltf")
+    # Save the assembly to GLTF
+    assy.export("out.gltf")
 
 Exporting SVG
 ###############
 
-The SVG exporter has several options which can be useful for achieving the desired final output. Those 
+The SVG exporter has several options which can be useful for achieving the desired final output. Those
 options are as follows.
 
 * *width* - Width of the resulting image (None to fit based on height).
@@ -245,7 +245,7 @@ options are as follows.
 * *showHidden* - Whether or not to show hidden lines.
 * *focus* - If specified, creates a perspective SVG with the projector at the distance specified.
 
-The options are passed to the exporter in a dictionary, and can be left out to force the SVG to be created with default options. 
+The options are passed to the exporter in a dictionary, and can be left out to force the SVG to be created with default options.
 Below are examples with and without options set.
 
 Without options:
@@ -257,13 +257,13 @@ Without options:
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, "/path/to/file/box.svg")
+    result.export("/path/to/file/box.svg")
 
 Results in:
 
 ..  image:: _static/importexport/box_default_options.svg
 
-Note that the exporters API figured out the format type from the file extension. The format 
+Note that the exporters API figured out the format type from the file extension. The format
 type can be set explicitly by using :py:class:`exporters.ExportTypes`.
 
 The following is an example of using options to alter the resulting SVG output by passing in the ``opt`` parameter.
@@ -275,8 +275,7 @@ The following is an example of using options to alter the resulting SVG output b
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(
-        result,
+    result.export(
         "/path/to/file/box_custom_options.svg",
         opt={
             "width": 300,
@@ -308,7 +307,7 @@ The STL exporter is capable of adjusting the quality of the resulting mesh, and 
 .. automethod::
     cadquery.occ_impl.shapes.Shape.exportStl
 
-For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the 
+For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the
 optimum values that will produce an acceptable mesh.
 
 .. code-block:: python
@@ -318,7 +317,7 @@ optimum values that will produce an acceptable mesh.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, "/path/to/file/mesh.stl")
+    result.export("/path/to/file/mesh.stl")
 
 Exporting AMF and 3MF
 ######################
@@ -329,7 +328,7 @@ The AMF and 3MF exporters are capable of adjusting the quality of the resulting 
 * ``tolerance`` - A linear deflection setting which limits the distance between a curve and its tessellation. Setting this value too low will result in large meshes that can consume computing resources. Setting the value too high can result in meshes with a level of detail that is too low. Default is 0.1, which is good starting point for a range of cases.
 * ``angularTolerance`` - Angular deflection setting which limits the angle between subsequent segments in a polyline. Default is 0.1.
 
-For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the 
+For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the
 optimum values that will produce an acceptable mesh. Note that parameters for color and material are absent.
 
 .. code-block:: python
@@ -339,7 +338,7 @@ optimum values that will produce an acceptable mesh. Note that parameters for co
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, "/path/to/file/mesh.amf", tolerance=0.01, angularTolerance=0.1)
+    result.export("/path/to/file/mesh.amf", tolerance=0.01, angularTolerance=0.1)
 
 
 Exporting TJS
@@ -351,7 +350,7 @@ The TJS (ThreeJS) exporter produces a file in JSON format that describes a scene
 * ``tolerance`` - A linear deflection setting which limits the distance between a curve and its tessellation. Setting this value too low will result in large meshes that can consume computing resources. Setting the value too high can result in meshes with a level of detail that is too low. Default is 0.1, which is good starting point for a range of cases.
 * ``angularTolerance`` - Angular deflection setting which limits the angle between subsequent segments in a polyline. Default is 0.1.
 
-For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the 
+For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the
 optimum values that will produce an acceptable mesh.
 
 .. code-block:: python
@@ -361,15 +360,14 @@ optimum values that will produce an acceptable mesh.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(
-        result,
+    result.export(
         "/path/to/file/mesh.json",
         tolerance=0.01,
         angularTolerance=0.1,
         exportType=exporters.ExportTypes.TJS,
     )
 
-Note that the export type was explicitly specified as ``TJS`` because the extension that was used for the file name was ``.json``. If the extension ``.tjs`` 
+Note that the export type was explicitly specified as ``TJS`` because the extension that was used for the file name was ``.json``. If the extension ``.tjs``
 had been used, CadQuery would have understood to use the ``TJS`` export format.
 
 Exporting VRML
@@ -381,7 +379,7 @@ The VRML exporter is capable of adjusting the quality of the resulting mesh, and
 * ``tolerance`` - A linear deflection setting which limits the distance between a curve and its tessellation. Setting this value too low will result in large meshes that can consume computing resources. Setting the value too high can result in meshes with a level of detail that is too low. Default is 0.1, which is good starting point for a range of cases.
 * ``angularTolerance`` - Angular deflection setting which limits the angle between subsequent segments in a polyline. Default is 0.1.
 
-For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the 
+For more complex objects, some experimentation with ``tolerance`` and ``angularTolerance`` may be required to find the
 optimum values that will produce an acceptable mesh.
 
 .. code-block:: python
@@ -391,8 +389,8 @@ optimum values that will produce an acceptable mesh.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(
-        result, "/path/to/file/mesh.vrml", tolerance=0.01, angularTolerance=0.1
+    result.export(
+        "/path/to/file/mesh.vrml", tolerance=0.01, angularTolerance=0.1
     )
 
 Exporting DXF
@@ -423,16 +421,26 @@ Options
     See `Units`_.
 
 .. code-block:: python
-    :caption: DXF document without options.
+    :caption: DXF of workplanes.
 
     import cadquery as cq
-    from cadquery import exporters
 
-    result = cq.Workplane().box(10, 10, 10)
+    result = cq.Workplane().box(10, 10, 10).section()
 
     exporters.exportDXF(result, "/path/to/file/object.dxf")
     # or
-    exporters.export(result, "/path/to/file/object.dxf")
+    result.export("/path/to/file/object.dxf")
+
+Sketches can be also directly exported to DXF.
+
+.. code-block:: python
+    :caption: DXF export of sketches.
+
+    import cadquery as cq
+
+    result = cq.Sketch().rect(1,1)
+
+    result.export("/path/to/file/object.dxf")
 
 
 Units
@@ -460,7 +468,7 @@ Document units can be set to any :doc:`unit supported by ezdxf <ezdxf-stable:con
     import cadquery as cq
     from cadquery import exporters
 
-    result = cq.Workplane().box(10, 10, 10)
+    result = cq.Workplane().box(10, 10, 10).section()
 
     exporters.exportDXF(
         result,
@@ -470,8 +478,7 @@ Document units can be set to any :doc:`unit supported by ezdxf <ezdxf-stable:con
 
     # or
 
-    exporters.export(
-        result,
+    result.export(
         "/path/to/file/object.dxf",
         opt={"doc_units": 6},  # set DXF document units to meters
     )
@@ -496,7 +503,7 @@ By default, the DXF exporter will output splines exactly as they are represented
 Exporting Other Formats
 ########################
 
-The remaining export formats do not accept any additional parameters other than file name, and can be exported 
+The remaining export formats do not accept any additional parameters other than file name, and can be exported
 using the following structure.
 
 .. code-block:: python
@@ -506,9 +513,9 @@ using the following structure.
 
     result = cq.Workplane().box(10, 10, 10)
 
-    exporters.export(result, "/path/to/file/object.[file_extension]")
+    result.export("/path/to/file/object.[file_extension]")
 
-Be sure to use the correct file extension so that CadQuery can determine the export format. If in doubt, fall 
+Be sure to use the correct file extension so that CadQuery can determine the export format. If in doubt, fall
 back to setting the type explicitly by using :py:class:`exporters.ExportTypes`.
 
 For example:
@@ -518,6 +525,6 @@ For example:
     import cadquery as cq
     from cadquery import exporters
 
-    result = cq.Workplane().box(10, 10, 10)
+    result = cq.Workplane().box(10, 10, 10).section()
 
-    exporters.export(result, "/path/to/file/object.dxf", exporters.ExportTypes.DXF)
+    result.export("/path/to/file/object.dxf", exporters.ExportTypes.DXF)

--- a/doc/importexport.rst
+++ b/doc/importexport.rst
@@ -431,7 +431,7 @@ Options
     # or
     result.export("/path/to/file/object.dxf")
 
-Sketches can be also directly exported to DXF.
+Sketches can also be directly exported to DXF.
 
 .. code-block:: python
     :caption: DXF export of sketches.

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -191,13 +191,16 @@ objects. This includes chaining and combining.
 Additional special methods
 --------------------------
 
-:py:class:`cadquery.Workplane` provides the following special methods that can be used
+:py:class:`cadquery.Workplane` and :py:class:`cadquery.Sketch` provide the following special methods that can be used
 for quick prototyping of selectors when implementing a complete selector via subclassing of
 :py:class:`cadquery.Selector` is not desirable.
 
     * :py:meth:`cadquery.Workplane.filter`
     * :py:meth:`cadquery.Workplane.sort`
     * :py:meth:`cadquery.Workplane.__getitem__`
+    * :py:meth:`cadquery.Sketch.filter`
+    * :py:meth:`cadquery.Sketch.sort`
+    * :py:meth:`cadquery.Sketch.__getitem__`
 
 For example, one could use those methods for selecting objects within a certain range of volumes.
 

--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -375,4 +375,4 @@ Exporting and importing
 
 It is possible to export sketches using :meth:`~cadquery.Sketch.export`.
 See :ref:`importexport` for more details.
-Importing of DXF files is supported as well using :meth:`~cadquery.Sketch.impotDXF`.
+Importing of DXF files is supported as well using :meth:`~cadquery.Sketch.importDXF`.

--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -41,13 +41,13 @@ Modes
 ^^^^^
 
 Every operation from the face API accepts a mode parameter to define
- how to combine the created object with existing ones. It can be fused (``mode='a'``),
-  cut (``mode='s'``), intersected (``mode='i'``), replaced (``mode='r'``)
-  or just stored for construction (``mode='c'``).
+how to combine the created object with existing ones. It can be fused (``mode='a'``),
+cut (``mode='s'``), intersected (``mode='i'``), replaced (``mode='r'``)
+or just stored for construction (``mode='c'``).
 In the last case, it is mandatory to specify a ``tag`` in order to be able to
- refer to the object later on. By default faces are fused together.
- Note the usage of the subtractive and additive modes in the example above.
- The additional two are demonstrated below.
+refer to the object later on. By default faces are fused together.
+Note the usage of the subtractive and additive modes in the example above.
+The additional two are demonstrated below.
 
 .. cadquery::
     :height: 600px
@@ -307,8 +307,8 @@ Sketches can be combined using :meth:`~cadquery.Sketch.face`.
 
    import cadquery as cq
 
-   s1 = cq.Sketch().rect(2,2)
-   s2 = cq.Sketch().circle(1)
+   s1 = cq.Sketch().rect(2, 2)
+   s2 = cq.Sketch().circle(0.5)
 
    result = s1.face(s2, mode='s')
 
@@ -320,11 +320,13 @@ It is also possible to use boolean operations to achieve the same effect.
 
    import cadquery as cq
 
-   s1 = cq.Sketch().rect(2,2)
-   s2 = cq.Sketch().circle(1)
+   s1 = cq.Sketch().rect(2, 2).vertices().fillet(0.25).reset()
+   s2 = cq.Sketch().rect(1, 1, angle=45).vertices().chamfer(0.1).reset()
 
    result = s1 - s2
 
+Boolean operations are selection sensitive, so in this example
+:meth:`~cadquery.Sketch.reset` call is needed.
 
 Offsets made easy
 =================
@@ -372,5 +374,5 @@ Exporting and importing
 =======================
 
 It is possible to export sketches using :meth:`~cadquery.Sketch.export`.
-See `importexport`_ for more details.
+See :ref:`importexport` for more details.
 Importing of DXF files is supported as well :meth:`~cadquery.Sketch.impotDXF`.

--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -375,4 +375,4 @@ Exporting and importing
 
 It is possible to export sketches using :meth:`~cadquery.Sketch.export`.
 See :ref:`importexport` for more details.
-Importing of DXF files is supported as well :meth:`~cadquery.Sketch.impotDXF`.
+Importing of DXF files is supported as well using :meth:`~cadquery.Sketch.impotDXF`.

--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -296,6 +296,36 @@ Two sketches on different workplanes are needed when using :meth:`~cadquery.Work
 
 When lofting only outer wires are taken into account and inner wires are silently ignored. Note that only sketches on the top of stack are considered for the current operation (i.e. there are no pending sketches), so when lofting or sweeping all relevant sketches have to be added in one `placeSketch` call.
 
+
+Combining sketches
+==================
+
+Sketches can be combined using :meth:`~cadquery.Sketch.face`.
+
+.. cadquery::
+   :height: 600px
+
+   import cadquery as cq
+
+   s1 = cq.Sketch().rect(2,2)
+   s2 = cq.Sketch().circle(1)
+
+   result = s1.face(s2, mode='s')
+
+
+It is also possible to use boolean operations to achieve the same effect.
+
+.. cadquery::
+   :height: 600px
+
+   import cadquery as cq
+
+   s1 = cq.Sketch().rect(2,2)
+   s2 = cq.Sketch().circle(1)
+
+   result = s1 - s2
+
+
 Offsets made easy
 =================
 
@@ -336,3 +366,11 @@ of the offset operation. Usually one wants to replace the original face, hence `
 
    result = cq.Workplane("front").placeSketch(sketch).extrude(1.0)
    result = result.faces(">Z").workplane().placeSketch(sketch_offset).cutBlind(-0.50)
+
+
+Exporting and importing
+=======================
+
+It is possible to export sketches using :meth:`~cadquery.Sketch.export`.
+See `importexport`_ for more details.
+Importing of DXF files is supported as well :meth:`~cadquery.Sketch.impotDXF`.

--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -13,7 +13,7 @@ approaches.
 Face-based API
 ==============
 
-The main approach for constructing sketches is based on constructing faces and 
+The main approach for constructing sketches is based on constructing faces and
 combining them using boolean operations.
 
 .. cadquery::
@@ -40,7 +40,14 @@ class does not implement history and all modifications happen in-place.
 Modes
 ^^^^^
 
-Every operation from the face API accepts a mode parameter to define how to combine the created object with existing ones. It can be fused (``mode='a'``), cut (``mode='s'``), intersected (``mode='i'``) or just stored for construction (``mode='c'``). In the last case, it is mandatory to specify a ``tag`` in order to be able to refer to the object later on. By default faces are fused together. Note the usage of the subtractive and additive modes in the example above. The additional two are demonstrated below.
+Every operation from the face API accepts a mode parameter to define
+ how to combine the created object with existing ones. It can be fused (``mode='a'``),
+  cut (``mode='s'``), intersected (``mode='i'``), replaced (``mode='r'``)
+  or just stored for construction (``mode='c'``).
+In the last case, it is mandatory to specify a ``tag`` in order to be able to
+ refer to the object later on. By default faces are fused together.
+ Note the usage of the subtractive and additive modes in the example above.
+ The additional two are demonstrated below.
 
 .. cadquery::
     :height: 600px
@@ -285,7 +292,7 @@ Two sketches on different workplanes are needed when using :meth:`~cadquery.Work
 
     s2 = Sketch().rect(2, 1).vertices().fillet(0.2)
 
-    result = Workplane().placeSketch(s1, s2.moved(Location(Vector(0, 0, 3)))).loft()
+    result = Workplane().placeSketch(s1, s2.moved(z=3)).loft()
 
 When lofting only outer wires are taken into account and inner wires are silently ignored. Note that only sketches on the top of stack are considered for the current operation (i.e. there are no pending sketches), so when lofting or sweeping all relevant sketches have to be added in one `placeSketch` call.
 
@@ -309,3 +316,23 @@ Conveniently, it is possible to reuse a sketch to create an :meth:`~cadquery.Ske
 
    result = cq.Workplane("front").placeSketch(sketch_offset).extrude(1.0)
    result = result.faces(">Z").workplane().placeSketch(sketch).cutBlind(-0.50)
+
+
+It is obviously possible to use negative offsets, but it requires being more careful with the mode
+of the offset operation. Usually one wants to replace the original face, hence ``mode='r'``.
+
+.. cadquery::
+   :height: 600px
+
+   import cadquery as cq
+
+   sketch  = (cq.Sketch()
+   .rect(1.0, 4.0)
+   .circle(1.0)
+   .clean()
+   )
+
+   sketch_offset = sketch.copy().wires().offset(-0.25, mode='r')
+
+   result = cq.Workplane("front").placeSketch(sketch).extrude(1.0)
+   result = result.faces(">Z").workplane().placeSketch(sketch_offset).cutBlind(-0.50)

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -694,7 +694,6 @@ def test_save(extension, args, nested_assy, nested_assy_sphere):
         ("step", (), {}),
         ("xml", (), {}),
         ("vrml", (), {}),
-        ("zip", ("VTKJS",), {}),
         ("gltf", (), {}),
         ("glb", (), {}),
         ("stl", (), {"ascii": False}),
@@ -705,13 +704,20 @@ def test_save(extension, args, nested_assy, nested_assy_sphere):
         ("stl", ("STL",), {}),
     ],
 )
-def test_export(extension, args, kwargs, tmpdir, nested_assy, nested_assy_sphere):
+def test_export(extension, args, kwargs, tmpdir, nested_assy):
 
     filename = "nested." + extension
 
     with tmpdir:
         nested_assy.export(filename, *args, **kwargs)
         assert os.path.exists(filename)
+
+
+def test_export_vtkjs(tmpdir, nested_assy):
+
+    with tmpdir:
+        nested_assy.export("nested.vtkjs")
+        assert os.path.exists("nested.vtkjs.zip")
 
 
 def test_export_errors(nested_assy):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -728,6 +728,9 @@ def test_export_errors(nested_assy):
     with pytest.raises(ValueError):
         nested_assy.export("nested.stl", "1234")
 
+    with pytest.raises(ValueError):
+        nested_assy.export("nested.step", mode="1234")
+
 
 def test_save_stl_formats(nested_assy_sphere):
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -688,6 +688,24 @@ def test_save(extension, args, nested_assy, nested_assy_sphere):
     assert os.path.exists(filename)
 
 
+@pytest.mark.parametrize(
+    "extension, args",
+    [
+        ("step", ()),
+        ("xml", ()),
+        ("stp", ("STEP",)),
+        ("caf", ("XML",)),
+        ("wrl", ("VRML",)),
+        ("stl", ("STL",)),
+    ],
+)
+def test_export(extension, args, nested_assy, nested_assy_sphere):
+
+    filename = "nested." + extension
+    nested_assy.export(filename, *args)
+    assert os.path.exists(filename)
+
+
 def test_save_stl_formats(nested_assy_sphere):
 
     # Binary export

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -15,6 +15,7 @@ from pytest import approx, raises
 
 from cadquery import *
 from cadquery import occ_impl
+from cadquery.occ_impl.shapes import *
 from tests import (
     BaseTest,
     writeStringToFile,
@@ -5790,3 +5791,29 @@ class TestCadQuery(BaseTest):
         verts, _ = Face.makePlane(1e-9, 1e-9).tessellate(1e-3)
 
         assert len(verts) == 0
+
+    def test_export(self):
+
+        w = Workplane().box(1, 1, 1).export("box.brep")
+
+        assert (w - Shape.importBrep("box.brep")).val().Volume() == approx(0)
+
+    def test_bool_operators(self):
+
+        w1 = Workplane().box(1, 1, 2)
+        w2 = Workplane().box(2, 2, 1)
+
+        assert (w1 + w2).val().Volume() == approx(5)
+        assert (w1 - w2).val().Volume() == approx(1)
+        assert (w1 * w2).val().Volume() == approx(1)
+        assert (w1 / w2).solids().size() == 3
+
+    def test_extrude_face(self):
+
+        f = face(rect(1, 1))
+        c = compound(f)
+
+        # face
+        assert Workplane().add(f).extrude(1).val().Volume() == approx(1)
+        # compound with face
+        assert Workplane().add(c).extrude(1).val().Volume() == approx(1)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5817,3 +5817,15 @@ class TestCadQuery(BaseTest):
         assert Workplane().add(f).extrude(1).val().Volume() == approx(1)
         # compound with face
         assert Workplane().add(c).extrude(1).val().Volume() == approx(1)
+
+    def test_workplane_iter(self):
+
+        s = Sketch().rarray(5, 0, 5, 1).rect(1, 1)
+        w1 = Workplane().pushPoints([(-10, 0), (10, 0)])
+        w2 = w1.box(1, 1, 1)  # NB this results in Compound of two Solids
+        w3 = w1.box(1, 1, 1, combine=False)
+
+        assert len(list(s)) == 5
+        assert len(list(w1)) == 0
+        assert len(list(w2)) == 2  # 2 beacuase __iter__ unpacks Compounds
+        assert len(list(w3)) == 2

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5820,7 +5820,7 @@ class TestCadQuery(BaseTest):
 
     def test_workplane_iter(self):
 
-        s = Sketch().rarray(5, 0, 5, 1).rect(1, 1)
+        s = Workplane().sketch().rarray(5, 0, 5, 1).rect(1, 1).finalize()
         w1 = Workplane().pushPoints([(-10, 0), (10, 0)])
         w2 = w1.box(1, 1, 1)  # NB this results in Compound of two Solids
         w3 = w1.box(1, 1, 1, combine=False)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5757,7 +5757,7 @@ class TestCadQuery(BaseTest):
 
     def test_getitem(self):
 
-        w = Workplane().rarray(2, 1, 5, 1).box(1, 1, 1, combine=False)
+        w = Workplane().rarray(2, 0, 5, 1).box(1, 1, 1, combine=False)
 
         assert w[0].solids().size() == 1
         assert w[-2:].solids().size() == 2
@@ -5765,7 +5765,7 @@ class TestCadQuery(BaseTest):
 
     def test_invoke(self):
 
-        w = Workplane().rarray(2, 1, 5, 1).box(1, 1, 1, combine=False)
+        w = Workplane().rarray(2, 0, 5, 1).box(1, 1, 1, combine=False)
 
         # builtin
         assert w.invoke(print).size() == 5

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -30,9 +30,8 @@ from cadquery import (
     Color,
 )
 
-from cadquery.occ_impl.shapes import rect, face
+from cadquery.occ_impl.shapes import rect, face, compound
 from cadquery.occ_impl.exporters.dxf import DxfDocument
-from cadquery.occ_impl.exporters.utils import toCompound
 from tests import BaseTest
 from OCP.GeomConvert import GeomConvert
 from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
@@ -308,7 +307,7 @@ class TestDxfDocument(BaseTest):
         workplane = Workplane().line(1, 1)
 
         plane = workplane.plane
-        shape = toCompound(workplane).transformShape(plane.fG)
+        shape = compound(*workplane).transformShape(plane.fG)
         edges = shape.Edges()
 
         result = DxfDocument._dxf_line(edges[0])
@@ -321,7 +320,7 @@ class TestDxfDocument(BaseTest):
         workplane = Workplane().circle(1)
 
         plane = workplane.plane
-        shape = toCompound(workplane).transformShape(plane.fG)
+        shape = compound(*workplane).transformShape(plane.fG)
         edges = shape.Edges()
 
         result = DxfDocument._dxf_circle(edges[0])
@@ -334,7 +333,7 @@ class TestDxfDocument(BaseTest):
         workplane = Workplane().radiusArc((1, 1), 1)
 
         plane = workplane.plane
-        shape = toCompound(workplane).transformShape(plane.fG)
+        shape = compound(*workplane).transformShape(plane.fG)
         edges = shape.Edges()
 
         result_type, result_attributes = DxfDocument._dxf_circle(edges[0])
@@ -362,7 +361,7 @@ class TestDxfDocument(BaseTest):
         workplane = Workplane().ellipse(2, 1, 0)
 
         plane = workplane.plane
-        shape = toCompound(workplane).transformShape(plane.fG)
+        shape = compound(*workplane).transformShape(plane.fG)
         edges = shape.Edges()
 
         result_type, result_attributes = DxfDocument._dxf_ellipse(edges[0])
@@ -398,7 +397,7 @@ class TestDxfDocument(BaseTest):
         )
 
         plane = workplane.plane
-        shape = toCompound(workplane).transformShape(plane.fG)
+        shape = compound(*workplane).transformShape(plane.fG)
         edges = shape.Edges()
 
         result_type, result_attributes = DxfDocument._dxf_spline(edges[0], plane)
@@ -653,9 +652,6 @@ class TestExporters(BaseTest):
     def testDXF(self):
 
         exporters.export(self._box().section(), "out.dxf")
-
-        with self.assertRaises(ValueError):
-            exporters.export(self._box().val(), "out.dxf")
 
         s1 = (
             Workplane("XZ")

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -547,3 +547,14 @@ def test_loft():
     assert r4.Volume() > 0
     assert r5.Area() == approx(1)
     assert len(r6.Faces()) == 16
+
+
+# %% export
+def test_export():
+
+    b1 = box(1, 1, 1)
+    b1.export("box.brep")
+
+    b2 = Shape.importBrep("box.brep")
+
+    assert (b1 - b2).Volume() == approx(0)

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -47,8 +47,8 @@ def test_face_interface():
     assert len(s7.vertices()._selection) == 3
     assert s7._faces.Area() == approx(0.5)
 
-    with raises(ValueError):
-        Sketch().face(Sketch().rect(1, 1)._faces)
+    s8 = Sketch().face(Sketch().rect(1, 1).val())
+    assert s8._faces.Area() == approx(1)
 
 
 def test_modes():
@@ -428,7 +428,7 @@ def test_selectors():
     assert s.val().toTuple() == approx((-2.5, -0.5, 0.0))
 
     s.reset().vertices(">>X[1] and <Y").val()
-    assert s.val().toTuple()[0] == approx((0, 0, 0))
+    assert len(s._selection) == 0
 
 
 def test_edge_interface():

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -880,6 +880,7 @@ def test_invoke(s1, s2):
     with raises(ValueError):
         s2.invoke(lambda x, y: 1)
 
+
 @fixture
 def s3():
     """

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -51,6 +51,12 @@ def test_face_interface():
     s8 = Sketch().face(Sketch().rect(1, 1).val())
     assert s8._faces.Area() == approx(1)
 
+    s9 = Sketch().face(Sketch().rect(1, 1))
+    assert s9._faces.Area() == approx(1)
+
+    with raises(ValueError):
+        Sketch().face(1234)
+
 
 def test_modes():
 

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -2,6 +2,7 @@ import os
 
 from cadquery.sketch import Sketch, Vector, Location
 from cadquery.selectors import LengthNthSelector
+from cadquery import Edge, Vertex
 
 from pytest import approx, raises
 from math import pi, sqrt
@@ -745,3 +746,33 @@ def test_dxf_import():
     s5 = Sketch().importDXF(filename, tol=1e-3, exclude=["1"])
 
     assert s5._faces.isValid()
+
+
+def test_val():
+
+    s1 = Sketch().segment((0, 0), (0, 1))
+
+    assert isinstance(s1.val(), Edge)
+
+    s1.vertices()
+
+    assert isinstance(s1.val(), Vertex)
+
+    s2 = Sketch().circle(1)
+
+    assert len(s2.val().Faces()) == 1
+
+
+def test_vals():
+
+    s1 = Sketch().segment((0, 0), (0, 1))
+
+    assert len(s1.vals()) == 1
+
+    s1.vertices()
+
+    assert len(s1.vals()) == 2
+
+    s2 = Sketch().circle(1)
+
+    assert len(s2.val().Faces()) == 1

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -796,3 +796,11 @@ def test_bool_ops():
     assert len((s1 / s3).val().Faces()) == 2
     assert len((s1 / s2).val().Faces()) == 3
     assert (s1 / s2).val().Area() == approx(1)
+
+
+def test_export():
+
+    s1 = Sketch().rect(1, 1).export("sketch.dxf")
+    s2 = Sketch().importDXF("sketch.dxf")
+
+    assert (s1 - s2).val().Area() == approx(0)

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -775,4 +775,4 @@ def test_vals():
 
     s2 = Sketch().circle(1)
 
-    assert len(s2.val().Faces()) == 1
+    assert len(s2.vals().Faces()) == 1

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -775,4 +775,4 @@ def test_vals():
 
     s2 = Sketch().circle(1)
 
-    assert len(s2.vals().Faces()) == 1
+    assert len(s2.vals()) == 1

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -776,3 +776,23 @@ def test_vals():
     s2 = Sketch().circle(1)
 
     assert len(s2.vals()) == 1
+
+
+def test_bool_ops():
+
+    s1 = Sketch().rect(0.5, 2)
+    s2 = Sketch().rect(1, 1)
+    s3 = Sketch().segment((-1, 0), (1, 0))
+
+    # sum
+    assert (s1 + s2).val().Area() == approx(1.5)
+    # diff
+    assert (s1 - s2).val().Area() == approx(0.5)
+    assert len((s1 - s2).val().Wires()) == 2
+    # common
+    assert (s1 * s2).val().Area() == approx(0.5)
+    assert len((s1 * s2).val().Wires()) == 1
+    # split
+    assert len((s1 / s3).val().Faces()) == 2
+    assert len((s1 / s2).val().Faces()) == 3
+    assert (s1 / s2).val().Area() == approx(1)

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -388,6 +388,9 @@ def test_delete():
 
     assert len(s2._edges) == 2
 
+    with raises(ValueError):
+        s2.vertices().delete()
+
 
 def test_selectors():
 


### PR DESCRIPTION
This should resolve #1614, #1575, #1511, #1519, #1603, #1615 and add special methods to `Sketch`.

- [x] val, vals
- [x] filter, map, apply, invoke
- [x] DXF export
- [x] `face()` accepts Shape
- [x] bool ops as operators
- [x] deprecate previous naming convention
- [x] uniform bool op naming for Shape, Sketch and Workplane
- [x] `add()`, `subtract()`  and `replace()` methods for Sketch
- [x] extend `Workplane._getFaces()` to work with selected faces
- [x] allow 0 spacing in `Workplane.rarray`
- [x] add `__iter__` to `Workplane`
- [x] add `export` to:
    - [x]  `Workplane`
    - [x] `Shape`
    - [x] `Assembly`
    - [x] `Sketch`
- [x] extend `Sketch.moved` 
- [x] make `Sketch._selection` optional, i.e. no selection and nothing selected are two different states now
- [x] tests
- [x] docs
-------------

Some notes:
* Should we add another state to `cq.Sketch` e.g. `selection: Optional[List[SketchVal]]`. This way it would be possible to differentiate between selection was not performed/reset and nothing was selected. -> After some experimentation I did go for this change.
* I removed `wires`, it seems that they were not needed.

----------
Quite some scope-creep but a lot of quality-of-life improvements.