### PR TITLE
Local and non-manifold sewing

### DIFF
--- a/cadquery/func.py
+++ b/cadquery/func.py
@@ -47,4 +47,5 @@ from .occ_impl.shapes import (
     check,
     closest,
     setThreads,
+    project,
 )

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -15,6 +15,8 @@ from typing import (
     Protocol,
 )
 
+from typing_extensions import Self
+
 from io import BytesIO
 
 from vtkmodules.vtkCommonDataModel import vtkPolyData
@@ -193,7 +195,7 @@ from OCP.StlAPI import StlAPI_Writer
 
 from OCP.ShapeUpgrade import ShapeUpgrade_UnifySameDomain
 
-from OCP.BRepTools import BRepTools, BRepTools_WireExplorer
+from OCP.BRepTools import BRepTools, BRepTools_WireExplorer, BRepTools_Substitution
 
 from OCP.LocOpe import LocOpe_DPrism
 
@@ -1689,6 +1691,18 @@ class Shape(object):
 
         self.wrapped = wrapped
         self.forConstruction = data[1]
+
+    def replace(self, old: "Shape", *new: "Shape") -> Self:
+        """
+        Replace old Subshape with new subshapes.
+        """
+
+        bldr = BRepTools_Substitution()
+        bldr.Substitute(old.wrapped, _shapes_to_toptools_list(new))
+
+        bldr.Build(self.wrapped)
+
+        return self
 
 
 class ShapeProtocol(Protocol):

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -5708,7 +5708,7 @@ def imprint(
         for s in shapes:
             try:
                 history[s] = _compound_or_shape(list(images.Find(s.wrapped)))
-            except Standard_NoSuchObject:
+            except Standard_NoSuchObject:  # pragma: no cover
                 pass
 
     return _compound_or_shape(builder.Shape())

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -1403,7 +1403,10 @@ class Shape(object):
         Minimal distance between two shapes
         """
 
-        return BRepExtrema_DistShapeShape(self.wrapped, other.wrapped).Value()
+        dist_calc = BRepExtrema_DistShapeShape(self.wrapped, other.wrapped)
+        dist_calc.SetMultiThread(True)
+
+        return dist_calc.Value()
 
     def distances(self, *others: "Shape") -> Iterator[float]:
         """
@@ -1411,6 +1414,8 @@ class Shape(object):
         """
 
         dist_calc = BRepExtrema_DistShapeShape()
+        dist_calc.SetMultiThread(True)
+
         dist_calc.LoadS1(self.wrapped)
 
         for s in others:

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -5082,7 +5082,7 @@ def _adaptor_curve_to_edge(crv: Adaptor3d_Curve, p1: float, p2: float) -> TopoDS
 
 #%% alternative constructors
 
-ShapeHistory = Dict[Union[Face, str], Face]
+ShapeHistory = Dict[Union[Shape, str], Shape]
 
 
 @multimethod

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -5145,17 +5145,11 @@ def _process_sewing_history(
         # collect shapes present in the history dict
         for k, v in history.items():
             if isinstance(k, str):
-                try:
-                    history[k] = Face(builder.Modified(v.wrapped))
-                except Standard_NoSuchObject:
-                    pass
+                history[k] = Face(builder.Modified(v.wrapped))
 
         # store all top-level shape relations
         for f in faces:
-            try:
-                history[f] = Face(builder.Modified(f.wrapped))
-            except Standard_NoSuchObject:
-                pass
+            history[f] = Face(builder.Modified(f.wrapped))
 
 
 @multimethod

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3555,6 +3555,20 @@ class Face(Shape):
 
         return self.__class__(rv)
 
+    def addHole(self, *inner: Wire | Edge) -> Self:
+        """
+        Add one or more holes.
+        """
+
+        bldr = BRepBuilderAPI_MakeFace(self.wrapped)
+
+        for w in inner:
+            bldr.Add(
+                TopoDS.Wire_s(w.wrapped if isinstance(w, Wire) else wire(w).wrapped)
+            )
+
+        return self.__class__(bldr.Face()).fix()
+
 
 class Shell(Shape):
     """

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -5708,7 +5708,7 @@ def imprint(
         for s in shapes:
             try:
                 history[s] = _compound_or_shape(list(images.Find(s.wrapped)))
-            except Standard_NoSuchObject:  # pragma: no cover
+            except Standard_NoSuchObject:
                 pass
 
     return _compound_or_shape(builder.Shape())

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3485,14 +3485,23 @@ class Face(Shape):
         return [self.isoline(p, direction) for p in params]
 
     def extend(
-        self, umin: bool, umax: bool, vmin: bool, vmax: bool, d: float
+        self, d: float, umin: bool, umax: bool, vmin: bool, vmax: bool
     ) -> "Face":
         """
-        Extend a face.
+        Extend a face. Does not work well in periodic directions.
+        
+        :param d: length of the extension.
+        :param umin: extend along the umin isoline.
+        :param umax: extend along the umax isoline.
+        :param vmin: extend along the vmin isoline.
+        :param umax: extend along the umax isoline.
         """
 
+        # convert to NURBS first
+        tmp = self.toNURBS().wrapped
+
         rv = TopoDS_Face()
-        BRepLib.ExtendFace_s(self.wrapped, d, umin, umax, vmin, vmax, rv)
+        BRepLib.ExtendFace_s(tmp, d, umin, umax, vmin, vmax, rv)
 
         return self.__class__(rv)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3570,7 +3570,6 @@ class Face(Shape):
         return self.__class__(bldr.Face()).fix()
 
 
-
 class Shell(Shape):
     """
     the outer boundary of a surface

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3486,7 +3486,12 @@ class Face(Shape):
         return [self.isoline(p, direction) for p in params]
 
     def extend(
-        self, d: float, umin: bool, umax: bool, vmin: bool, vmax: bool
+        self,
+        d: float,
+        umin: bool = True,
+        umax: bool = True,
+        vmin: bool = True,
+        vmax: bool = True,
     ) -> "Face":
         """
         Extend a face. Does not work well in periodic directions.

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -3501,12 +3501,6 @@ class Face(Shape):
         # convert to NURBS if needed
         tmp = self.toNURBS() if self.geomType() != "BSPLINE" else self
 
-        # check min degree
-        ga = tcast(Geom_BSplineSurface, tmp._geomAdaptor())
-        min_deg = min(ga.UDegree(), ga.VDegree())
-
-        assert min_deg >= 3, "At least degree 3 surface required"
-
         rv = TopoDS_Face()
         BRepLib.ExtendFace_s(tmp.wrapped, d, umin, umax, vmin, vmax, rv)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -4423,6 +4423,25 @@ class Solid(Shape, Mixin3D):
 
         return [s for s in self.Shells() if not s.isSame(outer)]
 
+    def addCavity(self, *shells: Union[Shell, "Solid"]) -> Self:
+        """
+        Add one or more cavities.
+        """
+
+        builder = BRepBuilderAPI_MakeSolid(self.wrapped)
+
+        # if a solid is provided only outer shell is added
+        for sh in shells:
+            builder.Add(
+                sh.wrapped if isinstance(sh, Shell) else sh.outerShell().wrapped
+            )
+
+        # fix orientations
+        sf = ShapeFix_Solid(builder.Solid())
+        sf.Perform()
+
+        return self.__class__(sf.Solid())
+
 
 class CompSolid(Shape, Mixin3D):
     """

--- a/doc/free-func.rst
+++ b/doc/free-func.rst
@@ -1,4 +1,4 @@
-.. _freefuncapi:
+
 
 *****************
 Free function API
@@ -241,7 +241,8 @@ Placement and creation of arrays is possible using :meth:`~cadquery.Shape.move` 
 Text
 ----
 
-The free function API has extensive text creation capabilities including text on planar curves and text on surfaces.
+The free function API has extensive text creation capabilities including text on
+planar curves and text on surfaces.
 
 
 .. cadquery::
@@ -275,3 +276,44 @@ The free function API has extensive text creation capabilities including text on
     r4 = offset(r3, TH).moved(z=S)
 
     result = compound(r1, r2, r3, r4)
+
+
+Adding features manually
+------------------------
+
+In certain cases it is desireable to add features such as holes or protrusions manually.
+E.g., for complicated shapes it might be beneficial performance-wise because it
+avoids boolean operations. One can add or remove faces, add holes to existing faces
+and last but not least reconstruct existing solids. 
+
+.. cadquery::
+    
+    from cadquery.func import *
+    
+    # box
+    b = box(1,1,1)
+    # bottom face
+    b_bot = b.faces('<Z')
+    # top faces
+    b_top = b.faces('>Z')
+    
+    # inner face 
+    inner = extrude(circle(0.45), (0,0,1))
+    
+    # add holes to the bottom and top face
+    b_bot_hole = b_bot.addHole(inner.edges('<Z'))
+    b_top_hole = b_top.addHole(inner.edges('>Z'))
+    
+    # needed to map between shapes before and after construction
+    hist = {}
+    
+    # construct the final solid
+    result = solid(
+        (b.remove(b_top, b_bot).faces(), #side faces
+         b_bot_hole, # bottom with a hole
+         inner, # inner cylinder face
+         b_top_hole, # top with a hole
+        ),
+        history=hist,
+    )
+

--- a/doc/free-func.rst
+++ b/doc/free-func.rst
@@ -315,7 +315,7 @@ and last but not least reconstruct existing solids.
         b_top_hole, # top with a hole
     )
 
-If the base shape is more complicate, it is possible to use local sewing that
+If the base shape is more complicated, it is possible to use local sewing that
 takes into account on indicated elements of the context shape. This, however,
 necessitates a two step approach - first a shell needs to be explicitly sewn
 and only then the final solid can be constructed.
@@ -346,3 +346,6 @@ and only then the final solid can be constructed.
     sh = shell(b_top_hole, feat.faces('<Z'), ctx=(b, feat))
     
     # construct the final solid
+    result = solid(sh)
+
+

--- a/doc/free-func.rst
+++ b/doc/free-func.rst
@@ -342,7 +342,7 @@ and only then the final solid can be constructed.
     b_top_hole = b_top.addHole(feat.edges('<Z'))
     b = b.replace(b_top, b_top_hole)
     
-    # locall sewing - only two faces are take into account
+    # local sewing - only two faces are take into account
     sh = shell(b_top_hole, feat.faces('<Z'), ctx=(b, feat))
     
     # construct the final solid

--- a/doc/free-func.rst
+++ b/doc/free-func.rst
@@ -342,7 +342,7 @@ and only then the final solid can be constructed.
     b_top_hole = b_top.addHole(feat.edges('<Z'))
     b = b.replace(b_top, b_top_hole)
     
-    # local sewing - only two faces are take into account
+    # local sewing - only two faces are taken into account
     sh = shell(b_top_hole, feat.faces('<Z'), ctx=(b, feat))
     
     # construct the final solid

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -430,6 +430,7 @@ def test_imprint():
 
     assert len(res_glue_full.Faces()) == len(compound(b1, b2).Faces()) - 1
 
+    # imprint with history
     history = dict(b1=b1, b3=b3)
     res_glue_partial = imprint(b1, b3, glue="partial", history=history)
 
@@ -438,6 +439,13 @@ def test_imprint():
 
     assert len(b1_imp.Faces()) == len(b1.Faces()) + 1
     assert len(res_glue_partial.Faces()) == len(b1_imp.Faces() + b3_imp.Faces()) - 1
+
+    # imprint with faulty history
+    history = dict(b2=b2)
+    # this does not raise!
+    res_glue_partial = imprint(b1, b3, glue="partial", history=history)
+
+    assert b2 not in history
 
 
 def test_setThreads():

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -205,18 +205,27 @@ def test_sewing():
     sh = b.remove(ftop)
 
     # regular local sewing
-    history1 = {}
+    history1 = dict(ftop=ftop)
     res1 = shell(sh.faces("not <Z"), ftop, ctx=(sh, ftop), history=history1)
 
     assert res1.isValid()
     assert res1.Area() == approx(6)
+    assert "ftop" in history1
 
-    # non-manifold sewing
-    res2 = shell(sh.faces(), ftop, ftop.moved(x=1), manifold=False)
+    # regular local sewing - with Shape context
+    history2 = {}
+    res2 = shell(sh.faces("not <Z"), ftop, ctx=compound(sh, ftop), history=history2)
 
     assert res2.isValid()
-    assert not solid(res2).isValid()
-    assert isinstance(res2, Shell)
+    assert res2.Area() == approx(6)
+    assert ftop in history2
+
+    # non-manifold sewing
+    res3 = shell(sh.faces(), ftop, ftop.moved(x=1), manifold=False)
+
+    assert res3.isValid()
+    assert not solid(res3).isValid()
+    assert isinstance(res3, Shell)
 
     # manifold sewing (default) - results in a compound
     res3 = shell(sh.faces(), ftop, ftop.moved(x=1), manifold=True)

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -1,4 +1,4 @@
-from cadquery.occ_impl.shapes import (
+from cadquery.func import (
     vertex,
     segment,
     polyline,
@@ -37,17 +37,22 @@ from cadquery.occ_impl.shapes import (
     Compound,
     Edge,
     Shell,
+    Wire,
+    check,
+    Vector,
+    closest,
+    imprint,
+    setThreads,
+    project,
+)
+
+from cadquery.occ_impl.shapes import (
     _get_one_wire,
     _get_wires,
     _get,
     _get_one,
     _get_edges,
     _adaptor_curve_to_edge,
-    check,
-    Vector,
-    closest,
-    imprint,
-    setThreads,
 )
 
 from OCP.BOPAlgo import BOPAlgo_CheckStatus
@@ -802,6 +807,26 @@ def test_loft_vertex():
     assert len(r4.Solids()) == 1
     assert r4.Volume() == approx(r3.Volume())  # inner features are ignored
     assert len(r5.Faces()) == 4
+
+
+def test_project():
+
+    base = cylinder(1, 2).faces("%CYLINDER")
+    e = circle(0.1).moved(rx=90).moved(y=0.5, z=1)
+
+    # project single edge
+    res = project(e, base)
+
+    assert res.isValid()
+    assert res.IsClosed()
+    assert isinstance(res, Edge)
+
+    # project multiple edges at once
+    res = project(e.moved([(0, -0.1), (0, 0.1)]), base)
+    assert isinstance(res, Compound)
+    for el in res:
+        assert el.isValid()
+        assert el.IsClosed()
 
 
 # %% export

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -168,25 +168,6 @@ def test_constructors():
     assert sh2.Area() == approx(6)
     assert sh3.isValid()
 
-    # solid
-    s1 = solid(b.Faces())
-    s2 = solid(*b.Faces())
-
-    assert s1.Volume() == approx(1)
-    assert s2.Volume() == approx(1)
-
-    # solid with voids
-    b1 = box(0.1, 0.1, 0.1)
-
-    s3 = solid(b.Faces(), b1.moved([(0.2, 0, 0.5), (-0.2, 0, 0.5)]).Faces())
-
-    assert s3.Volume() == approx(1 - 2 * 0.1 ** 3)
-
-    # solid from shells
-    s4 = solid(b.shells())
-
-    assert s4.Volume() == approx(1)
-
     # compound
     c1 = compound(b.Faces())
     c2 = compound(*b.Faces())
@@ -232,6 +213,41 @@ def test_sewing():
 
     assert res3.isValid()
     assert isinstance(res3, Compound)
+
+
+def test_solid():
+
+    b = box(1, 1, 1)
+
+    # solid
+    s1 = solid(b.Faces())
+    s2 = solid(*b.Faces())
+
+    assert s1.Volume() == approx(1)
+    assert s2.Volume() == approx(1)
+
+    # solid with voids
+    b1 = box(0.1, 0.1, 0.1)
+
+    s3 = solid(b.Faces(), b1.moved([(0.2, 0, 0.5), (-0.2, 0, 0.5)]).Faces())
+
+    assert s3.Volume() == approx(1 - 2 * 0.1 ** 3)
+
+    # solid from shells
+    s4 = solid(b.shells())
+
+    assert s4.Volume() == approx(1)
+
+    # check history handling
+    hist = {}
+    s4 = solid(
+        b.Faces(), b1.moved([(0.2, 0, 0.5), (-0.2, 0, 0.5)]).Faces(), history=hist
+    )
+
+    final_faces = s4.Faces()
+    final_faces_history = list(hist.values())
+    for f in final_faces:
+        assert f in final_faces_history
 
 
 #%% primitives

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -51,7 +51,7 @@ from cadquery.occ_impl.shapes import (
 
 from OCP.BOPAlgo import BOPAlgo_CheckStatus
 
-from pytest import approx, raises
+from pytest import approx, raises, fixture
 from math import pi
 
 #%% test utils
@@ -446,6 +446,36 @@ def test_imprint():
     res_glue_partial = imprint(b1, b3, glue="partial", history=history)
 
     assert b2 not in history
+
+
+@fixture
+def patch_find(monkeypatch):
+
+    import OCP
+    from OCP.TopTools import TopTools_DataMapOfShapeListOfShape
+    from OCP.Standard import Standard_NoSuchObject
+    from OCP.BOPAlgo import BOPAlgo_Builder
+
+    def dummy(x):
+
+        raise ValueError("A")
+        raise Standard_NoSuchObject
+
+    class DummyMap(TopTools_DataMapOfShapeListOfShape):
+        def Find(self, x):
+            raise Standard_NoSuchObject
+
+    monkeypatch.setattr(BOPAlgo_Builder, "Images", lambda x: DummyMap())
+
+
+def test_imprint_error(patch_find):
+
+    b1 = box(1, 1, 1)
+    b2 = b1.moved(x=1)
+
+    history = {}
+
+    _ = imprint(b1, b2, history=history)
 
 
 def test_setThreads():

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -36,6 +36,7 @@ from cadquery.occ_impl.shapes import (
     Shape,
     Compound,
     Edge,
+    Shell,
     _get_one_wire,
     _get_wires,
     _get,
@@ -195,6 +196,33 @@ def test_constructors():
 
     for f in list(c1) + list(c2):
         assert f.ShapeType() == "Face"
+
+
+def test_sewing():
+
+    b = box(1, 1, 1)
+    ftop = b.faces(">Z")
+    sh = b.remove(ftop)
+
+    # regular local sewing
+    history1 = {}
+    res1 = shell(sh.faces("not <Z"), ftop, ctx=(sh, ftop), history=history1)
+
+    assert res1.isValid()
+    assert res1.Area() == approx(6)
+
+    # non-manifold sewing
+    res2 = shell(sh.faces(), ftop, ftop.moved(x=1), manifold=False)
+
+    assert res2.isValid()
+    assert not solid(res2).isValid()
+    assert isinstance(res2, Shell)
+
+    # manifold sewing (default) - results in a compound
+    res3 = shell(sh.faces(), ftop, ftop.moved(x=1), manifold=True)
+
+    assert res3.isValid()
+    assert isinstance(res3, Compound)
 
 
 #%% primitives

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -450,8 +450,10 @@ def test_imprint():
 
 @fixture
 def patch_find(monkeypatch):
+    """
+    Fixture for throwing exception during imprinting.
+    """
 
-    import OCP
     from OCP.TopTools import TopTools_DataMapOfShapeListOfShape
     from OCP.Standard import Standard_NoSuchObject
     from OCP.BOPAlgo import BOPAlgo_Builder

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -264,3 +264,39 @@ def test_extend():
     f_ext = f.extend(1)
 
     assert f_ext.Area() > f.Area()
+
+
+def test_remove():
+
+    b = box(2, 2, 2) - box(1, 1, 1).moved(z=0.5)
+
+    assert len(b.Faces()) == 12
+
+    br = b.remove(*b.innerShells())
+
+    assert len(br.Faces()) == 6
+    assert br.isValid()
+
+
+def test_addCavity():
+
+    b1 = box(2, 2, 2)
+    b2 = box(1, 1, 1).moved(z=0.5)
+
+    br = b1.addCavity(b2)
+
+    assert len(br.Faces()) == 12
+    assert len(br.Shells()) == 2
+    assert br.isValid()
+
+
+def test_replace():
+
+    b = box(1, 1, 1)
+    f_top = b.faces(">Z")
+    f_top_split = f_top / plane(0.5, 0.5).moved(f_top.Center())
+
+    br = b.replace(f_top, f_top_split)
+
+    assert len(br.Faces()) == len(b.Faces()) + 1
+    assert br.isValid()

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -13,6 +13,7 @@ from cadquery.occ_impl.shapes import (
     cylinder,
     ellipse,
     spline,
+    sweep,
 )
 
 from pytest import approx, raises
@@ -255,3 +256,11 @@ def test_isolines():
 
     assert isos_u[0].Length() == approx(2)
     assert isos_v[0].Length() == approx(pi)
+
+
+def test_extend():
+
+    f = sweep(spline((0, 0), (0, 1), (2, 0)), spline((0, 0, 0), (0, 1, 1), (0, 1, 5)))
+    f_ext = f.extend(1)
+
+    assert f_ext.Area() > f.Area()

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -296,7 +296,12 @@ def test_replace():
     f_top = b.faces(">Z")
     f_top_split = f_top / plane(0.5, 0.5).moved(f_top.Center())
 
-    br = b.replace(f_top, f_top_split)
+    br1 = b.replace(f_top, f_top_split)
 
-    assert len(br.Faces()) == len(b.Faces()) + 1
-    assert br.isValid()
+    assert len(br1.Faces()) == len(b.Faces()) + 1
+    assert br1.isValid()
+
+    br2 = b.replace(f_top, *f_top_split)  # invoke with individual faces
+
+    assert len(br2.Faces()) == len(b.Faces()) + 1
+    assert br2.isValid()

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -305,3 +305,24 @@ def test_replace():
 
     assert len(br2.Faces()) == len(b.Faces()) + 1
     assert br2.isValid()
+
+
+def test_addHole():
+
+    f = plane(1, 1)
+    c = circle(0.1)
+
+    f1 = f.addHole(c)
+
+    assert len(f1.innerWires()) == 1
+    assert f1.isValid()
+
+    f2 = f.addHole(wire(c))
+
+    assert len(f2.innerWires()) == 1
+    assert f2.isValid()
+
+    f3 = f.addHole(*c.moved((-0.3, 0), (0.3, 0)))
+
+    assert len(f3.innerWires()) == 2
+    assert f3.isValid()


### PR DESCRIPTION
Supports advanced use cases of building shapes from individual faces.

- [x] local and non-manifold sewing
- [x] history for `shell` and `solid`
- [x] `addHole` for `Face`
- [x] tests
- [x] project (normal projection)
- [x] docs

```python
from cadquery.func import *
from cadquery.vis import show

# box
b = box(1,1,1)
# bottom face
bb = b.faces('<Z')
# top faces
bt = b.faces('>Z')

# make inner tube 
c = circle(0.45)
cf = extrude(c, (0,0,1))

# add holes to the bottom and top face
bb_hole = bb.addHole(c)
bt_hole = bt.addHole(cf.edges('>Z'))

hist = {}

# construct the final solid
rs = solid(
    (b.remove(bt, bb).faces(), #side faces
     bb_hole, # bottom with a hole
     cf, # inner cylinder face
     bt_hole, # top with a hole
    ),
    history=hist,
)

show(rs)

```

![image](https://github.com/user-attachments/assets/7901d35c-0771-4250-978f-1116d0ee89a1)
