### PR TITLE
Use Temporary Directories Everywhere in Tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 import pytest
-import os
-from contextlib import contextmanager
 
 
 def pytest_addoption(parser):
@@ -22,17 +20,3 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "gui" in item.keywords:
             item.add_marker(skip_gui)
-
-
-@pytest.fixture
-def cwd():
-    @contextmanager
-    def _cwd(path):
-        oldpwd = os.getcwd()
-        os.chdir(path)
-        try:
-            yield
-        finally:
-            os.chdir(oldpwd)
-
-    return _cwd

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1293,28 +1293,37 @@ def test_step_export_loc(assy_fixture, expected, request, tmpdir):
     assert pytest.approx(c.toTuple()) == expected["center"]
 
 
-def test_native_export(simple_assy):
+def test_native_export(simple_assy, tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    xml_path = os.path.join(tmpdir, "assy.xml")
 
-    exportCAF(simple_assy, "assy.xml")
-
-    # only sanity check for now
-    assert os.path.exists("assy.xml")
-
-
-def test_vtkjs_export(nested_assy):
-
-    exportVTKJS(nested_assy, "assy")
+    exportCAF(simple_assy, xml_path)
 
     # only sanity check for now
-    assert os.path.exists("assy.zip")
+    assert os.path.exists(xml_path)
 
 
-def test_vrml_export(simple_assy):
+def test_vtkjs_export(nested_assy, tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    zip_path = os.path.join(tmpdir, "assy.zip")
 
-    exportVRML(simple_assy, "assy.wrl")
+    exportVTKJS(nested_assy, zip_path.replace(".zip", ""))
 
     # only sanity check for now
-    assert os.path.exists("assy.wrl")
+    assert os.path.exists(zip_path)
+
+
+def test_vrml_export(simple_assy, tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    wrl_path = os.path.join(tmpdir, "assy.wrl")
+
+    exportVRML(simple_assy, wrl_path)
+
+    # only sanity check for now
+    assert os.path.exists(wrl_path)
 
 
 def test_toJSON(simple_assy, nested_assy, empty_top_assy):
@@ -1339,11 +1348,16 @@ def test_toJSON(simple_assy, nested_assy, empty_top_assy):
         ("stl", ("STL",)),
     ],
 )
-def test_save(extension, args, nested_assy, nested_assy_sphere):
+def test_save(extension, args, nested_assy, nested_assy_sphere, tmp_path_factory):
 
     filename = "nested." + extension
-    nested_assy.save(filename, *args)
-    assert os.path.exists(filename)
+
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    nested_path = os.path.join(tmpdir, filename)
+
+    nested_assy.save(nested_path, *args)
+    assert os.path.exists(nested_path)
 
 
 @pytest.mark.parametrize(
@@ -1363,13 +1377,17 @@ def test_save(extension, args, nested_assy, nested_assy_sphere):
         ("stl", ("STL",), {}),
     ],
 )
-def test_export(extension, args, kwargs, tmpdir, nested_assy, cwd):
+def test_export(extension, args, kwargs, tmpdir, nested_assy, cwd, tmp_path_factory):
 
     filename = "nested." + extension
 
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    nested_path = os.path.join(tmpdir, filename)
+
     with cwd(tmpdir):
-        nested_assy.export(filename, *args, **kwargs)
-        assert os.path.exists(filename)
+        nested_assy.export(nested_path, *args, **kwargs)
+        assert os.path.exists(nested_path)
 
 
 def test_export_vtkjs(tmpdir, nested_assy, cwd):
@@ -1391,62 +1409,84 @@ def test_export_errors(nested_assy):
         nested_assy.export("nested.step", mode="1234")
 
 
-def test_save_stl_formats(nested_assy_sphere):
+def test_save_stl_formats(nested_assy_sphere, tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    stl_path = os.path.join(tmpdir, "nested.stl")
 
     # Binary export
-    nested_assy_sphere.save("nested.stl", "STL", ascii=False)
-    assert os.path.exists("nested.stl")
+    nested_assy_sphere.save(stl_path, "STL", ascii=False)
+    assert os.path.exists(stl_path)
 
     # Trying to read a binary file as UTF-8/ASCII should throw an error
     with pytest.raises(UnicodeDecodeError):
-        with open("nested.stl", "r") as file:
+        with open(stl_path, "r") as file:
             file.read()
 
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    ascii_stl_path = os.path.join(tmpdir, "nested_ascii.stl")
+
     # ASCII export
-    nested_assy_sphere.save("nested_ascii.stl", ascii=True)
-    assert os.path.exists("nested_ascii.stl")
-    assert os.path.getsize("nested_ascii.stl") > 3960 * 1024
+    nested_assy_sphere.save(ascii_stl_path, ascii=True)
+    assert os.path.exists(ascii_stl_path)
+    assert os.path.getsize(ascii_stl_path) > 3960 * 1024
 
 
-def test_save_gltf(nested_assy_sphere):
+def test_save_gltf(nested_assy_sphere, tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    glb_path = os.path.join(tmpdir, "nested.glb")
 
     # Binary export
-    nested_assy_sphere.save("nested.glb")
-    assert os.path.exists("nested.glb")
+    nested_assy_sphere.save(glb_path)
+    assert os.path.exists(glb_path)
 
     # Trying to read a binary file as UTF-8/ASCII should throw an error
     with pytest.raises(UnicodeDecodeError):
-        with open("nested.glb", "r") as file:
+        with open(glb_path, "r") as file:
             file.read()
 
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    ascii_gltf_path = os.path.join(tmpdir, "nested_ascii.gltf")
+
     # ASCII export
-    nested_assy_sphere.save("nested_ascii.gltf")
-    assert os.path.exists("nested_ascii.gltf")
-    assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
+    nested_assy_sphere.save(ascii_gltf_path)
+    assert os.path.exists(ascii_gltf_path)
+    assert os.path.getsize(ascii_gltf_path) > 5 * 1024
 
 
-def test_exportGLTF(nested_assy_sphere):
+def test_exportGLTF(nested_assy_sphere, tmp_path_factory):
     """Tests the exportGLTF function directly for binary vs ascii export."""
 
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    glb_path = os.path.join(tmpdir, "nested_export_gltf.glb")
+
     # Test binary export inferred from file extension
-    cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested_export_gltf.glb")
+    cq.exporters.assembly.exportGLTF(nested_assy_sphere, glb_path)
     with pytest.raises(UnicodeDecodeError):
-        with open("nested_export_gltf.glb", "r") as file:
+        with open(glb_path, "r") as file:
             file.read()
+
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    glb_path_2 = os.path.join(tmpdir, "nested_export_gltf_2.glb")
 
     # Test explicit binary export
-    cq.exporters.assembly.exportGLTF(
-        nested_assy_sphere, "nested_export_gltf_2.glb", binary=True
-    )
+    cq.exporters.assembly.exportGLTF(nested_assy_sphere, glb_path_2, binary=True)
     with pytest.raises(UnicodeDecodeError):
-        with open("nested_export_gltf_2.glb", "r") as file:
+        with open(glb_path_2, "r") as file:
             file.read()
 
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    glb_path_3 = os.path.join(tmpdir, "nested_export_gltf_3.gltf")
+
     # Test explicit ascii export
-    cq.exporters.assembly.exportGLTF(
-        nested_assy_sphere, "nested_export_gltf_3.gltf", binary=False
-    )
-    with open("nested_export_gltf_3.gltf", "r") as file:
+    cq.exporters.assembly.exportGLTF(nested_assy_sphere, glb_path_3, binary=False)
+    with open(glb_path_3, "r") as file:
         lines = file.readlines()
         assert lines[0].startswith('{"accessors"')
 
@@ -1465,10 +1505,13 @@ def test_save_gltf_boxes2(boxes2_assy, tmpdir, capfd):
     assert output.err == ""
 
 
-def test_save_vtkjs(nested_assy):
+def test_save_vtkjs(nested_assy, tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    nested_path = os.path.join(tmpdir, "nested.zip")
 
-    nested_assy.save("nested", "VTKJS")
-    assert os.path.exists("nested.zip")
+    nested_assy.save(nested_path.replace(".zip", ""), "VTKJS")
+    assert os.path.exists(nested_path)
 
 
 def test_save_raises(nested_assy):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1293,37 +1293,31 @@ def test_step_export_loc(assy_fixture, expected, request, tmpdir):
     assert pytest.approx(c.toTuple()) == expected["center"]
 
 
-def test_native_export(simple_assy, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    xml_path = os.path.join(tmpdir, "assy.xml")
+def test_native_export(simple_assy, tmpdir):
 
-    exportCAF(simple_assy, xml_path)
+    with chdir(tmpdir):
+        exportCAF(simple_assy, "assy.xml")
 
-    # only sanity check for now
-    assert os.path.exists(xml_path)
+        # only sanity check for now
+        assert os.path.exists("assy.xml")
 
 
-def test_vtkjs_export(nested_assy, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    zip_path = os.path.join(tmpdir, "assy.zip")
+def test_vtkjs_export(nested_assy, tmpdir):
 
-    exportVTKJS(nested_assy, zip_path.replace(".zip", ""))
+    with chdir(tmpdir):
+        exportVTKJS(nested_assy, "assy")
 
-    # only sanity check for now
-    assert os.path.exists(zip_path)
+        # only sanity check for now
+        assert os.path.exists("assy.zip")
 
 
-def test_vrml_export(simple_assy, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    wrl_path = os.path.join(tmpdir, "assy.wrl")
+def test_vrml_export(simple_assy, tmpdir):
 
-    exportVRML(simple_assy, wrl_path)
+    with chdir(tmpdir):
+        exportVRML(simple_assy, "assy.wrl")
 
-    # only sanity check for now
-    assert os.path.exists(wrl_path)
+        # only sanity check for now
+        assert os.path.exists("assy.wrl")
 
 
 def test_toJSON(simple_assy, nested_assy, empty_top_assy):
@@ -1348,16 +1342,12 @@ def test_toJSON(simple_assy, nested_assy, empty_top_assy):
         ("stl", ("STL",)),
     ],
 )
-def test_save(extension, args, nested_assy, nested_assy_sphere, tmp_path_factory):
+def test_save(extension, args, nested_assy, nested_assy_sphere, tmpdir):
 
     filename = "nested." + extension
-
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    nested_path = os.path.join(tmpdir, filename)
-
-    nested_assy.save(nested_path, *args)
-    assert os.path.exists(nested_path)
+    with chdir(tmpdir):
+        nested_assy.save(filename, *args)
+        assert os.path.exists(filename)
 
 
 @pytest.mark.parametrize(
@@ -1377,22 +1367,18 @@ def test_save(extension, args, nested_assy, nested_assy_sphere, tmp_path_factory
         ("stl", ("STL",), {}),
     ],
 )
-def test_export(extension, args, kwargs, tmpdir, nested_assy, cwd, tmp_path_factory):
+def test_export(extension, args, kwargs, tmpdir, nested_assy):
 
     filename = "nested." + extension
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    nested_path = os.path.join(tmpdir, filename)
-
-    with cwd(tmpdir):
-        nested_assy.export(nested_path, *args, **kwargs)
-        assert os.path.exists(nested_path)
+    with chdir(tmpdir):
+        nested_assy.export(filename, *args, **kwargs)
+        assert os.path.exists(filename)
 
 
-def test_export_vtkjs(tmpdir, nested_assy, cwd):
+def test_export_vtkjs(tmpdir, nested_assy):
 
-    with cwd(tmpdir):
+    with chdir(tmpdir):
         nested_assy.export("nested.vtkjs")
         assert os.path.exists("nested.vtkjs.zip")
 
@@ -1409,86 +1395,67 @@ def test_export_errors(nested_assy):
         nested_assy.export("nested.step", mode="1234")
 
 
-def test_save_stl_formats(nested_assy_sphere, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    stl_path = os.path.join(tmpdir, "nested.stl")
+def test_save_stl_formats(nested_assy_sphere, tmpdir):
 
-    # Binary export
-    nested_assy_sphere.save(stl_path, "STL", ascii=False)
-    assert os.path.exists(stl_path)
+    with chdir(tmpdir):
+        # Binary export
+        nested_assy_sphere.save("nested.stl", "STL", ascii=False)
+        assert os.path.exists("nested.stl")
 
-    # Trying to read a binary file as UTF-8/ASCII should throw an error
-    with pytest.raises(UnicodeDecodeError):
-        with open(stl_path, "r") as file:
-            file.read()
+        # Trying to read a binary file as UTF-8/ASCII should throw an error
+        with pytest.raises(UnicodeDecodeError):
+            with open("nested.stl", "r") as file:
+                file.read()
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    ascii_stl_path = os.path.join(tmpdir, "nested_ascii.stl")
-
-    # ASCII export
-    nested_assy_sphere.save(ascii_stl_path, ascii=True)
-    assert os.path.exists(ascii_stl_path)
-    assert os.path.getsize(ascii_stl_path) > 3960 * 1024
+        # ASCII export
+        nested_assy_sphere.save("nested_ascii.stl", ascii=True)
+        assert os.path.exists("nested_ascii.stl")
+        assert os.path.getsize("nested_ascii.stl") > 3960 * 1024
 
 
-def test_save_gltf(nested_assy_sphere, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    glb_path = os.path.join(tmpdir, "nested.glb")
+def test_save_gltf(nested_assy_sphere, tmpdir):
 
-    # Binary export
-    nested_assy_sphere.save(glb_path)
-    assert os.path.exists(glb_path)
+    with chdir(tmpdir):
+        # Binary export
+        nested_assy_sphere.save("nested.glb")
+        assert os.path.exists("nested.glb")
 
-    # Trying to read a binary file as UTF-8/ASCII should throw an error
-    with pytest.raises(UnicodeDecodeError):
-        with open(glb_path, "r") as file:
-            file.read()
+        # Trying to read a binary file as UTF-8/ASCII should throw an error
+        with pytest.raises(UnicodeDecodeError):
+            with open("nested.glb", "r") as file:
+                file.read()
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    ascii_gltf_path = os.path.join(tmpdir, "nested_ascii.gltf")
-
-    # ASCII export
-    nested_assy_sphere.save(ascii_gltf_path)
-    assert os.path.exists(ascii_gltf_path)
-    assert os.path.getsize(ascii_gltf_path) > 5 * 1024
+        # ASCII export
+        nested_assy_sphere.save("nested_ascii.gltf")
+        assert os.path.exists("nested_ascii.gltf")
+        assert os.path.getsize("nested_ascii.gltf") > 5 * 1024
 
 
-def test_exportGLTF(nested_assy_sphere, tmp_path_factory):
+def test_exportGLTF(nested_assy_sphere, tmpdir):
     """Tests the exportGLTF function directly for binary vs ascii export."""
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    glb_path = os.path.join(tmpdir, "nested_export_gltf.glb")
+    with chdir(tmpdir):
+        # Test binary export inferred from file extension
+        cq.exporters.assembly.exportGLTF(nested_assy_sphere, "nested_export_gltf.glb")
+        with pytest.raises(UnicodeDecodeError):
+            with open("nested_export_gltf.glb", "r") as file:
+                file.read()
 
-    # Test binary export inferred from file extension
-    cq.exporters.assembly.exportGLTF(nested_assy_sphere, glb_path)
-    with pytest.raises(UnicodeDecodeError):
-        with open(glb_path, "r") as file:
-            file.read()
+        # Test explicit binary export
+        cq.exporters.assembly.exportGLTF(
+            nested_assy_sphere, "nested_export_gltf_2.glb", binary=True
+        )
+        with pytest.raises(UnicodeDecodeError):
+            with open("nested_export_gltf_2.glb", "r") as file:
+                file.read()
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    glb_path_2 = os.path.join(tmpdir, "nested_export_gltf_2.glb")
-
-    # Test explicit binary export
-    cq.exporters.assembly.exportGLTF(nested_assy_sphere, glb_path_2, binary=True)
-    with pytest.raises(UnicodeDecodeError):
-        with open(glb_path_2, "r") as file:
-            file.read()
-
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    glb_path_3 = os.path.join(tmpdir, "nested_export_gltf_3.gltf")
-
-    # Test explicit ascii export
-    cq.exporters.assembly.exportGLTF(nested_assy_sphere, glb_path_3, binary=False)
-    with open(glb_path_3, "r") as file:
-        lines = file.readlines()
-        assert lines[0].startswith('{"accessors"')
+        # Test explicit ascii export
+        cq.exporters.assembly.exportGLTF(
+            nested_assy_sphere, "nested_export_gltf_3.gltf", binary=False
+        )
+        with open("nested_export_gltf_3.gltf", "r") as file:
+            lines = file.readlines()
+            assert lines[0].startswith('{"accessors"')
 
 
 def test_save_gltf_boxes2(boxes2_assy, tmpdir, capfd):
@@ -1505,13 +1472,11 @@ def test_save_gltf_boxes2(boxes2_assy, tmpdir, capfd):
     assert output.err == ""
 
 
-def test_save_vtkjs(nested_assy, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    nested_path = os.path.join(tmpdir, "nested.zip")
+def test_save_vtkjs(nested_assy, tmpdir):
 
-    nested_assy.save(nested_path.replace(".zip", ""), "VTKJS")
-    assert os.path.exists(nested_path)
+    with chdir(tmpdir):
+        nested_assy.save("nested", "VTKJS")
+        assert os.path.exists("nested.zip")
 
 
 def test_save_raises(nested_assy):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -702,19 +702,16 @@ def test_assy_root_name(assy_fixture, root_name, request):
         assert list(map(len, m)) == [8, 4, 4, 4, 12]
 
 
-def test_step_export(nested_assy, tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    nested_path = os.path.join(tmpdir, "nested.step")
-    nested_options_path = os.path.join(tmpdir, "nested_options.step")
+def test_step_export(nested_assy, tmpdir):
 
-    exportAssembly(nested_assy, nested_path)
-    exportAssembly(
-        nested_assy, nested_options_path, write_pcurves=False, precision_mode=0
-    )
+    with chdir(tmpdir):
+        exportAssembly(nested_assy, "nested.step")
+        exportAssembly(
+            nested_assy, "nested_options.step", write_pcurves=False, precision_mode=0
+        )
+        w = cq.importers.importStep("nested.step")
+        o = cq.importers.importStep("nested_options.step")
 
-    w = cq.importers.importStep(nested_path)
-    o = cq.importers.importStep(nested_options_path)
     assert w.solids().size() == 4
     assert o.solids().size() == 4
 
@@ -725,15 +722,11 @@ def test_step_export(nested_assy, tmp_path_factory):
     assert pytest.approx(c2.toTuple()) == (0, 4, 0)
 
 
-def test_meta_step_export(tmp_path_factory):
+def test_meta_step_export(tmpdir):
     """
     Tests that an assembly can be exported to a STEP file with faces tagged with names and colors,
     and layers added.
     """
-
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    meta_path = os.path.join(tmpdir, "meta.step")
 
     # Most nested level of the assembly
     subsubassy = cq.Assembly(name="third-level")
@@ -806,97 +799,95 @@ def test_meta_step_export(tmp_path_factory):
         assy.addSubshape(cone_2.faces("<Z").val(), color=cq.Color(1.0, 0.0, 0.0))
         assy.addSubshape(cone_2.faces("<Z").val(), layer="cone_2_bottom_face")
 
-    # Write once with pcurves turned on
-    success = exportStepMeta(assy, meta_path)
-    assert success
+    with chdir(tmpdir):
+        # Write once with pcurves turned on
+        success = exportStepMeta(assy, "meta1.step")
+        assert success
+        # Make sure the step file exists
+        assert os.path.exists("meta1.step")
 
-    # Write again with pcurves turned off
-    success = exportStepMeta(assy, meta_path, write_pcurves=False)
-    assert success
+        # Write again with pcurves turned off
+        success = exportStepMeta(assy, "meta2.step", write_pcurves=False)
+        assert success
 
-    # Make sure the step file exists
-    assert os.path.exists(meta_path)
+        # Read the contents as a step file as a string so we can check the outputs
+        with open("meta2.step", "r") as f:
+            step_contents = f.read()
 
-    # Read the contents as a step file as a string so we can check the outputs
-    with open(meta_path, "r") as f:
-        step_contents = f.read()
+            # Make sure that the face name strings were applied in ADVACED_FACE entries
+            assert "ADVANCED_FACE('cube_1_top_face'" in step_contents
+            assert "ADVANCED_FACE('cube_2_bottom_face'" in step_contents
 
-        # Make sure that the face name strings were applied in ADVACED_FACE entries
-        assert "ADVANCED_FACE('cube_1_top_face'" in step_contents
-        assert "ADVANCED_FACE('cube_2_bottom_face'" in step_contents
+            # Make reasonably sure that the colors were applied to the faces
+            assert "DRAUGHTING_PRE_DEFINED_COLOUR('black')" in step_contents
+            assert "DRAUGHTING_PRE_DEFINED_COLOUR('white')" in step_contents
+            assert "DRAUGHTING_PRE_DEFINED_COLOUR('cyan')" in step_contents
+            assert "DRAUGHTING_PRE_DEFINED_COLOUR('yellow')" in step_contents
 
-        # Make reasonably sure that the colors were applied to the faces
-        assert "DRAUGHTING_PRE_DEFINED_COLOUR('black')" in step_contents
-        assert "DRAUGHTING_PRE_DEFINED_COLOUR('white')" in step_contents
-        assert "DRAUGHTING_PRE_DEFINED_COLOUR('cyan')" in step_contents
-        assert "DRAUGHTING_PRE_DEFINED_COLOUR('yellow')" in step_contents
-
-        # Make sure that the layers were created
-        assert (
-            "PRESENTATION_LAYER_ASSIGNMENT('cube_1_top_face','visible'" in step_contents
-        )
-        assert (
-            "PRESENTATION_LAYER_ASSIGNMENT('cube_2_bottom_face','visible'"
-            in step_contents
-        )
+            # Make sure that the layers were created
+            assert (
+                "PRESENTATION_LAYER_ASSIGNMENT('cube_1_top_face','visible'"
+                in step_contents
+            )
+            assert (
+                "PRESENTATION_LAYER_ASSIGNMENT('cube_2_bottom_face','visible'"
+                in step_contents
+            )
 
 
-def test_meta_step_export_edge_cases(tmp_path_factory):
+def test_meta_step_export_edge_cases(tmpdir):
     """
     Test all the edge cases of the STEP export function.
     """
-
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    meta_path = os.path.join(tmpdir, "meta_edges_cases.step")
 
     # Create an assembly where the child is empty
     assy = cq.Assembly(name="top-level")
     subassy = cq.Assembly(name="second-level")
     assy.add(subassy)
 
-    # Write an assembly with no children
-    success = exportStepMeta(assy, meta_path)
-    assert success
+    with chdir(tmpdir):
+        # Write an assembly with no children
+        success = exportStepMeta(assy, "meta_edge_cases1.step")
+        assert success
 
-    # Test an object with no color set
-    cube = cq.Workplane().box(10.0, 10.0, 10.0)
-    assy.add(cube, name="cube")
-    success = exportStepMeta(assy, meta_path)
-    assert success
+        # Test an object with no color set
+        cube = cq.Workplane().box(10.0, 10.0, 10.0)
+        assy.add(cube, name="cube")
+        success = exportStepMeta(assy, "meta_edge_cases2.step")
+        assert success
 
-    # Tag a face that does not match the object
-    with pytest.raises(ValueError):
-        assy.addSubshape(plane(1, 1), name="cube_top_face")
+        # Tag a face that does not match the object
+        with pytest.raises(ValueError):
+            assy.addSubshape(plane(1, 1), name="cube_top_face")
 
-    # Tag the name but nothing else
-    assy.addSubshape(cube.faces(">Z").val(), name="cube_top_face")
-    success = exportStepMeta(assy, meta_path)
-    assert success
+        # Tag the name but nothing else
+        assy.addSubshape(cube.faces(">Z").val(), name="cube_top_face")
+        success = exportStepMeta(assy, "meta_edge_cases3.step")
+        assert success
 
-    # Reset the assembly
-    assy.remove("cube")
-    cube = cq.Workplane().box(9.9, 9.9, 9.9)
-    assy.add(cube, name="cube")
+        # Reset the assembly
+        assy.remove("cube")
+        cube = cq.Workplane().box(9.9, 9.9, 9.9)
+        assy.add(cube, name="cube")
 
-    # Tag the color but nothing else
-    assy.addSubshape(cube.faces(">Z").val(), color=cq.Color(1.0, 0.0, 0.0))
-    success = exportStepMeta(assy, meta_path)
-    assert success
+        # Tag the color but nothing else
+        assy.addSubshape(cube.faces(">Z").val(), color=cq.Color(1.0, 0.0, 0.0))
+        success = exportStepMeta(assy, "meta_edge_cases4.step")
+        assert success
 
-    # Reset the assembly
-    assy.remove("cube")
-    cube = cq.Workplane().box(9.8, 9.8, 9.8)
-    assy.add(cube, name="cube")
+        # Reset the assembly
+        assy.remove("cube")
+        cube = cq.Workplane().box(9.8, 9.8, 9.8)
+        assy.add(cube, name="cube")
 
-    # Tag the layer but nothing else
-    assy.addSubshape(cube.faces(">Z").val(), layer="cube_top_face")
-    success = exportStepMeta(assy, meta_path)
-    assert success
+        # Tag the layer but nothing else
+        assy.addSubshape(cube.faces(">Z").val(), layer="cube_top_face")
+        success = exportStepMeta(assy, "meta_edge_cases5.step")
+        assert success
 
 
 @pytest.mark.parametrize("kind", ["step", "xml", "xbf"])
-def test_step_roundtrip_with_materials(kind, tmp_path_factory):
+def test_step_roundtrip_with_materials(kind, tmpdir):
     """
     Tests to make sure that once materials have been exported to a file format
     such as STEP, the materials can be imported again.
@@ -909,40 +900,36 @@ def test_step_roundtrip_with_materials(kind, tmp_path_factory):
         material=cq.Material(name="copper"),
     )
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    materials_path = os.path.join(tmpdir, f"roundtrip_materials.{kind}")
+    materials_path = f"roundtrip_materials.{kind}"
 
-    exportAssembly(materials_assy, materials_path)
+    with chdir(tmpdir):
+        exportAssembly(materials_assy, materials_path)
 
-    # Read the contents as a step file as a string so we can check the outputs
-    with open(materials_path, "r") as f:
-        step_contents = f.read()
+        # Read the contents as a step file as a string so we can check the outputs
+        with open(materials_path, "r") as f:
+            step_contents = f.read()
 
         # Make sure that the face name string is present in the exported STEP contents
         assert "copper" in step_contents
 
-    # Import the STEP file back in as an assembly
-    test_assy = cq.Assembly.importStep(materials_path)
+        # Import the STEP file back in as an assembly
+        test_assy = cq.Assembly.importStep(materials_path)
 
     # Make sure that the material was re-imported
     assert test_assy.children[0].material is not None
     assert test_assy.children[0].material.name == "copper"
 
 
-def test_assembly_step_import(tmp_path_factory, subshape_assy):
+def test_assembly_step_import(tmpdir, subshape_assy):
     """
     Test if the STEP import works correctly for an assembly with subshape data attached.
     """
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    assy_step_path = os.path.join(tmpdir, "assembly_with_subshapes.step")
+    with chdir(tmpdir):
+        subshape_assy.export("assembly_with_subshapes.step")
 
-    subshape_assy.export(assy_step_path)
-
-    # Import the STEP file back in
-    imported_assy = cq.Assembly.importStep(assy_step_path)
+        # Import the STEP file back in
+        imported_assy = cq.Assembly.importStep("assembly_with_subshapes.step")
 
     # Check that the assembly was imported successfully
     assert imported_assy is not None
@@ -973,29 +960,30 @@ def test_assembly_step_import(tmp_path_factory, subshape_assy):
     assert imported_assy.name == "top_level"
 
     # Test a STEP file that does not contain an assembly
-    wp_step_path = os.path.join(tmpdir, "plain_workplane.step")
     res = cq.Workplane().box(10, 10, 10)
-    res.export(wp_step_path)
+    with chdir(tmpdir):
+        res.export("plain_workplane.step")
 
-    # Import the STEP file back in
-    with pytest.raises(ValueError):
-        imported_assy = cq.Assembly.importStep(wp_step_path)
+        # Import the STEP file back in
+        with pytest.raises(ValueError):
+            imported_assy = cq.Assembly.importStep("plain_workplane.step")
 
 
 @pytest.mark.parametrize("kind", ["step", "xml", "xbf"])
-def test_assembly_subshape_import(tmp_path_factory, subshape_assy, kind):
+def test_assembly_subshape_import(tmpdir, subshape_assy, kind):
     """
     Test if a STEP/XBF/XML file containing subshape information can be imported correctly.
     """
 
-    tmpdir = tmp_path_factory.mktemp("out")
-    assy_step_path = os.path.join(tmpdir, f"subshape_assy.{kind}")
+    assy_step_path = f"subshape_assy.{kind}"
 
-    # Export the assembly
-    subshape_assy.export(assy_step_path)
+    with chdir(tmpdir):
+        # Export the assembly
+        subshape_assy.export(assy_step_path)
 
-    # Import the file back in
-    imported_assy = cq.Assembly.load(assy_step_path)
+        # Import the file back in
+        imported_assy = cq.Assembly.load(assy_step_path)
+
     assert imported_assy.name == "top_level"
 
     # Check the advanced face name
@@ -1021,19 +1009,19 @@ def test_assembly_subshape_import(tmp_path_factory, subshape_assy, kind):
 
 
 @pytest.mark.parametrize("kind", ["step", "xml", "xbf"])
-def test_assembly_multi_subshape_import(tmp_path_factory, multi_subshape_assy, kind):
+def test_assembly_multi_subshape_import(tmpdir, multi_subshape_assy, kind):
     """
     Test if a file containing subshape information can be imported correctly.
     """
 
-    tmpdir = tmp_path_factory.mktemp("out")
-    assy_step_path = os.path.join(tmpdir, f"multi_subshape_assy.{kind}")
+    assy_step_path = f"multi_subshape_assy.{kind}"
 
-    # Export the assembly
-    multi_subshape_assy.export(assy_step_path)
+    with chdir(tmpdir):
+        # Export the assembly
+        multi_subshape_assy.export(assy_step_path)
 
-    # Import the file back in
-    imported_assy = cq.Assembly.load(assy_step_path)
+        # Import the file back in
+        imported_assy = cq.Assembly.load(assy_step_path)
 
     # Check that the top-level assembly name is correct
     assert imported_assy.name == "top_level"
@@ -1068,27 +1056,21 @@ def test_assembly_multi_subshape_import(tmp_path_factory, multi_subshape_assy, k
     assert layer_name == "cube_2_right_face"
 
 
-def test_bad_step_file_import(tmp_path_factory):
+def test_bad_step_file_import(tmpdir):
     """
     Test if a bad STEP file raises an error when importing.
     """
 
-    tmpdir = tmp_path_factory.mktemp("out")
-    bad_step_path = os.path.join(tmpdir, "bad_step.step")
-
-    # Check that an error is raised when trying to import a non-existent STEP file
-    with pytest.raises(ValueError):
-        # Export the assembly
-        cq.Assembly.importStep(bad_step_path)
+    with chdir(tmpdir):
+        # Check that an error is raised when trying to import a non-existent STEP file
+        with pytest.raises(ValueError):
+            cq.Assembly.importStep("bad_step.step")
 
 
-def test_plain_assembly_import(tmp_path_factory):
+def test_plain_assembly_import(tmpdir):
     """
     Test to make sure that importing plain assemblies has not been broken.
     """
-
-    tmpdir = tmp_path_factory.mktemp("out")
-    plain_step_path = os.path.join(tmpdir, "plain_assembly_step.step")
 
     # Simple cubes
     cube_1 = cq.Workplane().box(10, 10, 10)
@@ -1102,11 +1084,13 @@ def test_plain_assembly_import(tmp_path_factory):
     assy.add(cube_3, loc=cq.Location((-10, -10, -10)), color=cq.Color("red"))
     assy.add(cube_4, loc=cq.Location((10, -10, -10)), color=cq.Color("red"))
 
-    # Export the assembly, but do not use the meta STEP export method
-    assy.export(plain_step_path)
+    with chdir(tmpdir):
+        # Export the assembly, but do not use the meta STEP export method
+        assy.export("plain_assembly_step.step")
 
-    # Import the STEP file back in
-    imported_assy = cq.Assembly.importStep(plain_step_path)
+        # Import the STEP file back in
+        imported_assy = cq.Assembly.importStep("plain_assembly_step.step")
+
     assert imported_assy.name == "top_level"
 
     # Check the locations
@@ -1145,19 +1129,15 @@ def test_plain_assembly_import(tmp_path_factory):
     )  # red
 
 
-def test_copied_assembly_import(tmp_path_factory):
+def test_copied_assembly_import(tmpdir):
     """
     Tests to make sure that copied children in assemblies work correctly.
     """
     from cadquery import Assembly, Location, Color
     from cadquery.func import box, rect
 
-    # Create the temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-
     # prepare the model
     def make_model(name: str, COPY: bool):
-        name = os.path.join(tmpdir, name)
 
         b = box(1, 1, 1)
 
@@ -1172,7 +1152,8 @@ def test_copied_assembly_import(tmp_path_factory):
                 color=Color("red"),
             )
 
-        assy.export(name)
+        with chdir(tmpdir):
+            assy.export(name)
 
         return assy
 
@@ -1180,21 +1161,20 @@ def test_copied_assembly_import(tmp_path_factory):
     make_model("test_assy.step", False)
 
     # import the assy with copies
-    assy_copy = Assembly.importStep(os.path.join(tmpdir, "test_assy_copy.step"))
+    with chdir(tmpdir):
+        assy_copy = Assembly.importStep("test_assy_copy.step")
     assert 5 == len(assy_copy.children)
 
     # import the assy without copies
-    assy_normal = Assembly.importStep(os.path.join(tmpdir, "test_assy.step"))
+    with chdir(tmpdir):
+        assy_normal = Assembly.importStep("test_assy.step")
     assert 5 == len(assy_normal.children)
 
 
-def test_nested_subassembly_step_import(tmp_path_factory):
+def test_nested_subassembly_step_import(tmpdir):
     """
     Tests if the STEP import works correctly with nested subassemblies.
     """
-
-    tmpdir = tmp_path_factory.mktemp("out")
-    nested_step_path = os.path.join(tmpdir, "plain_assembly_step.step")
 
     # Create a simple assembly
     assy = cq.Assembly()
@@ -1208,8 +1188,9 @@ def test_nested_subassembly_step_import(tmp_path_factory):
     assy.add(subassy)
 
     # Export and then re-import the nested assembly STEP
-    assy.export(nested_step_path)
-    imported_assy = cq.Assembly.importStep(nested_step_path)
+    with chdir(tmpdir):
+        assy.export("nested_assembly_step.step")
+        imported_assy = cq.Assembly.importStep("nested_assembly_step.step")
 
     # Check the locations
     assert imported_assy.children[0].loc.toTuple()[0] == (0.0, 0.0, 0.0)
@@ -1224,15 +1205,13 @@ def test_nested_subassembly_step_import(tmp_path_factory):
 @pytest.mark.parametrize(
     "assy_orig", ["subshape_assy", "boxes0_assy", "nested_assy", "simple_assy"],
 )
-def test_assembly_step_import_roundtrip(assy_orig, kind, tmp_path_factory, request):
+def test_assembly_step_import_roundtrip(assy_orig, kind, tmpdir, request):
     """
     Tests that the assembly does not mutate during successive export-import round trips.
     """
 
     assy_orig = request.getfixturevalue(assy_orig)
 
-    # Set up the temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
     round_trip_path = os.path.join(tmpdir, f"round_trip.{kind}")
 
     # First export
@@ -1320,7 +1299,7 @@ def test_vrml_export(simple_assy, tmpdir):
         assert os.path.exists("assy.wrl")
 
 
-def test_toJSON(simple_assy, nested_assy, empty_top_assy):
+def test_toJSON(simple_assy, empty_top_assy):
 
     r1 = toJSON(simple_assy)
     r2 = toJSON(simple_assy)
@@ -1342,7 +1321,7 @@ def test_toJSON(simple_assy, nested_assy, empty_top_assy):
         ("stl", ("STL",)),
     ],
 )
-def test_save(extension, args, nested_assy, nested_assy_sphere, tmpdir):
+def test_save(extension, args, nested_assy, tmpdir):
 
     filename = "nested." + extension
     with chdir(tmpdir):
@@ -2406,13 +2385,11 @@ def test_remove_without_parent():
     assert len(assy.objects) == 1
 
 
-def test_step_color(tmp_path_factory):
+def test_step_color(tmpdir):
     """
     Checks color handling for STEP export.
     """
 
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
     step_color_path = os.path.join(tmpdir, "step_color.step")
 
     # Create a simple assembly with color

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -2,14 +2,18 @@
     This module tests cadquery creation and manipulation functions
 
 """
+
 # system modules
-import math, os.path, time, tempfile
+import math, time
+from typing import ClassVar
 from pathlib import Path
 from random import random
 from random import randrange
 from itertools import product
 
+import pytest
 from pytest import approx, raises
+from contextlib import chdir
 
 # my modules
 
@@ -28,10 +32,6 @@ from tests import (
 # test data directory
 testdataDir = Path(__file__).parent.joinpath("testdata")
 testFont = str(testdataDir / "OpenSans-Regular.ttf")
-
-# where unit test output will be saved
-OUTDIR = tempfile.gettempdir()
-SUMMARY_FILE = os.path.join(OUTDIR, "testSummary.html")
 
 SUMMARY_TEMPLATE = """<html>
     <head>
@@ -55,12 +55,19 @@ TEST_RESULT_TEMPLATE = """
     <!--TEST_CONTENT-->
 """
 
-# clean up any summary file that is in the output directory.
-# i know, this sux, but there is no other way to do this in 2.6, as we cannot do class fixtures till 2.7
-writeStringToFile(SUMMARY_TEMPLATE, SUMMARY_FILE)
+
+@pytest.fixture(scope="class")
+def tmpdir(request, tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("cadquery")
+    request.cls.tmpdir = tmp
+    return tmp
 
 
+@pytest.mark.usefixtures("tmpdir")
 class TestCadQuery(BaseTest):
+    tmpdir: ClassVar[Path] = Path()
+    summary_file: ClassVar[Path | None] = None
+
     def tearDown(self):
         """
         Update summary with data from this test.
@@ -69,11 +76,14 @@ class TestCadQuery(BaseTest):
 
         So what we do here is to read the existing file, stick in more content, and leave it
         """
-        svgFile = os.path.join(OUTDIR, self._testMethodName + ".svg")
+        svgFile = (self.tmpdir / self._testMethodName).with_suffix(".svg")
 
         # all tests do not produce output
-        if os.path.exists(svgFile):
-            existingSummary = readFileAsString(SUMMARY_FILE)
+        if svgFile.exists():
+            if self.summary_file is None:
+                type(self).summary_file = self.tmpdir / "testSummary.html"
+                writeStringToFile(SUMMARY_TEMPLATE, self.summary_file)
+            existingSummary = readFileAsString(self.summary_file)
             svgText = readFileAsString(svgFile)
             svgText = svgText.replace(
                 '<?xml version="1.0" encoding="UTF-8" standalone="no"?>', ""
@@ -86,15 +96,17 @@ class TestCadQuery(BaseTest):
                 TEST_RESULT_TEMPLATE % (dict(svg=svgText, name=self._testMethodName)),
             )
 
-            writeStringToFile(existingSummary, SUMMARY_FILE)
+            writeStringToFile(existingSummary, self.summary_file)
 
     def saveModel(self, shape):
         """
         shape must be a CQ object
         Save models in SVG and STEP format
         """
-        shape.exportSvg(os.path.join(OUTDIR, self._testMethodName + ".svg"))
-        shape.val().exportStep(os.path.join(OUTDIR, self._testMethodName + ".step"))
+        shape.exportSvg(str((self.tmpdir / self._testMethodName).with_suffix(".svg")))
+        shape.val().exportStep(
+            str((self.tmpdir / self._testMethodName).with_suffix(".step"))
+        )
 
     def testToOCC(self):
         """
@@ -1918,14 +1930,13 @@ class TestCadQuery(BaseTest):
 
     def testBasicLines(self):
         "Make a triangular boss"
-        global OUTDIR
         s = Workplane(Plane.XY())
 
         # TODO:  extrude() should imply wire() if not done already
         # most users dont understand what a wire is, they are just drawing
 
         r = s.lineTo(1.0, 0).lineTo(0, 1.0).close().wire().extrude(0.25)
-        r.val().exportStep(os.path.join(OUTDIR, "testBasicLinesStep1.STEP"))
+        r.val().exportStep(str(self.tmpdir / "testBasicLinesStep1.STEP"))
 
         # no faces on the original workplane
         self.assertEqual(0, s.faces().size())
@@ -1940,7 +1951,7 @@ class TestCadQuery(BaseTest):
             .cutThruAll()
         )
         self.assertEqual(6, r1.faces().size())
-        r1.val().exportStep(os.path.join(OUTDIR, "testBasicLinesXY.STEP"))
+        r1.val().exportStep(str(self.tmpdir / "testBasicLinesXY.STEP"))
 
         # now add a circle through a top
         r2 = (
@@ -1950,7 +1961,7 @@ class TestCadQuery(BaseTest):
             .cutThruAll()
         )
         self.assertEqual(9, r2.faces().size())
-        r2.val().exportStep(os.path.join(OUTDIR, "testBasicLinesZ.STEP"))
+        r2.val().exportStep(str(self.tmpdir / "testBasicLinesZ.STEP"))
 
         self.saveModel(r2)
 
@@ -5291,11 +5302,9 @@ class TestCadQuery(BaseTest):
         # import/export to file
         s = Workplane().box(1, 1, 1).val()
 
-        # Use a temporary directory
-        brep_export_path = os.path.join(OUTDIR, "test.brep")
-
-        s.exportBrep(brep_export_path)
-        si = Shape.importBrep(brep_export_path)
+        with chdir(self.tmpdir):
+            s.exportBrep("test.brep")
+            si = Shape.importBrep("test.brep")
 
         self.assertTrue(si.isValid())
         self.assertAlmostEqual(si.Volume(), 1)
@@ -5308,7 +5317,8 @@ class TestCadQuery(BaseTest):
         s.exportBrep(bio)
         bio.seek(0)
 
-        si = Shape.importBrep(brep_export_path)
+        with chdir(self.tmpdir):
+            si = Shape.importBrep("test.brep")
 
         self.assertTrue(si.isValid())
         self.assertAlmostEqual(si.Volume(), 1)
@@ -5819,12 +5829,11 @@ class TestCadQuery(BaseTest):
         assert len(verts) == 0
 
     def test_export(self):
-        # Use a temporary directory
-        box_export_path = os.path.join(OUTDIR, "box.brep")
 
-        w = Workplane().box(1, 1, 1).export(box_export_path)
+        with chdir(self.tmpdir):
+            w = Workplane().box(1, 1, 1).export("box.brep")
 
-        assert (w - Shape.importBrep(box_export_path)).val().Volume() == approx(0)
+            assert (w - Shape.importBrep("box.brep")).val().Volume() == approx(0)
 
     def test_bool_operators(self):
 

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -5291,8 +5291,11 @@ class TestCadQuery(BaseTest):
         # import/export to file
         s = Workplane().box(1, 1, 1).val()
 
-        s.exportBrep("test.brep")
-        si = Shape.importBrep("test.brep")
+        # Use a temporary directory
+        brep_export_path = os.path.join(OUTDIR, "test.brep")
+
+        s.exportBrep(brep_export_path)
+        si = Shape.importBrep(brep_export_path)
 
         self.assertTrue(si.isValid())
         self.assertAlmostEqual(si.Volume(), 1)
@@ -5305,7 +5308,7 @@ class TestCadQuery(BaseTest):
         s.exportBrep(bio)
         bio.seek(0)
 
-        si = Shape.importBrep("test.brep")
+        si = Shape.importBrep(brep_export_path)
 
         self.assertTrue(si.isValid())
         self.assertAlmostEqual(si.Volume(), 1)
@@ -5816,10 +5819,12 @@ class TestCadQuery(BaseTest):
         assert len(verts) == 0
 
     def test_export(self):
+        # Use a temporary directory
+        box_export_path = os.path.join(OUTDIR, "box.brep")
 
-        w = Workplane().box(1, 1, 1).export("box.brep")
+        w = Workplane().box(1, 1, 1).export(box_export_path)
 
-        assert (w - Shape.importBrep("box.brep")).val().Volume() == approx(0)
+        assert (w - Shape.importBrep(box_export_path)).val().Volume() == approx(0)
 
     def test_bool_operators(self):
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,7 @@ from glob import glob
 from itertools import chain, count
 
 from pathlib import Path
+from contextlib import chdir
 
 from docutils.parsers.rst import directives
 from docutils.core import publish_doctree
@@ -61,10 +62,10 @@ def find_examples_in_docs(pattern="doc/*.rst", path=Path("doc")):
 @pytest.mark.parametrize(
     "code, path", chain(find_examples(), find_examples_in_docs()), ids=count(0)
 )
-def test_example(code, path, tmpdir, cwd):
+def test_example(code, path, tmpdir):
 
     # build
-    with cwd(tmpdir):
+    with chdir(tmpdir):
         # tmpdir is for future use; currently there are no examples that export files
         res = cqgi.parse(code).build()
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -3,7 +3,6 @@
 """
 # core modules
 import os
-import io
 from pathlib import Path
 import re
 import sys
@@ -40,7 +39,7 @@ from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 
 @pytest.fixture(scope="module")
 def tmpdir(tmp_path_factory):
-    return tmp_path_factory.mktemp("out")
+    return tmp_path_factory.mktemp("exporters")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -1,4 +1,3 @@
-import os
 from cadquery.func import (
     vertex,
     segment,
@@ -62,19 +61,16 @@ from OCP.BOPAlgo import BOPAlgo_CheckStatus
 
 import pytest
 from pytest import approx, raises, fixture
+from contextlib import chdir
 from math import pi
 
-<<<<<<< HEAD
 
 @pytest.fixture(scope="function")
 def tmpdir(tmp_path_factory):
-    return tmp_path_factory.mktemp("sketch")
+    return tmp_path_factory.mktemp("free_functions")
 
 
-#%% test utils
-=======
 # %% test utils
->>>>>>> master
 
 
 def assert_all_valid(*objs: Shape):
@@ -939,15 +935,13 @@ def test_project():
 
 
 # %% export
-def test_export(tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    ff_export_path = os.path.join(tmpdir, "box.brep")
+def test_export(tmpdir):
 
-    b1 = box(1, 1, 1)
-    b1.export(ff_export_path)
+    with chdir(tmpdir):
+        b1 = box(1, 1, 1)
+        b1.export("box.brep")
 
-    b2 = Shape.importBrep(ff_export_path)
+        b2 = Shape.importBrep("box.brep")
 
     assert (b1 - b2).Volume() == approx(0)
 

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -1,3 +1,4 @@
+import os
 from cadquery.func import (
     vertex,
     segment,
@@ -59,8 +60,15 @@ from cadquery.occ_impl.shapes import (
 
 from OCP.BOPAlgo import BOPAlgo_CheckStatus
 
+import pytest
 from pytest import approx, raises, fixture
 from math import pi
+
+
+@pytest.fixture(scope="function")
+def tmpdir(tmp_path_factory):
+    return tmp_path_factory.mktemp("sketch")
+
 
 #%% test utils
 
@@ -890,12 +898,15 @@ def test_project():
 
 
 # %% export
-def test_export():
+def test_export(tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    ff_export_path = os.path.join(tmpdir, "box.brep")
 
     b1 = box(1, 1, 1)
-    b1.export("box.brep")
+    b1.export(ff_export_path)
 
-    b2 = Shape.importBrep("box.brep")
+    b2 = Shape.importBrep(ff_export_path)
 
     assert (b1 - b2).Volume() == approx(0)
 

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from cadquery.sketch import Sketch, Vector, Location
 from cadquery.selectors import LengthNthSelector
@@ -8,6 +9,11 @@ from pytest import approx, raises, fixture
 from math import pi, sqrt
 
 testdataDir = os.path.join(os.path.dirname(__file__), "testdata")
+
+
+@pytest.fixture(scope="function")
+def tmpdir(tmp_path_factory):
+    return tmp_path_factory.mktemp("sketch")
 
 
 def test_face_interface():
@@ -820,10 +826,13 @@ def test_bool_ops():
     assert (s1 / s2).val().Area() == approx(1)
 
 
-def test_export():
+def test_export(tmp_path_factory):
+    # Use a temporary directory
+    tmpdir = tmp_path_factory.mktemp("out")
+    sketch_export_path = os.path.join(tmpdir, "sketch.dxf")
 
-    s1 = Sketch().rect(1, 1).export("sketch.dxf")
-    s2 = Sketch().importDXF("sketch.dxf")
+    s1 = Sketch().rect(1, 1).export(sketch_export_path)
+    s2 = Sketch().importDXF(sketch_export_path)
 
     assert (s1 - s2).val().Area() == approx(0)
 

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from contextlib import chdir
 
 from cadquery.sketch import Sketch, Vector, Location
 from cadquery.selectors import LengthNthSelector
@@ -826,13 +827,11 @@ def test_bool_ops():
     assert (s1 / s2).val().Area() == approx(1)
 
 
-def test_export(tmp_path_factory):
-    # Use a temporary directory
-    tmpdir = tmp_path_factory.mktemp("out")
-    sketch_export_path = os.path.join(tmpdir, "sketch.dxf")
+def test_export(tmpdir):
 
-    s1 = Sketch().rect(1, 1).export(sketch_export_path)
-    s2 = Sketch().importDXF(sketch_export_path)
+    with chdir(tmpdir):
+        s1 = Sketch().rect(1, 1).export("sketch.dxf")
+        s2 = Sketch().importDXF("sketch.dxf")
 
     assert (s1 - s2).val().Area() == approx(0)
 


### PR DESCRIPTION
Running `pytest` without specifying a temporary directory would pollute the local tree with output files from the tests. This PR is an attempt to address that.