### PR TITLE
docs: explain selector chaining

### DIFF
--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -53,6 +53,7 @@ Much more complex expressions are possible as well:
     )
 
 Note that in the above example selector methods are chained. In this case each selector refines the previous selection, i.e. only edges from the selected face are considered when calling ``faces(...).edges(...)``. Chaining can make complicated selections easier to read or possible at all.
+
 .. _filteringfaces:
 
 Filtering Faces

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -52,6 +52,26 @@ Much more complex expressions are possible as well:
         .chamfer(0.1)
     )
 
+Selector methods can also be chained. Each selector operates on the current
+selection, so chaining is useful when an expression is easier to read as a
+sequence of narrowing steps. For example, ``faces(">Y").edges("%CIRCLE")`` first
+selects the positive Y face and then selects only the circular edges belonging to
+that face:
+
+.. cadquery::
+
+    result = (
+        cq.Workplane("XY")
+        .box(4, 4, 1)
+        .faces(">Z")
+        .workplane()
+        .rarray(2, 2, 2, 2)
+        .hole(0.5)
+        .faces(">Z")
+        .edges("%CIRCLE")
+        .chamfer(0.08)
+    )
+
 .. _filteringfaces:
 
 Filtering Faces

--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -52,26 +52,7 @@ Much more complex expressions are possible as well:
         .chamfer(0.1)
     )
 
-Selector methods can also be chained. Each selector operates on the current
-selection, so chaining is useful when an expression is easier to read as a
-sequence of narrowing steps. For example, ``faces(">Y").edges("%CIRCLE")`` first
-selects the positive Y face and then selects only the circular edges belonging to
-that face:
-
-.. cadquery::
-
-    result = (
-        cq.Workplane("XY")
-        .box(4, 4, 1)
-        .faces(">Z")
-        .workplane()
-        .rarray(2, 2, 2, 2)
-        .hole(0.5)
-        .faces(">Z")
-        .edges("%CIRCLE")
-        .chamfer(0.08)
-    )
-
+Note that in the above example selector methods are chained. In this case each selector refines the previous selection, i.e. only edges from the selected face are considered when calling ``faces(...).edges(...)``. Chaining can make complicated selections easier to read or possible at all.
 .. _filteringfaces:
 
 Filtering Faces


### PR DESCRIPTION
## Summary
- add an explicit explanation of selector chaining to the selectors reference
- include a focused example that narrows from faces to circular edges before chamfering

Fixes #900

## Test plan
- `python3 - <<'PY' ...` sanity check that the selector chaining section exists and cadquery directive bodies are indented
- `git diff --check`
