### PR TITLE
(Part 1/3) DXF export does not support 3D/tilted circles

### DIFF
--- a/cadquery/occ_impl/exporters/dxf.py
+++ b/cadquery/occ_impl/exporters/dxf.py
@@ -1,5 +1,6 @@
 """DXF export utilities."""
 
+import warnings
 from typing import (
     Any,
     Dict,
@@ -243,6 +244,13 @@ class DxfDocument:
 
         direction_y = circ.YAxis().Direction()
         direction_z = circ.Axis().Direction()
+
+        # DXF circle does not support tilted 3D circles.
+        dz = gp_Dir(0, 0, 1)
+        if abs(RAD2DEG * direction_z.Angle(dz)) % 180 > 1e-6:
+            warnings.warn(
+                "Circle not coplanar. This will fail in the future.",
+            )
 
         dy = gp_Dir(0, 1, 0)
 


### PR DESCRIPTION
Measure the angle between the 3D circle's normal axis `dz` and the plane representing the 2D DXF drawing. If `angle % 180 != 0`, print the user warning to the console.

> OK, so DXF export only exports 2D sections and (at least currently) it does not do projections like export SVG (the use case for DXF export so far was generating file for laser cutting). It is mentioned in passing in the docstring. I'll add a note to the docs to make it clearer.
>
> From @adam-urbanczyk at https://github.com/CadQuery/cadquery/issues/1767#issuecomment-2750280582

Resolve: #1767 .