### PR TITLE
Updated version specification for nlopt to try to resolve issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if not is_rtd and not is_appveyor and not is_azure and not is_conda:
         "cadquery-ocp>=7.7.0a0,<7.8",
         "ezdxf",
         "multimethod>=1.11,<2.0",
-        "nlopt",
+        "nlopt>=2.9.0,<3.0",
         "typish",
         "casadi",
         "path",


### PR DESCRIPTION
A new version of nlopt (2.9.0) was released on on PyPI on November 16th. I have updated setup.py for this version and newer to try to resolve the issues that some users are having.

https://pypi.org/project/nlopt/

I did not try to pin the version for conda because it does not seem to be needed. Let me know if someone thinks I need to do that as well.