### PR TITLE
Replace deprecated pyparsing names and arguments

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -58,21 +58,21 @@ def _define_grammar():
         Optional,
         alphas,
         alphanums,
-        delimitedList,
+        DelimitedList,
     )
 
     Separator = Literal("@").suppress()
     TagSeparator = Literal("?").suppress()
 
-    Name = delimitedList(
+    Name = DelimitedList(
         Word(alphas, alphanums + "_"), PATH_DELIM, combine=True
-    ).setResultsName("name")
-    Tag = Word(alphas, alphanums + "_").setResultsName("tag")
-    Selector = _selector_grammar.setResultsName("selector")
+    ).set_results_name("name")
+    Tag = Word(alphas, alphanums + "_").set_results_name("tag")
+    Selector = _selector_grammar.set_results_name("selector")
 
     SelectorType = (
         Literal("solids") | Literal("faces") | Literal("edges") | Literal("vertices")
-    ).setResultsName("selector_kind")
+    ).set_results_name("selector_kind")
 
     return (
         Name
@@ -331,7 +331,7 @@ class Assembly(object):
         tmp: Workplane
         res: Workplane
 
-        query = _grammar.parseString(q, True)
+        query = _grammar.parse_string(q, True)
         name: str = query.name
 
         obj = self.objects[name].obj

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -15,9 +15,9 @@ from pyparsing import (
     nums,
     Optional,
     Combine,
-    oneOf,
+    one_of,
     Group,
-    infixNotation,
+    infix_notation,
     opAssoc,
 )
 from functools import reduce
@@ -606,23 +606,23 @@ def _makeGrammar():
     )
 
     # direction definition
-    simple_dir = oneOf(["X", "Y", "Z", "XY", "XZ", "YZ"])
+    simple_dir = one_of(["X", "Y", "Z", "XY", "XZ", "YZ"])
     direction = simple_dir("simple_dir") | vector("vector_dir")
 
     # CQ type definition
-    cqtype = oneOf(
+    cqtype = one_of(
         set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()), caseless=True,
     )
-    cqtype = cqtype.setParseAction(pyparsing_common.upcaseTokens)
+    cqtype = cqtype.set_parse_action(pyparsing_common.upcase_tokens)
 
     # type operator
     type_op = Literal("%")
 
     # direction operator
-    direction_op = oneOf([">", "<"])
+    direction_op = one_of([">", "<"])
 
     # center Nth operator
-    center_nth_op = oneOf([">>", "<<"])
+    center_nth_op = one_of([">>", "<<"])
 
     # index definition
     ix_number = Group(Optional("-") + Word(nums))
@@ -632,10 +632,10 @@ def _makeGrammar():
     index = lsqbracket + ix_number("index") + rsqbracket
 
     # other operators
-    other_op = oneOf(["|", "#", "+", "-"])
+    other_op = one_of(["|", "#", "+", "-"])
 
     # named view
-    named_view = oneOf(["front", "back", "left", "right", "top", "bottom"])
+    named_view = one_of(["front", "back", "left", "right", "top", "bottom"])
 
     return (
         direction("only_dir")
@@ -760,14 +760,14 @@ def _makeExpressionGrammar(atom):
     # define operators
     and_op = Literal("and")
     or_op = Literal("or")
-    delta_op = oneOf(["exc", "except"])
+    delta_op = one_of(["exc", "except"])
     not_op = Literal("not")
 
     def atom_callback(res):
         return _SimpleStringSyntaxSelector(res)
 
     # construct a simple selector from every matched
-    atom.setParseAction(atom_callback)
+    atom.set_parse_action(atom_callback)
 
     # define callback functions for all operations
     def and_callback(res):
@@ -790,7 +790,7 @@ def _makeExpressionGrammar(atom):
         return InverseSelector(right)
 
     # construct the final grammar and set all the callbacks
-    expr = infixNotation(
+    expr = infix_notation(
         atom,
         [
             (and_op, 2, opAssoc.LEFT, and_callback),
@@ -862,7 +862,7 @@ class StringSyntaxSelector(Selector):
         Feed the input string through the parser and construct an relevant complex selector object
         """
         self.selectorString = selectorString
-        parse_result = _expression_grammar.parseString(selectorString, parseAll=True)
+        parse_result = _expression_grammar.parse_string(selectorString, parse_all=True)
         self.mySelector = parse_result.asList()[0]
 
     def filter(self, objectList: Sequence[Shape]):

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python >=3.10
     - ocp=7.8.1
     - vtk=*=qt*
-    - pyparsing >=2.1.9
+    - pyparsing >=3.0.0
     - ezdxf>=1.3.0
     - ipython
     - typing_extensions

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - ipython
   - ocp=7.8.1
   - vtk=*=qt*
-  - pyparsing>=2.1.9
+  - pyparsing>=3.0.0
   - sphinx=9.1.0
 #  - sphinx_rtd_theme=3.1.0
   - mypy

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ if not is_rtd and not is_appveyor and not is_azure and not is_conda:
         "path",
         "trame",
         "trame-vtk",
+        "pyparsing>=3.0.0",
     ]
 
 

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1135,7 +1135,7 @@ class TestCQSelectors(BaseTest):
         ]
 
         for e in expressions:
-            gram.parseString(e, parseAll=True)
+            gram.parse_string(e, parse_all=True)
 
     def testShape(self):
         """


### PR DESCRIPTION
Require pyparsing>=3.0.0

See https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html

FYI, ezdxf made this change here:
https://github.com/mozman/ezdxf/commit/526a95113ae7ff2b5f4730596b2c7b2cd877e404