### PR TITLE
feat: Tree traversal based initialization for assembly solving

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -119,12 +119,12 @@ class ConstraintGraph:
             self.locked.add((i, _Quantity.POINT))
             self.locked.add((i, _Quantity.AXIS))
         elif kind == "FixedPoint":
-            src, = srcs
-            src.setCoord(*param)
+            (src,) = srcs
+            src.SetCoord(*param)
             self.locked.add((i, _Quantity.POINT))
         elif kind == "FixedAxis":
-            src, = srcs
-            src.setCoord(*param)
+            (src,) = srcs
+            src.SetCoord(*param)
             self.locked.add((i, _Quantity.AXIS))
 
     def add_binary(self, i, j, pod):
@@ -472,12 +472,14 @@ class Assembly(object):
     @overload
     def constrain(
         self, q1: str, q2: str, kind: ConstraintKind, param: Any = None
-    ) -> "Assembly": ...
+    ) -> "Assembly":
+        ...
 
     @overload
     def constrain(
         self, q1: str, kind: ConstraintKind, param: Any = None
-    ) -> "Assembly": ...
+    ) -> "Assembly":
+        ...
 
     @overload
     def constrain(
@@ -488,7 +490,8 @@ class Assembly(object):
         s2: Shape,
         kind: ConstraintKind,
         param: Any = None,
-    ) -> "Assembly": ...
+    ) -> "Assembly":
+        ...
 
     @overload
     def constrain(
@@ -497,7 +500,8 @@ class Assembly(object):
         s1: Shape,
         kind: ConstraintKind,
         param: Any = None,
-    ) -> "Assembly": ...
+    ) -> "Assembly":
+        ...
 
     def constrain(self, *args, param=None):
         """


### PR DESCRIPTION
Resolves #1868 

This PR adds an optional initializer, which traverses through the constraint graph and locally solves every constraint with no degree of freedom. The traversal starts at fixed constraints. This provides a starting point for the solver to work with. If the constraint graph is a forest in which each tree has at most one fixed root, and each constraint has zero degree of freedom (e.g. axis with degree 0 or 180, or point), then this solves the constraints exactly.

Try this out:
```python
import cadquery as Cq

def mk_marker() -> Cq.Solid:
    return Cq.Solid.makeSphere(2)
def mk_cube() -> Cq.Solid:
    return Cq.Solid.makeBox(1.5, 1.6, 1.7)

a = (
    Cq.Assembly()
    .add(mk_marker(), name="m1", loc=Cq.Location(-1, 0, 0))
    .add(mk_marker(), name="m2", loc=Cq.Location(0, 1, 0))
    .add(mk_marker(), name="m3", loc=Cq.Location(0, 0, 1))
    .add(mk_cube(), name="cube", loc=Cq.Location(0, 0, 0))
    .constrain("m1", "m2", "Point")
    .constrain("m2", "m3", "Point")
    .constrain("m3", "cube@faces@<Z", "Point")
    .solve(verbosity=5, tree_initialize=True)
)
```
with `tree_initialize`, the number of iteration drops from 11 to (...)

- [X] Implement tree traversal
- [ ] Map each constraint point back to the object's location