### PR TITLE
Disable fxaa by default

### DIFF
--- a/cadquery/vis.py
+++ b/cadquery/vis.py
@@ -409,7 +409,7 @@ def show(
     gradient: bool = True,
     xpos: Union[int, float] = 0,
     ypos: Union[int, float] = 0,
-    fxaa: bool = True,
+    fxaa: bool = False,
     orthographic: bool = False,
 ):
     """


### PR DESCRIPTION
I had issues with fxaa when running in containers/wsl and I it does not work for me at all with 7.9.3. Other users also reported issues.