### PR TITLE
feat: Enhance vis.py show routine

### DIFF
--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -391,8 +391,11 @@ def show(
     zoom: float = 1.0,
     roll: float = -35,
     elevation: float = -45,
+    azimuth: float = 0,
     position: Optional[Tuple[float, float, float]] = None,
     focus: Optional[Tuple[float, float, float]] = None,
+    viewup: Optional[Tuple[float, float, float]] = None,
+    clipping_range: Optional[Tuple[float, float]] = None,
     width: Union[int, float] = 0.5,
     height: Union[int, float] = 0.5,
     trihedron: bool = True,
@@ -491,17 +494,27 @@ def show(
 
     # set camera
     camera = renderer.GetActiveCamera()
+
+    # Reset orientation to known state
+    renderer.ResetCamera()
+
+    # Update camera position with user provided absolute positions
+    if viewup:
+        camera.SetViewUp(*viewup)
+    if position:
+        camera.SetPosition(*position)
+    if focus:
+        camera.SetFocalPoint(*focus)
+
+    # Update camera position with user defined relative positions
     camera.Roll(roll)
     camera.Elevation(elevation)
-    camera.Zoom(zoom)
+    camera.Azimuth(azimuth)
 
-    if position or focus:
-        if position:
-            camera.SetPosition(*position)
-        if focus:
-            camera.SetFocalPoint(*focus)
-    else:
-        renderer.ResetCamera()
+    # Update camera view frustum
+    camera.Zoom(zoom)
+    if clipping_range:
+        camera.SetClippingRange(*clipping_range)
 
     # initialize and set size
     inter.Initialize()


### PR DESCRIPTION
 - Add parameters azimuth viewup and clipping_range to allow for improved control of the rendering.
 - Always call ResetCamera early so the camera is in a known state before applying user defined parameters, some of which are relative.