### PR TITLE
Fix license in citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 doi: 10.5281/zenodo.10513848
-license: "Apache 2.0"
+license: "Apache-2.0"
 url: https://github.com/CadQuery/cadquery
 title: "CadQuery"
 message: "If you use this software, please cite it using these metadata."


### PR DESCRIPTION
Incorrect license value caused a parsing error.

Syntax of `CITATION.cff` was checked with [cffconvert](https://pypi.org/project/cffconvert/) which identified the value for license should be "Apache-2.0" rather than "Apache 2.0".

```
$ cffconvert --validate
jsonschema.exceptions.ValidationError: 'Apache 2.0' is not one of […, 'Apache-1.0', 'Apache-1.1', 'Apache-2.0',…
⋮
```

Closes #1886