### PR TITLE
Removed CadQuery 2 Mentions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,6 @@
 
 
-CadQuery 2 Documentation
+CadQuery Documentation
 ===================================
 
 CadQuery is an intuitive, easy-to-use Python library for building parametric 3D CAD models.  It has several goals:
@@ -13,11 +13,6 @@ CadQuery is an intuitive, easy-to-use Python library for building parametric 3D 
     * Output high quality CAD formats like STEP, AMF and 3MF in addition to traditional STL
 
     * Provide a non-proprietary, plain text model format that can be edited and executed with only a web browser
-
-See CadQuery in Action
--------------------------
-
-This `Getting Started Video <https://youtu.be/lxhBNOE7GVs>`_ will show you what CadQuery can do. Please note that the video has not been updated for CadQuery 2 and still shows CadQuery use within FreeCAD.
 
 
 Quick Links

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -18,7 +18,7 @@ CadQuery is an intuitive, easy-to-use Python library for building parametric 3D 
 
     * Provide a non-proprietary, plain text model format that can be edited and executed with only a web browser
 
-CadQuery 2 is based on
+CadQuery is based on
 `OCP <https://github.com/CadQuery/OCP>`_,
 which is a set of Python bindings for the open-source `OpenCascade <http://www.opencascade.com/>`_ modelling kernel.
 


### PR DESCRIPTION
We added the `2` to the docs title back when we were making the transition from the FreeCAD API to OCP. I don't think it is relevant anymore. Nobody calls CadQuery "CadQuery 2".

I also removed a link to an old YouTube video of mine which is extremely outdated now. I had already edited the description of the video to warn users, but I still get comments from people who are confused.