### PR TITLE
Fix the function call errors for gp_Ax2() and size()

### DIFF
--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -34,12 +34,12 @@ is actually equivalent to::
 As long as you return a valid OCP Shape, you can use any OCP methods you like. You can even mix and match the
 two. For example, consider this script, which creates a OCP box, but then uses CadQuery to select its faces::
 
-    box = cq.Shape.cast(
+    box1 = cq.Shape.cast(
         BRepPrimAPI_MakeBox(
             gp_Ax2(gp_Pnt(-0.5, -1.0, -1.5), gp_Dir(0, 0, 1)), 1.0, 2.0, 3.0
         ).Shape()
     )
-    return box.faces(">X").Area()      # return 6.0
+    return box1.faces(">X").Area()      # return 6.0
 
 
 Extending CadQuery: Plugins

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -22,9 +22,12 @@ any valid OCP script will execute just fine. For example, this simple CadQuery s
 
 is actually equivalent to::
 
+    from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox
+    from OCP.gp import gp_Ax2, gp_Dir, gp_Pnt
+
     return cq.Shape.cast(
         BRepPrimAPI_MakeBox(
-            gp_Ax2(Vector(-0.1, -1.0, -1.5), Vector(0, 0, 1)), 1.0, 2.0, 3.0
+            gp_Ax2(gp_Pnt(-0.5, -1.0, -1.5), gp_Dir(0, 0, 1)), 1.0, 2.0, 3.0
         ).Shape()
     )
 
@@ -33,10 +36,10 @@ two. For example, consider this script, which creates a OCP box, but then uses C
 
     box = cq.Shape.cast(
         BRepPrimAPI_MakeBox(
-            gp_Ax2(Vector(-0.1, -1.0, -1.5), Vector(0, 0, 1)), 1.0, 2.0, 3.0
+            gp_Ax2(gp_Pnt(-0.5, -1.0, -1.5), gp_Dir(0, 0, 1)), 1.0, 2.0, 3.0
         ).Shape()
     )
-    cq = Workplane(box).faces(">Z").size()  # returns 6
+    return box.faces(">X").Area()      # return 6.0
 
 
 Extending CadQuery: Plugins


### PR DESCRIPTION
`Workplane(box).faces(">Z").size() ` return the number of objects currently on the stack, not the object size.
So, I replaced it with `box.faces(">X").Area()`.

Also, I fixed the typo of `gp_Ax2(Vector(-0.1, -1.0, -1.5)` .