### PR TITLE
adding name of duplicate name to error message

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -218,7 +218,7 @@ class Assembly(object):
             # enforce unique names
             name = kwargs["name"] if kwargs.get("name") else arg.name
             if name in self.objects:
-                raise ValueError("Unique name is required")
+                raise ValueError(f"Unique name is required. {name} is already in the assembly")
 
             subassy = arg._copy()
 

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -218,7 +218,9 @@ class Assembly(object):
             # enforce unique names
             name = kwargs["name"] if kwargs.get("name") else arg.name
             if name in self.objects:
-                raise ValueError(f"Unique name is required. {name} is already in the assembly")
+                raise ValueError(
+                    f"Unique name is required. {name} is already in the assembly"
+                )
 
             subassy = arg._copy()
 


### PR DESCRIPTION
We have some scripts that add many names and would benefit from at slight tweaked error message. So when the error is triggered we know what the incorrect name is.

Would we be able to extend the error message like this 