### PR TITLE
Deemphasize Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,8 +3,8 @@ contact_links:
   - name: Online documentation
     url: https://cadquery.readthedocs.io/
     about: CadQuery's extensive online documentation
-  - name: Discord channel
-    url: https://discord.gg/qz3uAdF
+  - name: GitHub Discussions
+    url: https://github.com/CadQuery/cadquery/discussions
     about: For more casual discussion and help
   - name: Google group
     url: https://groups.google.com/forum/#!forum/cadquery

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ---
 
 ### Quick Links
-[***Documentation***](https://cadquery.readthedocs.io/en/latest/) | [***Cheatsheet***](https://cadquery.readthedocs.io/en/latest/_static/cadquery_cheatsheet.html) | [***Discord***](https://discord.com/invite/Bj9AQPsCfx) | [***Google Group***](https://groups.google.com/g/cadquery) | [***GUI Editor***](https://github.com/CadQuery/CQ-editor)
+[***Documentation***](https://cadquery.readthedocs.io/en/latest/) | [***Cheatsheet***](https://cadquery.readthedocs.io/en/latest/_static/cadquery_cheatsheet.html) | [***GitHub Discussions***](https://github.com/CadQuery/cadquery/discussions) | [***Google Group***](https://groups.google.com/g/cadquery) | [***GUI Editor***](https://github.com/CadQuery/CQ-editor)
 
 ---
 
@@ -125,7 +125,9 @@ You can find the full CadQuery documentation at [cadquery.readthedocs.io](https:
 
 We also have a [Google Group](https://groups.google.com/forum/#!forum/cadquery) to make it easy to get help from other CadQuery users. We want you to feel welcome and encourage you to join the group and introduce yourself. We would also love to hear what you are doing with CadQuery.
 
-There is a [Discord server](https://discord.gg/Bj9AQPsCfx) as well. You can ask for help in the _general_ channel.
+[GitHub Discussions](https://github.com/CadQuery/cadquery/discussions) is a good place to ask general questions that are not tied to a bug report or feature request.
+
+There is also a [Discord](https://discord.com/invite/Bj9AQPsCfx) server, but the other methods of getting help are much better for newcomers.
 
 ## Projects using CadQuery
 


### PR DESCRIPTION
We have been pointing new users to the Discord server, but it looks like they are often not getting help once they get there. New users will have much more luck getting help with the other resources that are listed, and I added GitHub Discussions as a primary way to get help (in place of the Discord server). I have removed all of the prominent mentions of the Discord server, and added a line to let users know that they can go there, but it may not be the best place for them to get help.

The Discord server has turned into a broader discussion area for CodeCAD, often for more advanced topics. I will probably rework the server somewhat to reflect that.