### PR TITLE
History support for wire

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -243,6 +243,10 @@ class Vector(object):
 
         yield from (self.x, self.y, self.z)
 
+    def toXYZ(self) -> gp_XYZ:
+
+        return self.wrapped.XYZ()
+
     def toPnt(self) -> gp_Pnt:
 
         return gp_Pnt(self.wrapped.XYZ())

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -84,6 +84,7 @@ from OCP.BRepAdaptor import (
 )
 
 from OCP.BRepBuilderAPI import (
+    BRepBuilderAPI_Command,
     BRepBuilderAPI_MakeShape,
     BRepBuilderAPI_MakeVertex,
     BRepBuilderAPI_MakeEdge,
@@ -5754,8 +5755,6 @@ def _update_history(
         # construct the history step
         op = Op()
 
-        history.append(op, name)
-
         # track all subshapes
         for shape in shapes:
             op._tracked.update(shape.Faces())
@@ -5765,6 +5764,12 @@ def _update_history(
         # iterate over all builders and collect history information
         builder: Any
         for builder in builders:
+
+            if isinstance(builder, BRepBuilderAPI_Command):
+                assert (
+                    builder.IsDone()
+                ), f"Builder {builder} not done, cannot fill history."
+
             has_first_last = isinstance(
                 builder, (BRepPrimAPI_MakeRevol, BRepPrimAPI_MakePrism,),
             )
@@ -5851,6 +5856,8 @@ def _update_history(
                 if has_first_last_shape:
                     op._first_shape |= _compound_or_shape(builder.FirstShape())
                     op._last_shape |= _compound_or_shape(builder.LastShape())
+
+        history.append(op, name)
 
 
 def _remap_history_values(history: History | None, aux: History,) -> None:

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6063,13 +6063,18 @@ def wire(*s: Shape, history: History | None = None, name: str | None = None,) ->
         for ix, v, rev in zip(order, new_edges, reverse):
             k = edges[ix]
             op._modified[k] = v
+            op._images[k] = v
 
             if rev:
                 op._modified[k.endVertex()] = v.startVertex()
                 op._modified[k.startVertex()] = v.endVertex()
+                op._images[k.endVertex()] = v.startVertex()
+                op._images[k.startVertex()] = v.endVertex()
             else:
                 op._modified[k.startVertex()] = v.startVertex()
                 op._modified[k.endVertex()] = v.endVertex()
+                op._images[k.startVertex()] = v.startVertex()
+                op._images[k.endVertex()] = v.endVertex()
 
     return _shape(builder.Shape(), Wire)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -2078,6 +2078,12 @@ class Mixin1DProtocol(ShapeProtocol, Protocol):
     def paramsLength(self, locations: Iterable[float]) -> list[float]:
         ...
 
+    def startVertex(self) -> Vertex:
+        ...
+
+    def endVertex(self) -> Vertex:
+        ...
+
 
 T1D = TypeVar("T1D", bound=Mixin1DProtocol)
 
@@ -2103,10 +2109,7 @@ class Mixin1D(object):
         Note, circles may have the start and end points the same
         """
 
-        v1, _ = TopoDS_Vertex(), TopoDS_Vertex()
-        ShapeAnalysis.FindBounds_s(self.wrapped, v1, _)
-
-        return Vertex(v1).Center()
+        return self.startVertex().Center()
 
     def endPoint(self: Mixin1DProtocol) -> Vector:
         """
@@ -2116,10 +2119,33 @@ class Mixin1D(object):
         Note, circles may have the start and end points the same
         """
 
+        return self.endVertex().Center()
+
+    def startVertex(self: Mixin1DProtocol) -> Vertex:
+        """
+
+        :return: a vertex representing the start point of this edge
+
+        Note, circles may have the start and end vertex the same
+        """
+
+        v1, _ = TopoDS_Vertex(), TopoDS_Vertex()
+        ShapeAnalysis.FindBounds_s(self.wrapped, v1, _)
+
+        return Vertex(v1)
+
+    def endVertex(self: Mixin1DProtocol) -> Vertex:
+        """
+
+        :return: a vertex representing the end point of this edge.
+
+        Note, circles may have the start and end vertex the same
+        """
+
         _, v2 = TopoDS_Vertex(), TopoDS_Vertex()
         ShapeAnalysis.FindBounds_s(self.wrapped, _, v2)
 
-        return Vertex(v2).Center()
+        return Vertex(v2)
 
     def _approxCurve(self: Mixin1DProtocol) -> Geom_BSplineCurve:
         """
@@ -5152,7 +5178,7 @@ def _get_wires(s: Shape) -> Iterable[Shape]:
         raise ValueError(f"Required type(s): Edge, Wire; encountered {t}")
 
 
-def _get_edges(*shapes: Shape) -> Iterable[Shape]:
+def _get_edges(*shapes: Shape) -> Iterable[Edge]:
     """
     Get edges or edges from wires.
     """
@@ -5161,7 +5187,7 @@ def _get_edges(*shapes: Shape) -> Iterable[Shape]:
         t = s.ShapeType()
 
         if t == "Edge":
-            yield s
+            yield s.edge()
         elif t == "Wire":
             yield from _get_edges(s.edges())
         elif t == "Compound":
@@ -5760,6 +5786,7 @@ def _update_history(
                     BRepBuilderAPI_MakeShape,
                     BOPAlgo_Builder,
                     BRepOffset_MakeOffset,
+                    BRepBuilderAPI_MakeWire,
                 ),
             )
             has_modifidied = isinstance(
@@ -5968,23 +5995,41 @@ def wireOn(base: Shape, w: Shape, tol: float = 1e-6, N: int = 20) -> Wire:
 
 
 @multidispatch
-def wire(*s: Shape) -> Wire:
+def wire(*s: Shape, history: History | None = None, name: str | None = None,) -> Wire:
     """
     Build wire from edges.
     """
 
     builder = BRepBuilderAPI_MakeWire()
 
-    edges = _shapes_to_toptools_list(e for el in s for e in _get_edges(el))
-    builder.Add(edges)
+    new_edges = []
+    edges: list[Edge] = []
+    for el in s:
+        edges.extend(_get_edges(el))
+
+    for e in edges:
+        builder.Add(e.edge().wrapped)
+        new_edges.append(Edge(builder.Edge()))
+
+    _update_history(history, name, s, builder)
+
+    # handle OCCT lack of implementation
+    if history:
+        op = history[-1]
+        for k, v in zip(edges, new_edges):
+            op._modified[k] = v
+            op._modified[k.startVertex()] = v.startVertex()
+            op._modified[k.endVertex()] = v.endVertex()
 
     return _shape(builder.Shape(), Wire)
 
 
 @multidispatch
-def wire(s: Sequence[Shape]) -> Wire:
+def wire(
+    s: Sequence[Shape], history: History | None = None, name: str | None = None,
+) -> Wire:
 
-    return wire(*s)
+    return wire(*s, history=history, name=name)
 
 
 @multidispatch

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -277,6 +277,7 @@ from OCP.ShapeAnalysis import (
     ShapeAnalysis_Wire,
     ShapeAnalysis_Surface,
     ShapeAnalysis,
+    ShapeAnalysis_WireOrder,
 )
 from OCP.TopTools import TopTools_HSequenceOfShape
 
@@ -5995,6 +5996,33 @@ def wireOn(base: Shape, w: Shape, tol: float = 1e-6, N: int = 20) -> Wire:
     return wire(rvs)
 
 
+def _reorder_edges(edges: list[Edge]) -> tuple[list[int], list[bool]]:
+    """
+    Private helper for reordering of edges before wire construction. Returns order and
+    correct orientation.
+    """
+
+    n_edges = len(edges)
+    order = [0] * len(edges)
+    reverse = [False] * n_edges
+
+    ana = ShapeAnalysis_WireOrder()
+
+    for e in edges:
+        ana.Add(e.startPoint().toXYZ(), e.endPoint().toXYZ())
+
+    ana.Perform()
+
+    for i in range(n_edges):
+        i_old = ana.Ordered(i + 1)
+        i_old_abs = abs(i_old) - 1
+
+        order[i] = i_old_abs
+        reverse[i] = i_old < 0
+
+    return order, reverse
+
+
 @multidispatch
 def wire(*s: Shape, history: History | None = None, name: str | None = None,) -> Wire:
     """
@@ -6008,8 +6036,17 @@ def wire(*s: Shape, history: History | None = None, name: str | None = None,) ->
     for el in s:
         edges.extend(_get_edges(el))
 
-    for e in edges:
-        builder.Add(e.edge().wrapped)
+    # reorder and check orientation
+    order, reverse = _reorder_edges(edges)
+
+    # build and store new edges for history construction
+    for i, rev in zip(order, reverse):
+        edge = edges[i].edge().wrapped
+
+        if rev:
+            edge = TopoDS.Edge(edge.Reversed())
+
+        builder.Add(edge)
         status = builder.Error()
 
         assert (
@@ -6023,10 +6060,16 @@ def wire(*s: Shape, history: History | None = None, name: str | None = None,) ->
     # handle OCCT lack of implementation
     if history:
         op = history[-1]
-        for k, v in zip(edges, new_edges):
+        for ix, v, rev in zip(order, new_edges, reverse):
+            k = edges[ix]
             op._modified[k] = v
-            op._modified[k.startVertex()] = v.startVertex()
-            op._modified[k.endVertex()] = v.endVertex()
+
+            if rev:
+                op._modified[k.endVertex()] = v.startVertex()
+                op._modified[k.startVertex()] = v.endVertex()
+            else:
+                op._modified[k.startVertex()] = v.startVertex()
+                op._modified[k.endVertex()] = v.endVertex()
 
     return _shape(builder.Shape(), Wire)
 

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6031,6 +6031,7 @@ def wire(*s: Shape, history: History | None = None, name: str | None = None,) ->
 
     builder = BRepBuilderAPI_MakeWire()
 
+    # collect all edges and initialize
     new_edges = []
     edges: list[Edge] = []
     for el in s:
@@ -6055,9 +6056,10 @@ def wire(*s: Shape, history: History | None = None, name: str | None = None,) ->
 
         new_edges.append(Edge(builder.Edge()))
 
+    # NB: this is a dummy update, the builder does not implement history correctly
     _update_history(history, name, s, builder)
 
-    # handle OCCT lack of implementation
+    # Update history manually
     if history:
         op = history[-1]
         for ix, v, rev in zip(order, new_edges, reverse):

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -90,6 +90,7 @@ from OCP.BRepBuilderAPI import (
     BRepBuilderAPI_MakeFace,
     BRepBuilderAPI_MakePolygon,
     BRepBuilderAPI_MakeWire,
+    BRepBuilderAPI_WireError,
     BRepBuilderAPI_Sewing,
     BRepBuilderAPI_Copy,
     BRepBuilderAPI_GTransform,
@@ -5614,7 +5615,7 @@ class Op:
         if s:
             return self._get(self._modified, s)
 
-        return _normalize(compound(*self._modified.values()))
+        return _normalize(compound(*set(self._modified.values())))
 
     def generated(self, s: Shape | None = None) -> Shape:
         """
@@ -6009,6 +6010,12 @@ def wire(*s: Shape, history: History | None = None, name: str | None = None,) ->
 
     for e in edges:
         builder.Add(e.edge().wrapped)
+        status = builder.Error()
+
+        assert (
+            status == BRepBuilderAPI_WireError.BRepBuilderAPI_WireDone
+        ), f"Wire construction failed: {status}"
+
         new_edges.append(Edge(builder.Edge()))
 
     _update_history(history, name, s, builder)

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -1469,6 +1469,7 @@ def test_wire_history():
 
     edges = [segment(p1, p2) for p1, p2 in zip(pts, pts[1:] + pts[:1])]
 
+    # regular case
     _ = wire(edges, history=h)
 
     op = h[-1]
@@ -1478,3 +1479,21 @@ def test_wire_history():
 
     for e in edges:
         assert (e.Center() - op.modified(e).Center()).Length == approx(0)
+
+        for v in e:
+            assert (v.Center() - op.modified(v).Center()).Length == approx(0)
+
+    # test with wrong edge order
+    edges = [edges[0], edges[2].reverse(), edges[1], edges[3]]
+    _ = wire(edges, history=h)
+
+    op = h[-1]
+
+    assert op.modified().edges().size() == 4
+    assert op.modified().vertices().size() == 4
+
+    for e in edges:
+        assert (e.Center() - op.modified(e).Center()).Length == approx(0)
+
+        for v in e:
+            assert (v.Center() - op.modified(v).Center()).Length == approx(0)

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -1464,6 +1464,16 @@ def test_chamfer2D_history():
 
 def test_wire_history():
 
+    # private helper
+    def _check(op, edges):
+        for e in edges:
+            assert (e.Center() - op.modified(e).Center()).Length == approx(0)
+            assert (e.Center() - op.images(e).Center()).Length == approx(0)
+
+            for v in e:
+                assert (v.Center() - op.modified(v).Center()).Length == approx(0)
+                assert (v.Center() - op.images(v).Center()).Length == approx(0)
+
     h = History()
     pts = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]
 
@@ -1477,11 +1487,7 @@ def test_wire_history():
     assert op.modified().edges().size() == 4
     assert op.modified().vertices().size() == 4
 
-    for e in edges:
-        assert (e.Center() - op.modified(e).Center()).Length == approx(0)
-
-        for v in e:
-            assert (v.Center() - op.modified(v).Center()).Length == approx(0)
+    _check(op, edges)
 
     # test with wrong edge order
     edges = [edges[0], edges[2].reverse(), edges[1], edges[3]]
@@ -1492,8 +1498,15 @@ def test_wire_history():
     assert op.modified().edges().size() == 4
     assert op.modified().vertices().size() == 4
 
-    for e in edges:
-        assert (e.Center() - op.modified(e).Center()).Length == approx(0)
+    _check(op, edges)
 
-        for v in e:
-            assert (v.Center() - op.modified(v).Center()).Length == approx(0)
+    # same but open wire
+    edges = edges[:-1]
+    _ = wire(edges, history=h)
+
+    op = h[-1]
+
+    assert op.modified().edges().size() == 3
+    assert op.modified().vertices().size() == 4
+
+    _check(op, edges)

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -1460,3 +1460,21 @@ def test_chamfer2D_history():
 
     assert new_edges.edges().size() == 4
     assert mod_edges.edges().size() == 4
+
+
+def test_wire_history():
+
+    h = History()
+    pts = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]
+
+    edges = [segment(p1, p2) for p1, p2 in zip(pts, pts[1:] + pts[:1])]
+
+    _ = wire(edges, history=h)
+
+    op = h[-1]
+
+    assert op.modified().edges().size() == 4
+    assert op.modified().vertices().size() == 4
+
+    for e in edges:
+        assert (e.Center() - op.modified(e).Center()).Length == approx(0)


### PR DESCRIPTION
NB: this required manual implementation due to lack of proper support on the OCCT side. The interface is there, but it does not return anything. 

NB2: also includes more robust implementation with edge reordering.