### PR TITLE
Fixed the URL for the funding manifest URLs file

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -20,7 +20,7 @@
         },
         "repositoryUrl": {
             "url": "https://github.com/CadQuery/cadquery",
-            "wellKnown": "https://raw.githubusercontent.com/CadQuery/cadquery/master/.well-known/funding-manifest-urls"
+            "wellKnown": "https://github.com/CadQuery/cadquery/blob/master/.well-known/funding-manifest-urls"
         },
         "licenses": ["spdx:Apache-2.0"],
         "tags": ["scientific-computing", "programming", "development", "design", "3d-modeling", "cad"]


### PR DESCRIPTION
It wasn't until I tried to submit the manifest to FLOSS Fund that I saw that it gave me an error about the wellknown URL being a raw GitHub link and therefore a different domain than the main URL.