### PR TITLE
Dxf export performance

### DIFF
--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -197,8 +197,6 @@ class DxfDocument:
                     dxfattribs=general_attributes
                 ).apply_construction_tool(entity)
 
-        zoom.extents(self.msp)
-
         return self
 
     @staticmethod
@@ -394,4 +392,5 @@ def exportDXF(
         for s in w:
             dxf.add_shape(s)
 
+    zoom.extents(dxf.msp)
     dxf.document.saveas(fname)


### PR DESCRIPTION
This is a very small PR that changes when the the viewport on a DXF layout is aligned.

I noticed every slow DXF export times (multiple minutes in some larger designs). The problem is that the mentioned alignment is done each time a shape is added to the document. My shapes very fairly simple, but there are many (72 in the example below, but we are regularly dealing many thousands.

The following output from the profiler illustrates the immense cost of this constant re-aligning:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001   21.836   21.836 /<path>.py:35(create_artifacts)
...
       72    0.015    0.000   20.345    0.283 /<path>/site-packages/cadquery/occ_impl/exporters/dxf.py:149(add_shape)
       72    0.000    0.000   19.222    0.267 /<path>/site-packages/ezdxf/zoom.py:62(extents)
   107492    0.164    0.000   19.137    0.000 /<path>/site-packages/ezdxf/bbox.py:145(multi_flat)
   107420    0.288    0.000   18.615    0.000 /<path>/site-packages/ezdxf/bbox.py:158(extends_)
       72    0.002    0.000   17.964    0.250 /<path>/site-packages/ezdxf/zoom.py:39(zoom_to_entities)
       72    0.102    0.001   16.184    0.225 /<path>/site-packages/ezdxf/bbox.py:127(extents)
   214840    0.312    0.000   16.161    0.000 /<path>/site-packages/ezdxf/bbox.py:92(multi_recursive)
   214840    0.163    0.000   11.722    0.000 /<path>/site-packages/ezdxf/disassemble.py:584(to_primitives)
   214840    0.215    0.000   10.906    0.000 /<path>/site-packages/ezdxf/disassemble.py:542(recursive_decompose)
   322260    2.454    0.000    4.401    0.000 /<path>/site-packages/ezdxf/math/bbox.py:442(extents3d)
   214840    0.584    0.000    3.697    0.000 /<path>/site-packages/ezdxf/math/bbox.py:184(extend)
   214912    0.225    0.000    1.976    0.000 /<path>/site-packages/ezdxf/math/bbox.py:163(__init__)
   106382    0.125    0.000    1.959    0.000 /<path>/site-packages/ezdxf/disassemble.py:192(bbox)
   107420    0.059    0.000    1.133    0.000 /<path>/site-packages/ezdxf/disassemble.py:66(is_empty)
```
As one can infer from the timings, generating the 72 shapes only takes ~1.5 sec, adding them to the dxf document takes ~1.1sec, and the alignment takes the remaining time. I believe that the alignment doesn't scale linearly, as the amount of entities already added to the document slows things down (200 shapes took ~20min).

Long story short: do the alignment just before saving the DXF.