### PR TITLE
Introducing CadQuery Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![codecov](https://codecov.io/gh/CadQuery/cadquery/branch/master/graph/badge.svg)](https://codecov.io/gh/CadQuery/cadquery)
 [![Documentation Status](https://readthedocs.org/projects/cadquery/badge/?version=latest)](https://cadquery.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4498634.svg)](https://doi.org/10.5281/zenodo.4498634)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20CadQuery%20Guru-006BFF)](https://gurubase.io/g/cadquery)
 
 
 ---


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CadQuery Guru](https://gurubase.io/g/cadquery) to Gurubase. CadQuery Guru uses the data from this repo and data from the [docs](https://cadquery.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "CadQuery Guru", which highlights that CadQuery now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CadQuery Guru in Gurubase, just let me know that's totally fine.
