### PR TITLE
Feature | Adding Multi-Arch Docker

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,6 +8,37 @@ To install both Cadquery and CQ-Editor together with a single installer see the 
 
 CadQuery may be installed with either conda or pip.  The conda installation method is the better tested and more mature option.
 
+Install via docker
+------------------
+```rst
+Docker
+------
+
+If you prefer not to install Python or CadQuery directly on your system, you can use a
+Docker-based Jupyter environment. This provides a self-contained CadQuery installation
+with JupyterLab and the Jupyter-CadQuery viewer extension, running in your web browser.
+
+The Docker assets live in the main CadQuery repository:
+
+- ``docker/jupyter-cadquery/`` (Dockerfile and usage guide)
+
+See the README in that directory for build and run instructions:
+
+.. _docker-jupyter-cadquery:
+
+   https://github.com/CadQuery/cadquery/tree/master/docker/jupyter-cadquery
+
+The Docker workflow is intended to:
+
+* Provide a **fully self-contained environment** for trying CadQuery and running
+  the examples.
+* Offer a **consistent development environment** for contributors.
+* Support both **Linux** and **Windows** (via Docker Desktop), with a default
+  user interface based on **JupyterLab + Jupyter-CadQuery**.
+
+Models are rendered in the browser and use the host machine's graphics capabilities.
+No GPU driver needs to be configured inside the container.
+
 
 Install via conda
 ------------------

--- a/docker/jupyter-cadquery/Dockerfile
+++ b/docker/jupyter-cadquery/Dockerfile
@@ -1,0 +1,71 @@
+# CadQuery + Jupyter-CadQuery container
+# - Multi-arch via mambaorg/micromamba
+# - Default: JupyterLab + jupyter-cadquery (browser viewer)
+# - Optional: CQ-editor GUI (Linux + X11)
+
+FROM mambaorg/micromamba:2.3.0-ubuntu22.04
+
+# Ensure conda "base" env is activated in RUN steps (see micromamba-docker docs)
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+# ---- System packages (minimal) ----
+USER root
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        # Dependencies useful for CQ-editor / OpenGL on Linux
+        libgl1-mesa-glx \
+        libgl1-mesa-dri \
+        libglu1-mesa \
+        libxrender1 \
+        libxext6 \
+        libxkbcommon0 \
+        libxi6 \
+        fonts-dejavu-core \
+        # For nice shell experience if you drop into the container
+        bash-completion \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to the unprivileged micromamba user provided by the base image
+USER $MAMBA_USER
+WORKDIR /home/$MAMBA_USER
+
+# ---- Core conda environment: Python + CadQuery + Jupyter ----
+# Channels: conda-forge + cadquery, as recommended in the official docs.
+RUN micromamba install -y -n base \
+        -c conda-forge -c cadquery \
+        python=3.11 \
+        cadquery \
+        jupyterlab \
+        ipywidgets \
+    && micromamba clean --all --yes
+
+# ---- Jupyter-CadQuery viewer (pip) ----
+# Jupyter-CadQuery 4.x supports CadQuery >= 2.5 and uses ocp_vscode/three-cad-viewer. :contentReference[oaicite:3]{index=3}
+RUN pip install --no-cache-dir "jupyter-cadquery>=4.0.2"
+
+# ---- Optional CQ-editor (GUI) ----
+# Build arg lets you choose whether to pull CQ-editor into this image.
+# Build with: `--build-arg WITH_CQEDITOR=true` to enable.
+ARG WITH_CQEDITOR=false
+RUN if [ "$WITH_CQEDITOR" = "true" ]; then \
+        micromamba install -y -n base -c cadquery -c conda-forge cq-editor && \
+        micromamba clean --all --yes; \
+    fi
+
+# Workspace inside the container
+RUN mkdir -p /home/$MAMBA_USER/work
+
+# Jupyter port
+EXPOSE 8888
+
+# Default: start JupyterLab with no token, serving /home/mambauser/work
+# (Micromamba's entrypoint will auto-activate the "base" env.)
+CMD ["bash", "-lc", "jupyter lab \
+    --ip=0.0.0.0 \
+    --port=8888 \
+    --no-browser \
+    --NotebookApp.token='' \
+    --NotebookApp.password='' \
+    --notebook-dir=/home/mambauser/work"]

--- a/docker/jupyter-cadquery/README.md
+++ b/docker/jupyter-cadquery/README.md
@@ -1,0 +1,51 @@
+# CadQuery + Jupyter Docker image
+
+This directory contains a Docker image that provides:
+
+- A ready-to-use **CadQuery** environment
+- **JupyterLab** as the main user interface
+- The **Jupyter-CadQuery** viewer extension for in-browser 3D visualization
+- Optional **CQ-editor** inside the image (for advanced users who want a GUI in addition to Jupyter)
+
+The goal is to offer a reproducible, cross-platform way to:
+
+- Try CadQuery without touching your host Python installation
+- Develop and run CadQuery notebooks and scripts
+- Provide a consistent dev environment for contributors
+
+The image is designed to work with:
+
+- **Linux** (native Docker)
+- **Windows** (Docker Desktop, Linux engine)
+- **macOS / ARM devices** (via `linux/arm64` builds, where supported by Docker)
+
+> CadQuery is installed using the conda-based workflow recommended in the official documentation, with `cadquery` coming from `conda-forge` / `cadquery` channels and Jupyter-CadQuery installed via `pip`. 
+
+---
+
+## Features
+
+- **CadQuery** preinstalled with its dependencies
+- **JupyterLab** with **Jupyter-CadQuery 4.x** for browser-based 3D viewing
+- **CPU-only image** – no special GPU drivers needed in the container; rendering uses WebGL in your browser on the host
+- **Multi-arch capable** Dockerfile:
+  - `linux/amd64`
+  - `linux/arm64` (for Docker Desktop on Apple Silicon, ARM servers, etc.)
+- Optional **CQ-editor** in the image via a build argument
+
+---
+
+## Image contents
+
+At a high level the image provides:
+
+- Python 3.x
+- CadQuery (installed via `mamba` from conda-forge / cadquery channels)
+- JupyterLab
+- Jupyter-CadQuery 4.x (`pip install jupyter-cadquery`)
+- A non-root user (default: `cadquery`) with a simple home directory layout:
+
+```text
+/home/cadquery/
+  ├── work/        # Your mounted project directory
+  └── .conda/...   # Environment managed inside the image

--- a/docker/jupyter-cadquery/docker-compose.yml
+++ b/docker/jupyter-cadquery/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  cadquery:
+    build:
+      context: .
+      args:
+        WITH_CQEDITOR: "false"   # set "true" if you want CQ-editor in the image
+    image: cadquery/jupyter-cadquery:local
+    container_name: cadquery
+    restart: unless-stopped
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./work:/home/mambauser/work


### PR DESCRIPTION
## Summary

This PR adds a first-party Docker-based workflow for running CadQuery in Jupyter,
aimed at both new users and contributors:

- New `docker/jupyter-cadquery/Dockerfile` providing a CadQuery + JupyterLab
  environment with the Jupyter-CadQuery viewer extension.
- New `docker/jupyter-cadquery/README.md` with build/run instructions for Linux
  and Windows (Docker Desktop).
- Documentation update: new **Docker** subsection under *Installing CadQuery*
  that links to the Docker README and describes the intended workflow.

The default UI is **JupyterLab + Jupyter-CadQuery**; CQ-editor support remains
available via the existing installation paths.

## Motivation

Today the recommended installation paths are conda and pip, plus CQ-editor and
Jupyter on top. These work well, but some users:

- Prefer not to modify their host Python installation.
- Want a repeatable environment they can share across teams and CI.
- Would like a "one-command" way to try CadQuery with a working 3D viewer.

Upstream Jupyter-CadQuery already supports JupyterLab 4 and current CadQuery
releases. This PR packages that stack into a reproducible Docker image that
matches the installation guidance in the docs (conda-based CadQuery install,
Jupyter-CadQuery via pip). 

## Implementation details

- The Dockerfile installs CadQuery from the `conda-forge` / `cadquery` channels,
  following the "Install via conda" instructions from the documentation.
- JupyterLab and Jupyter-CadQuery 4.x are installed via `pip`, providing an
  in-browser 3D viewer.
- The image runs as an unprivileged `cadquery` user and exposes JupyterLab on
  port 8888.
- A build argument `WITH_CQEDITOR` optionally adds CQ-editor to the image for
  advanced users who want a GUI in addition to Jupyter.
- The Dockerfile is written to be multi-arch capable and can be built with
  `docker buildx` for `linux/amd64` and `linux/arm64`, assuming the base images
  and wheels are available for those platforms.

No GPU-specific configuration is required inside the container. 3D rendering
is done in the browser via WebGL, so the host OS and browser are responsible
for using NVIDIA / AMD / Apple / Intel GPUs as available.

## Usage overview

After building the image:

```bash
# Example (Linux)
docker run --rm -it \
  -p 8888:8888 \
  -v "$PWD":/home/cadquery/work \
  cadquery/jupyter-cadquery:latest
```

On Windows (Powershell / Docker Desktop)
```powershell
docker run --rm -it `
  -p 8888:8888 `
  -v "${PWD}:/home/cadquery/work" `
  cadquery/jupyter-cadquery:latest
```

Screenshots:
<img width="3452" height="1901" alt="Screenshot 2025-11-30 105701" src="https://github.com/user-attachments/assets/f6a18717-c25d-4cf0-815d-e315160d900a" />
<img width="2692" height="1386" alt="Screenshot 2025-11-30 105720" src="https://github.com/user-attachments/assets/b8a787db-7f9b-4bed-960d-67c99803bcd1" />
<img width="1918" height="955" alt="image" src="https://github.com/user-attachments/assets/4f696bcd-b3d4-4003-bdfb-4530462f3f69" />
