### PR TITLE
Add TypeVar to deprecate_kwarg_name to preserve type information

### DIFF
--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -58,7 +58,7 @@ class deprecate_kwarg_name:
         self.name = name
         self.new_name = new_name
 
-    def __call__(self, f):
+    def __call__(self, f: TCallable) -> TCallable:
         @wraps(f)
         def wrapped(*args, **kwargs):
 
@@ -70,7 +70,7 @@ class deprecate_kwarg_name:
 
             return f(*args, **kwargs)
 
-        return wrapped
+        return cast(TCallable, wrapped)
 
 
 def get_arity(f: TCallable) -> int:


### PR DESCRIPTION
Fixes issue initially reported in #1308, based off changes in #1348.

Initially reported issue reported issues with functions typed with `deprecate_kwarg_name`, but the fix PR fixed `deprecate_kwarg` which appeared to suffer from the same issue. I'm encountering the initially reported issue with calls to `.text` still, so this PR applies the fix from the initial issue description to the `deprecate_kwarg_name` class as well.

I've tested locally and confirmed this resolves typing issues on `.text` for me. 