### PR TITLE
Fix Calculation of Compound Center of Masses

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -841,7 +841,6 @@ class Shape(object):
     def ShapeType(self) -> Shapes:
         return tcast(Shapes, shape_LUT[shapetype(self.wrapped)])
 
-
     def _entities(self, topo_type: Shapes) -> Iterable[TopoDS_Shape]:
 
         shape_set = TopTools_IndexedMapOfShape()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -724,17 +724,12 @@ class Shape(object):
 
         raise NotImplementedError
 
-    def Center(self, shape_type: Shapes = None) -> Vector:
+    def Center(self) -> Vector:
         """
         :returns: The point of the center of mass of this Shape
         """
 
-        if shape_type is None:
-            occ_shape_type = None
-        else:
-            occ_shape_type = inverse_shape_LUT[shape_type]
-
-        return Shape.centerOfMass(self, shape_type=occ_shape_type)
+        return Shape.centerOfMass(self)
 
     def CenterOfBoundBox(self, tolerance: Optional[float] = None) -> Vector:
         """
@@ -4718,6 +4713,7 @@ class Compound(Shape, Mixin3D):
             return rv if level == 1 else _siblings(rv, level - 1)
 
         return Compound.makeCompound(_siblings(self, level))
+        return Shape.centerOfMass(self, shape_type=self._getHighestOrderShapeType())
 
 
 def sortWiresByBuildOrder(wireList: List[Wire]) -> List[List[Wire]]:

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -12,7 +12,7 @@ from typing import (
     TypeVar,
     cast as tcast,
     Literal,
-    Protocol, get_args,
+    Protocol,
 )
 
 from typing_extensions import Self

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -758,6 +758,9 @@ class Shape(object):
 
     @staticmethod
     def _mass_calc_function(obj: "Shape") -> Any:
+        """
+        Helper to find the correct mass calculation function with special compound handling.
+        """
 
         type_ = shapetype(obj.wrapped)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -4703,38 +4703,6 @@ class Compound(Shape, Mixin3D):
 
         return Compound.makeCompound(_siblings(self, level))
 
-    def getHighestOrderShapeType(self) -> Shapes:
-        """
-        Determines the highest-order topological shape within a compound shape, or returns the shape type itself.
-
-        If the shape is not a compound (`TopoDS_Compound`), it directly returns its shape type.
-        If the shape is a compound, it iterates through all shape types (excluding CompSolid and Compound) in descending topological order
-        (e.g., Solid > Shell > Face > Wire > Edge) and returns the type of the highest-level shape present within the compound.
-
-        :returns: Shapes
-        """
-        return tcast(Shapes, shape_LUT[self._getHighestOrderShapeType()])
-
-    def _getHighestOrderShapeType(self) -> ta:
-        """
-        :returns: TopAbs
-        """
-        shape_OCC = self.wrapped
-
-        if shape_OCC.ShapeType() != ta.TopAbs_COMPOUND:
-            return shape_OCC.ShapeType()
-
-        reversed_shape_types = list(reversed(get_args(Shapes)))
-
-        for shape_type in reversed_shape_types[2:]: # Iterate over topo shapes excluding Compounds and CompSolids
-            if not self._entities(shape_type).IsEmpty():
-                return inverse_shape_LUT[shape_type]
-
-        raise Exception("Unable to find any shape types present in the given shape.")
-
-    def Center(self) -> Vector:
-        return Shape.centerOfMass(self, shape_type=self._getHighestOrderShapeType())
-
 
 def sortWiresByBuildOrder(wireList: List[Wire]) -> List[List[Wire]]:
     """Tries to determine how wires should be combined into faces.

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -12,7 +12,7 @@ from typing import (
     TypeVar,
     cast as tcast,
     Literal,
-    Protocol,
+    Protocol, get_args,
 )
 
 from typing_extensions import Self
@@ -815,6 +815,35 @@ class Shape(object):
 
     def ShapeType(self) -> Shapes:
         return tcast(Shapes, shape_LUT[shapetype(self.wrapped)])
+
+    def getHighestOrderShapeType(self) -> Shapes:
+        """
+        Determines the highest-order topological shape within a compound shape, or returns the shape type itself.
+
+        If the shape is not a compound (`TopoDS_Compound`), it directly returns its shape type.
+        If the shape is a compound, it iterates through all shape types (excluding CompSolid and Compound) in descending topological order
+        (e.g., Solid > Shell > Face > Wire > Edge) and returns the type of the highest-level shape present within the compound.
+
+        :returns: Shapes
+        """
+        return tcast(Shapes, shape_LUT[self._getHighestOrderShapeType()])
+
+    def _getHighestOrderShapeType(self) -> ta:
+        """
+        :returns: TopAbs
+        """
+        shape_OCC = self.wrapped
+
+        if shape_OCC.ShapeType() != ta.TopAbs_COMPOUND:
+            return shape_OCC.ShapeType()
+
+        reversed_shape_types = list(reversed(get_args(Shapes)))
+
+        for shape_type in reversed_shape_types[2:]: # Iterate over topo shapes excluding Compounds and CompSolids
+            if not self._entities(shape_type).IsEmpty():
+                return inverse_shape_LUT[shape_type]
+
+        raise Exception("Unable to find any shape types present in the given shape.")
 
     def _entities(self, topo_type: Shapes) -> Iterable[TopoDS_Shape]:
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -821,34 +821,6 @@ class Shape(object):
     def ShapeType(self) -> Shapes:
         return tcast(Shapes, shape_LUT[shapetype(self.wrapped)])
 
-    def getHighestOrderShapeType(self) -> Shapes:
-        """
-        Determines the highest-order topological shape within a compound shape, or returns the shape type itself.
-
-        If the shape is not a compound (`TopoDS_Compound`), it directly returns its shape type.
-        If the shape is a compound, it iterates through all shape types (excluding CompSolid and Compound) in descending topological order
-        (e.g., Solid > Shell > Face > Wire > Edge) and returns the type of the highest-level shape present within the compound.
-
-        :returns: Shapes
-        """
-        return tcast(Shapes, shape_LUT[self._getHighestOrderShapeType()])
-
-    def _getHighestOrderShapeType(self) -> ta:
-        """
-        :returns: TopAbs
-        """
-        shape_OCC = self.wrapped
-
-        if shape_OCC.ShapeType() != ta.TopAbs_COMPOUND:
-            return shape_OCC.ShapeType()
-
-        reversed_shape_types = list(reversed(get_args(Shapes)))
-
-        for shape_type in reversed_shape_types[2:]: # Iterate over topo shapes excluding Compounds and CompSolids
-            if not self._entities(shape_type).IsEmpty():
-                return inverse_shape_LUT[shape_type]
-
-        raise Exception("Unable to find any shape types present in the given shape.")
 
     def _entities(self, topo_type: Shapes) -> Iterable[TopoDS_Shape]:
 
@@ -4713,6 +4685,37 @@ class Compound(Shape, Mixin3D):
             return rv if level == 1 else _siblings(rv, level - 1)
 
         return Compound.makeCompound(_siblings(self, level))
+
+    def getHighestOrderShapeType(self) -> Shapes:
+        """
+        Determines the highest-order topological shape within a compound shape, or returns the shape type itself.
+
+        If the shape is not a compound (`TopoDS_Compound`), it directly returns its shape type.
+        If the shape is a compound, it iterates through all shape types (excluding CompSolid and Compound) in descending topological order
+        (e.g., Solid > Shell > Face > Wire > Edge) and returns the type of the highest-level shape present within the compound.
+
+        :returns: Shapes
+        """
+        return tcast(Shapes, shape_LUT[self._getHighestOrderShapeType()])
+
+    def _getHighestOrderShapeType(self) -> ta:
+        """
+        :returns: TopAbs
+        """
+        shape_OCC = self.wrapped
+
+        if shape_OCC.ShapeType() != ta.TopAbs_COMPOUND:
+            return shape_OCC.ShapeType()
+
+        reversed_shape_types = list(reversed(get_args(Shapes)))
+
+        for shape_type in reversed_shape_types[2:]: # Iterate over topo shapes excluding Compounds and CompSolids
+            if not self._entities(shape_type).IsEmpty():
+                return inverse_shape_LUT[shape_type]
+
+        raise Exception("Unable to find any shape types present in the given shape.")
+
+    def Center(self) -> Vector:
         return Shape.centerOfMass(self, shape_type=self._getHighestOrderShapeType())
 
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -724,12 +724,17 @@ class Shape(object):
 
         raise NotImplementedError
 
-    def Center(self) -> Vector:
+    def Center(self, shape_type: Shapes = None) -> Vector:
         """
         :returns: The point of the center of mass of this Shape
         """
 
-        return Shape.centerOfMass(self)
+        if shape_type is None:
+            occ_shape_type = None
+        else:
+            occ_shape_type = inverse_shape_LUT[shape_type]
+
+        return Shape.centerOfMass(self, shape_type=occ_shape_type)
 
     def CenterOfBoundBox(self, tolerance: Optional[float] = None) -> Vector:
         """
@@ -773,14 +778,19 @@ class Shape(object):
             raise NotImplementedError
 
     @staticmethod
-    def centerOfMass(obj: "Shape") -> Vector:
+    def centerOfMass(obj: "Shape", shape_type: ta = None) -> Vector:
         """
         Calculates the center of 'mass' of an object.
 
         :param obj: Compute the center of mass of this object
+        :param shape_type: An optional specification of the topological type of the shape. If not provided,
+        the shape type is inferred automatically. This is used to determine the correct
+        property calculation function from the lookup table.
         """
         Properties = GProp_GProps()
-        calc_function = shape_properties_LUT[shapetype(obj.wrapped)]
+        if shape_type is None:
+            shape_type = shapetype(obj.wrapped)
+        calc_function = shape_properties_LUT[shape_type]
 
         if calc_function:
             calc_function(obj.wrapped, Properties)

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5904,3 +5904,13 @@ class TestCadQuery(BaseTest):
         # in both cases we get a solid
         assert w1.solids().size() == 1
         assert w2.solids().size() == 1
+
+    def test_compound_faces_center(self):
+        sk = Sketch().rect(50, 50).faces()
+        face1 = sk.val()
+        face2 = face1.copy().translate(Vector(100, 0, 0))
+        compound = Compound.makeCompound([face1, face2])
+        expected_center = Shape.CombinedCenter([face1, face2])
+
+        assert compound.Center() == expected_center, "Incorrect center of mass of the compound, expected {}, got {}".format(
+            expected_center, compound.Center())

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5912,5 +5912,8 @@ class TestCadQuery(BaseTest):
         compound = Compound.makeCompound([face1, face2])
         expected_center = Shape.CombinedCenter([face1, face2])
 
-        assert compound.Center() == expected_center, "Incorrect center of mass of the compound, expected {}, got {}".format(
-            expected_center, compound.Center())
+        assert (
+            compound.Center() == expected_center
+        ), "Incorrect center of mass of the compound, expected {}, got {}".format(
+            expected_center, compound.Center()
+        )


### PR DESCRIPTION
The problem is described in the #1817 

- [x] Reimplement the `Center ` method of a compound.
- [x] Add  a new utility method that inspects the compound for the highest-order topological shape.
- [x] Add test case.

