### PR TITLE
Enhance color initialization with hex support

### DIFF
--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -226,8 +226,9 @@ class Color(object):
             self.wrapped = Quantity_ColorRGBA()
         elif len(args) == 1:
             self.wrapped = Quantity_ColorRGBA()
-            exists = (Quantity_ColorRGBA.ColorFromName_s(args[0], self.wrapped) or
-                      Quantity_ColorRGBA.ColorFromHex_s(args[0], self.wrapped))
+            exists = Quantity_ColorRGBA.ColorFromName_s(
+                args[0], self.wrapped
+            ) or Quantity_ColorRGBA.ColorFromHex_s(args[0], self.wrapped)
             if not exists:
                 raise ValueError(f"Unknown color name: {args[0]}")
         elif len(args) == 3:

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -226,7 +226,8 @@ class Color(object):
             self.wrapped = Quantity_ColorRGBA()
         elif len(args) == 1:
             self.wrapped = Quantity_ColorRGBA()
-            exists = Quantity_ColorRGBA.ColorFromName_s(args[0], self.wrapped)
+            exists = (Quantity_ColorRGBA.ColorFromName_s(args[0], self.wrapped) or
+                      Quantity_ColorRGBA.ColorFromHex_s(args[0], self.wrapped))
             if not exists:
                 raise ValueError(f"Unknown color name: {args[0]}")
         elif len(args) == 3:

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -644,6 +644,33 @@ def test_color():
     assert c4.wrapped.GetRGB().Green() == pytest.approx(0.2)
     assert c4.wrapped.Alpha() == 0.5
 
+    # "#FF0" for short sRGB color, "#FF0F" for short sRGBA color, "#FFFF00" for RGB color, or "#FFFF00FF" for RGBA color
+    c5 = cq.Color("#FF0")
+    assert c5.wrapped.GetRGB().Red() == 1
+    assert c5.wrapped.GetRGB().Green() == 1
+    assert c5.wrapped.GetRGB().Blue() == 0
+    with pytest.raises(AttributeError):
+        c5.wrapped.GetRGB().Alpha()
+
+    c6 = cq.Color("#FF0F")
+    assert c6.wrapped.GetRGB().Red() == 1
+    assert c6.wrapped.GetRGB().Green() == 1
+    assert c6.wrapped.GetRGB().Blue() == 0
+    assert c6.wrapped.Alpha() == 1.0
+
+    c7 = cq.Color("#FFFF00")
+    assert c7.wrapped.GetRGB().Red() == 1
+    assert c7.wrapped.GetRGB().Green() == 1
+    assert c7.wrapped.GetRGB().Blue() == 0
+    with pytest.raises(AttributeError):
+        c7.wrapped.GetRGB().Alpha()
+
+    c8 = cq.Color("#FFFF00FF")
+    assert c8.wrapped.GetRGB().Red() == 1
+    assert c8.wrapped.GetRGB().Green() == 1
+    assert c8.wrapped.GetRGB().Blue() == 0
+    assert c8.wrapped.Alpha() == 1.0
+
     with pytest.raises(ValueError):
         cq.Color("?????")
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -644,7 +644,7 @@ def test_color():
     assert c4.wrapped.GetRGB().Green() == pytest.approx(0.2)
     assert c4.wrapped.Alpha() == 0.5
 
-    # "#FF0" for short sRGB color, "#FF0F" for short sRGBA color, "#FFFF00" for RGB color, or "#FFFF00FF" for RGBA color
+    # test for hex string for short sRGB color
     c5 = cq.Color("#FF0")
     assert c5.wrapped.GetRGB().Red() == 1
     assert c5.wrapped.GetRGB().Green() == 1
@@ -652,12 +652,14 @@ def test_color():
     with pytest.raises(AttributeError):
         c5.wrapped.GetRGB().Alpha()
 
+    # test for hex string for short sRGBA color
     c6 = cq.Color("#FF0F")
     assert c6.wrapped.GetRGB().Red() == 1
     assert c6.wrapped.GetRGB().Green() == 1
     assert c6.wrapped.GetRGB().Blue() == 0
     assert c6.wrapped.Alpha() == 1.0
 
+    # test for hex string for RGB color
     c7 = cq.Color("#FFFF00")
     assert c7.wrapped.GetRGB().Red() == 1
     assert c7.wrapped.GetRGB().Green() == 1
@@ -665,6 +667,7 @@ def test_color():
     with pytest.raises(AttributeError):
         c7.wrapped.GetRGB().Alpha()
 
+    # test for hex string for RGBA color
     c8 = cq.Color("#FFFF00FF")
     assert c8.wrapped.GetRGB().Red() == 1
     assert c8.wrapped.GetRGB().Green() == 1


### PR DESCRIPTION
Adds ColorFromHex_s support to initializing a `cq.Color` with a string value

From OCP:
```
        ColorFromHex_s(theHexColorString: str, theColor: OCP.OCP.Quantity.Quantity_ColorRGBA, theAlphaComponentIsOff: bool = False) -> bool
        
        Parses the string as a hex color (like "#FF0" for short sRGB color, "#FF0F" for short sRGBA color, "#FFFF00" for RGB color, or "#FFFF00FF" for RGBA color)
```
