### PR TITLE
Replacing typish with runtype

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -12,7 +12,6 @@ from typing import (
     get_args,
 )
 from typing_extensions import Literal, Self
-from runtype import isa
 from uuid import uuid1 as uuid
 from warnings import warn
 from itertools import chain
@@ -39,7 +38,7 @@ from .occ_impl.exporters.assembly import (
 from .occ_impl.importers.assembly import importStep as _importStep, importXbf, importXml
 
 from .selectors import _expression_grammar as _selector_grammar
-from .utils import deprecate, BiDict
+from .utils import deprecate, BiDict, instance_of
 
 # type definitions
 AssemblyObjects = Union[Shape, Workplane, None]
@@ -413,7 +412,7 @@ class Assembly(object):
         if len(args) == 2:
             q1, kind = args
             id1, s1 = self._query(q1)
-        elif len(args) == 3 and isa(args[1], UnaryConstraintKind):
+        elif len(args) == 3 and instance_of(args[1], UnaryConstraintKind):
             q1, kind, param = args
             id1, s1 = self._query(q1)
         elif len(args) == 3:
@@ -432,10 +431,10 @@ class Assembly(object):
             raise ValueError(f"Incompatible arguments: {args}")
 
         # handle unary and binary constraints
-        if isa(kind, UnaryConstraintKind):
+        if instance_of(kind, UnaryConstraintKind):
             loc1, id1_top = self._subloc(id1)
             c = Constraint((id1_top,), (s1,), (loc1,), kind, param)
-        elif isa(kind, BinaryConstraintKind):
+        elif instance_of(kind, BinaryConstraintKind):
             loc1, id1_top = self._subloc(id1)
             loc2, id2_top = self._subloc(id2)
             c = Constraint((id1_top, id2_top), (s1, s2), (loc1, loc2), kind, param)
@@ -472,12 +471,12 @@ class Assembly(object):
             unary_objects = [
                 c.objects[0]
                 for c in self.constraints
-                if isa(c.kind, UnaryConstraintKind)
+                if instance_of(c.kind, UnaryConstraintKind)
             ]
             binary_objects = [
                 c.objects[0]
                 for c in self.constraints
-                if isa(c.kind, BinaryConstraintKind)
+                if instance_of(c.kind, BinaryConstraintKind)
             ]
             for b in binary_objects:
                 if b not in unary_objects:

--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -12,7 +12,7 @@ from typing import (
     get_args,
 )
 from typing_extensions import Literal, Self
-from typish import instance_of
+from runtype import isa
 from uuid import uuid1 as uuid
 from warnings import warn
 from itertools import chain
@@ -413,7 +413,7 @@ class Assembly(object):
         if len(args) == 2:
             q1, kind = args
             id1, s1 = self._query(q1)
-        elif len(args) == 3 and instance_of(args[1], UnaryConstraintKind):
+        elif len(args) == 3 and isa(args[1], UnaryConstraintKind):
             q1, kind, param = args
             id1, s1 = self._query(q1)
         elif len(args) == 3:
@@ -432,10 +432,10 @@ class Assembly(object):
             raise ValueError(f"Incompatible arguments: {args}")
 
         # handle unary and binary constraints
-        if instance_of(kind, UnaryConstraintKind):
+        if isa(kind, UnaryConstraintKind):
             loc1, id1_top = self._subloc(id1)
             c = Constraint((id1_top,), (s1,), (loc1,), kind, param)
-        elif instance_of(kind, BinaryConstraintKind):
+        elif isa(kind, BinaryConstraintKind):
             loc1, id1_top = self._subloc(id1)
             loc2, id2_top = self._subloc(id2)
             c = Constraint((id1_top, id2_top), (s1, s2), (loc1, loc2), kind, param)
@@ -472,12 +472,12 @@ class Assembly(object):
             unary_objects = [
                 c.objects[0]
                 for c in self.constraints
-                if instance_of(c.kind, UnaryConstraintKind)
+                if isa(c.kind, UnaryConstraintKind)
             ]
             binary_objects = [
                 c.objects[0]
                 for c in self.constraints
-                if instance_of(c.kind, BinaryConstraintKind)
+                if isa(c.kind, BinaryConstraintKind)
             ]
             for b in binary_objects:
                 if b not in unary_objects:

--- a/cadquery/fig.py
+++ b/cadquery/fig.py
@@ -10,7 +10,7 @@ from threading import Thread
 from itertools import chain
 from webbrowser import open_new_tab
 
-from typish import instance_of
+from runtype import isa
 
 from trame.app import get_server
 from trame.app.core import Server
@@ -231,7 +231,7 @@ class Figure:
                 self.shapes.clear()
 
             for s in shapes:
-                if instance_of(s, ShapeLike):
+                if isa(s, ShapeLike):
                     for a in self.shapes[s]:
                         self.ren.RemoveActor(a)
 

--- a/cadquery/fig.py
+++ b/cadquery/fig.py
@@ -10,8 +10,6 @@ from threading import Thread
 from itertools import chain
 from webbrowser import open_new_tab
 
-from runtype import isa
-
 from trame.app import get_server
 from trame.app.core import Server
 from trame.widgets import html, vtk as vtk_widgets, client
@@ -32,6 +30,8 @@ from vtkmodules.vtkInteractionWidgets import vtkOrientationMarkerWidget
 from vtkmodules.vtkRenderingAnnotation import vtkAxesActor
 
 from vtkmodules.vtkInteractionStyle import vtkInteractorStyleTrackballCamera
+
+from .utils import instance_of
 
 FULL_SCREEN = "position:absolute; left:0; top:0; width:100vw; height:100vh;"
 
@@ -231,7 +231,7 @@ class Figure:
                 self.shapes.clear()
 
             for s in shapes:
-                if isa(s, ShapeLike):
+                if instance_of(s, ShapeLike):
                     for a in self.shapes[s]:
                         self.ren.RemoveActor(a)
 

--- a/cadquery/occ_impl/solver.py
+++ b/cadquery/occ_impl/solver.py
@@ -13,7 +13,6 @@ from typing import (
 )
 
 from math import radians, pi
-from runtype import isa
 
 import casadi as ca
 
@@ -34,6 +33,7 @@ from OCP.Precision import Precision
 from .geom import Location, Vector, Plane
 from .shapes import Shape, Face, Edge, Wire
 from ..types import Real
+from ..utils import instance_of
 
 # type definitions
 
@@ -131,7 +131,7 @@ class ConstraintSpec(object):
         """
 
         # validate
-        if not isa(kind, ConstraintKind):
+        if not instance_of(kind, ConstraintKind):
             raise ValueError(f"Unknown constraint {kind}.")
 
         if kind in CompoundConstraints:
@@ -178,7 +178,7 @@ class ConstraintSpec(object):
                 raise ValueError(f"Unsupported entity {a} for constraint {kind}.")
 
         # check parameter
-        if not isa(param, param_type) and param is not None:
+        if not instance_of(param, param_type) and param is not None:
             raise ValueError(
                 f"Unsupported argument types {get_origin(param)}, required {param_type}."
             )

--- a/cadquery/occ_impl/solver.py
+++ b/cadquery/occ_impl/solver.py
@@ -9,10 +9,11 @@ from typing import (
     Literal,
     cast as tcast,
     Type,
+    get_origin,
 )
 
 from math import radians, pi
-from typish import instance_of, get_type
+from runtype import isa
 
 import casadi as ca
 
@@ -130,7 +131,7 @@ class ConstraintSpec(object):
         """
 
         # validate
-        if not instance_of(kind, ConstraintKind):
+        if not isa(kind, ConstraintKind):
             raise ValueError(f"Unknown constraint {kind}.")
 
         if kind in CompoundConstraints:
@@ -177,9 +178,9 @@ class ConstraintSpec(object):
                 raise ValueError(f"Unsupported entity {a} for constraint {kind}.")
 
         # check parameter
-        if not instance_of(param, param_type) and param is not None:
+        if not isa(param, param_type) and param is not None:
             raise ValueError(
-                f"Unsupported argument types {get_type(param)}, required {param_type}."
+                f"Unsupported argument types {get_origin(param)}, required {param_type}."
             )
 
         # check parameter conversion

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -13,12 +13,13 @@ from typing import (
     cast as tcast,
     Literal,
     overload,
+    get_origin,
 )
 
 from math import tan, sin, cos, pi, radians, remainder
 from itertools import product, chain
 from multimethod import multimethod
-from typish import instance_of, get_type
+from runtype import isa
 
 from .hull import find_hull
 from .selectors import StringSyntaxSelector, Selector
@@ -115,9 +116,9 @@ class Constraint(object):
                 f"Unsupported geometry types {[e.geomType() for e in args]} for constraint {kind}."
             )
 
-        if not instance_of(param, param_type):
+        if not isa(param, param_type):
             raise ValueError(
-                f"Unsupported argument types {get_type(param)}, required {param_type}."
+                f"Unsupported argument types {get_origin(param)}, required {param_type}."
             )
 
         # if all is fine store everything and possibly convert the params

--- a/cadquery/sketch.py
+++ b/cadquery/sketch.py
@@ -19,12 +19,11 @@ from typing import (
 from math import tan, sin, cos, pi, radians, remainder
 from itertools import product, chain
 from multimethod import multimethod
-from runtype import isa
 
 from .hull import find_hull
 from .selectors import StringSyntaxSelector, Selector
 from .types import Real
-from .utils import get_arity
+from .utils import get_arity, instance_of
 
 from .occ_impl.shapes import (
     Shape,
@@ -116,7 +115,7 @@ class Constraint(object):
                 f"Unsupported geometry types {[e.geomType() for e in args]} for constraint {kind}."
             )
 
-        if not isa(param, param_type):
+        if not instance_of(param, param_type):
             raise ValueError(
                 f"Unsupported argument types {get_origin(param)}, required {param_type}."
             )

--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from inspect import signature, isbuiltin
 from typing import TypeVar, Callable, cast
+from runtype import isa
 from warnings import warn
 from collections import UserDict
 
@@ -116,3 +117,6 @@ class BiDict(UserDict[K, V]):
     def inv(self) -> dict[V, list[K]]:
 
         return self._inv
+
+def instance_of(obj: object, *args: object):
+    return isa(obj, args)

--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from inspect import signature, isbuiltin
-from typing import TypeVar, Callable, cast
+from typing import TypeVar, Callable, cast, Any
 from runtype import isa
 from warnings import warn
 from collections import UserDict
@@ -119,5 +119,9 @@ class BiDict(UserDict[K, V]):
         return self._inv
 
 
-def instance_of(obj: object, *args: object):
-    return isa(obj, args)
+def instance_of(obj: object, *args: object) -> bool:
+    """
+    Replacement for the instance_of method of typish, which
+    now uses the isa method of the runtype package.
+    """
+    return isa(obj, cast(tuple[type[Any], ...], args))

--- a/cadquery/utils.py
+++ b/cadquery/utils.py
@@ -118,5 +118,6 @@ class BiDict(UserDict[K, V]):
 
         return self._inv
 
+
 def instance_of(obj: object, *args: object):
     return isa(obj, args)

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -14,7 +14,7 @@ from .occ_impl.assembly import _loc2vtk, toVTKAssy
 
 from typing import Union, Any, List, Tuple, Iterable, cast, Optional
 
-from typish import instance_of
+from runtype import isa
 
 from OCP.TopoDS import TopoDS_Shape
 from OCP.Geom import Geom_BSplineSurface
@@ -101,7 +101,7 @@ def _split_showables(
     rv_a: List[vtkProp3D] = []
 
     for el in objs:
-        if instance_of(el, ShapeLike):
+        if isa(el, ShapeLike):
             rv_s.append(el)
         elif isinstance(el, Vector):
             rv_v.append(el)

--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -14,8 +14,6 @@ from .occ_impl.assembly import _loc2vtk, toVTKAssy
 
 from typing import Union, Any, List, Tuple, Iterable, cast, Optional
 
-from runtype import isa
-
 from OCP.TopoDS import TopoDS_Shape
 from OCP.Geom import Geom_BSplineSurface
 
@@ -39,6 +37,7 @@ from vtkmodules.vtkCommonDataModel import vtkCellArray, vtkPolyData
 from vtkmodules.vtkCommonColor import vtkNamedColors
 from vtkmodules.vtkIOImage import vtkPNGWriter
 
+from .utils import instance_of
 
 DEFAULT_COLOR = (1, 0.8, 0)
 DEFAULT_EDGE_COLOR = (0, 0, 0)
@@ -101,7 +100,7 @@ def _split_showables(
     rv_a: List[vtkProp3D] = []
 
     for el in objs:
-        if isa(el, ShapeLike):
+        if instance_of(el, ShapeLike):
             rv_s.append(el)
         elif isinstance(el, Vector):
             rv_v.append(el)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - nlopt
     - multimethod >=1.11,<2.0
     - casadi
-    - typish
+    - runtype
     - trame
     - trame-vtk
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - nlopt
   - path
   - casadi
-  - typish
+  - runtype
   - multimethod >=1.11,<2.0
   - typed-ast
   - regex

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,7 +31,7 @@ ignore_missing_imports = True
 [mypy-docutils.*]
 ignore_missing_imports = True
 
-[mypy-typish.*]
+[mypy-runtype.*]
 ignore_missing_imports = True
 
 [mypy-casadi.*]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if not is_rtd and not is_appveyor and not is_azure and not is_conda:
         "ezdxf>=1.3.0",
         "multimethod>=1.11,<2.0",
         "nlopt>=2.9.0,<3.0",
-        "typish",
+        "runtype",
         "casadi",
         "path",
         "trame",

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1811,6 +1811,18 @@ def test_constrain(simple_assy, nested_assy):
         .IsEqual(gp_XYZ(2, -4, 0.75), 1e-6)
     )
 
+    # Make sure that calling with too many args causes an error
+    with pytest.raises(ValueError):
+        simple_assy.constrain(
+            subassy1.name,
+            b2.faces(">Z").val(),
+            subassy2.name,
+            b3.faces("<Z").val(),
+            "Point",
+            "Point",
+            "Point"
+        )
+
 
 def test_constrain_with_tags(nested_assy):
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1820,7 +1820,7 @@ def test_constrain(simple_assy, nested_assy):
             b3.faces("<Z").val(),
             "Point",
             "Point",
-            "Point"
+            "Point",
         )
 
 

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -18,7 +18,7 @@ from vtkmodules.vtkIOImage import vtkPNGWriter
 from pytest import fixture, raises
 from path import Path
 
-from typish import instance_of
+from runtype import isa
 from typing import List
 
 
@@ -182,39 +182,39 @@ def test_style(wp, assy):
 
     # Shape
     act = style(t, color="red", alpha=0.5, tubes=True, spheres=True)
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # Assy
     act = style(assy, color="red", alpha=0.5, tubes=True, spheres=True)
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # Workplane
     act = style(wp, color="red", alpha=0.5, tubes=True, spheres=True)
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # Shape
     act = style(e)
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # Sketch
     act = style(Sketch().circle(1))
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # list[Vector]
     act = style(pts)
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # list[Location]
     act = style(locs)
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # vtkAssembly
     act = style(style(t))
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
     # vtkActor
     act = style(ctrlPts(e.toNURBS()))
-    assert instance_of(act, List[vtkProp3D])
+    assert isa(act, List[vtkProp3D])
 
 
 def test_camera_position(wp, patch_vtk):

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -22,6 +22,7 @@ from path import Path
 
 from typing import List
 
+
 @fixture(scope="module")
 def tmpdir(tmp_path_factory):
     return Path(tmp_path_factory.mktemp("screenshots"))

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -4,6 +4,8 @@ from cadquery.vis import show, show_object, vtkAxesActor, ctrlPts, style
 
 import cadquery.vis as vis
 
+from cadquery.utils import instance_of
+
 from vtkmodules.vtkRenderingCore import (
     vtkRenderWindow,
     vtkRenderWindowInteractor,
@@ -18,9 +20,7 @@ from vtkmodules.vtkIOImage import vtkPNGWriter
 from pytest import fixture, raises
 from path import Path
 
-from runtype import isa
 from typing import List
-
 
 @fixture(scope="module")
 def tmpdir(tmp_path_factory):
@@ -182,39 +182,39 @@ def test_style(wp, assy):
 
     # Shape
     act = style(t, color="red", alpha=0.5, tubes=True, spheres=True)
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # Assy
     act = style(assy, color="red", alpha=0.5, tubes=True, spheres=True)
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # Workplane
     act = style(wp, color="red", alpha=0.5, tubes=True, spheres=True)
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # Shape
     act = style(e)
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # Sketch
     act = style(Sketch().circle(1))
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # list[Vector]
     act = style(pts)
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # list[Location]
     act = style(locs)
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # vtkAssembly
     act = style(style(t))
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
     # vtkActor
     act = style(ctrlPts(e.toNURBS()))
-    assert isa(act, List[vtkProp3D])
+    assert instance_of(act, List[vtkProp3D])
 
 
 def test_camera_position(wp, patch_vtk):


### PR DESCRIPTION
@adam-urbanczyk As discussed in #1966 this PR attempts to replace typish with runtype. Let me know if you think there is a better replacement for `get_type` than `get_origin`.