### PR TITLE
Fix bug in mirrorX and mirrorY

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -2305,6 +2305,9 @@ class Workplane(object):
             consolidated.objects.append(w)
             consolidated._addPendingWire(w)
 
+        # Reset the first point for the next operation
+        self.ctx.firstPoint = None
+
         # attempt again to consolidate all of the wires
         return consolidated.consolidateWires()
 
@@ -2330,6 +2333,9 @@ class Workplane(object):
         for w in mirroredWires:
             consolidated.objects.append(w)
             consolidated._addPendingWire(w)
+
+        # Reset the first point for the next operation
+        self.ctx.firstPoint = None
 
         # attempt again to consolidate all of the wires
         return consolidated.consolidateWires()


### PR DESCRIPTION
This should close #1015 

Another user ran into this bug. Consider the following.

```python
PROFILE_OUTER = [
    (10,  0),
    ( 8,  8),
    ( 0, 10),
]

PROFILE_INNER = [
    ( 1, 1),
    ( 9, 1),
    ( 9, 9),
    ( 1, 9),
]

# Do the mirroring, but stop after the bugged mirrorY call
terrain = (cq.Workplane("XY")
        .polyline(PROFILE_OUTER)
        .mirrorX()
        .mirrorY()
        .extrude(1)
        .faces(">Z")
        .workplane()
        .polyline(PROFILE_INNER)
        .close()
        .extrude(2))

show_object(terrain)
```

At present, the following is produced because of the mirror bug:

<img width="919" height="771" alt="Screenshot from 2025-09-30 09-21-36" src="https://github.com/user-attachments/assets/6a711e88-9239-4312-89a4-918c84e48545" />

But with the fix in this PR, the object will now look like this:

<img width="916" height="813" alt="Screenshot from 2025-09-30 09-20-12" src="https://github.com/user-attachments/assets/3b0be61b-7a3c-44a4-b363-1dce12388f99" />

