### PR TITLE
Added ezdxf version pins

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - ocp 7.7.2
     - vtk=*=qt*
     - pyparsing >=2.1.9
-    - ezdxf
+    - ezdxf>=1.3.0
     - ipython
     - typing_extensions
     - nlopt

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - codecov
   - pytest
   - pytest-cov
-  - ezdxf
+  - ezdxf>=1.3.0
   - typing_extensions
   - nlopt
   - path

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ is_conda = "CONDA_PREFIX" in os.environ
 if not is_rtd and not is_appveyor and not is_azure and not is_conda:
     reqs = [
         "cadquery-ocp>=7.7.0,<7.8",
-        "ezdxf",
+        "ezdxf>=1.3.0",
         "multimethod>=1.11,<2.0",
         "nlopt>=2.9.0,<3.0",
         "typish",


### PR DESCRIPTION
At least some of the variants of conda seem to be solving to much older versions of ezdxf (0.3.0 instead of 1.3.0), so this PR pins the version in environment.yml to try to counteract this, and adds the same pin to setup.py for consistency.

This should address issue #1704 