### PR TITLE
Add enclose bool op

### DIFF
--- a/cadquery/func.py
+++ b/cadquery/func.py
@@ -59,6 +59,7 @@ from .occ_impl.shapes import (
     chamfer2D,
     draft,
     History,
+    enclose,
 )
 
 __all__ = [
@@ -124,4 +125,5 @@ __all__ = [
     "fillet2D",
     "draft",
     "History",
+    "enclose",
 ]

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6906,6 +6906,8 @@ def enclose(
     """
 
     builder = BOPAlgo_MakerVolume()
+    # ignore non-intersecting internal faces
+    builder.SetAvoidInternalShapes(True)
     _set_builder_options(builder, tol)
 
     for s in shapes:

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -266,6 +266,8 @@ from OCP.BOPAlgo import (
     BOPAlgo_FUSE,
     BOPAlgo_CUT,
     BOPAlgo_COMMON,
+    BOPAlgo_MakerVolume,
+    BOPAlgo_Splitter,
 )
 
 from OCP.IFSelect import IFSelect_ReturnStatus
@@ -6879,12 +6881,41 @@ def split(
     Split one shape with another.
     """
 
-    builder = BRepAlgoAPI_Splitter()
-    _bool_op(s1, s2, builder, tol)
+    builder = BOPAlgo_Splitter()
+    _set_builder_options(builder, tol)
+
+    builder.AddArgument(s1.wrapped)
+    builder.AddTool(s2.wrapped)
+
+    builder.Perform()
 
     _update_history(history, name, [s1, s2], builder)
 
     return _compound_or_shape(builder.Shape())
+
+
+def enclose(
+    *shapes: Shape,
+    tol: float = 0.0,
+    history: History | None = None,
+    name: str | None = None,
+) -> Shape:
+    """
+    Build a solid enclosed by the specified faces. Faces can intersect or touch.
+    If all faces are touching, solid() has better performance.
+    """
+
+    builder = BOPAlgo_MakerVolume()
+    _set_builder_options(builder, tol)
+
+    for s in shapes:
+        builder.AddArgument(s.wrapped)
+
+    builder.Perform()
+
+    _update_history(history, name, shapes, builder)
+
+    return Shape.cast(builder.Shape())
 
 
 def imprint(

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6915,7 +6915,7 @@ def enclose(
 
     _update_history(history, name, shapes, builder)
 
-    return Shape.cast(builder.Shape())
+    return _compound_or_shape(builder.Shape())
 
 
 def imprint(

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -67,6 +67,7 @@ from cadquery.occ_impl.shapes import (
     _get_faces,
     _combine_hist_dict,
     enclose,
+    split,
 )
 
 from OCP.BOPAlgo import BOPAlgo_CheckStatus
@@ -593,6 +594,17 @@ def test_operators():
     assert len(intersect(b1, b3, tol=1e-3).Faces()) == 6
 
 
+def test_split():
+
+    c = cylinder(2, 10)
+    p = plane(2, 2).moved(z=1)
+
+    res = split(c, p)
+
+    assert res.isValid()
+    assert res.solids().size() == 2
+
+
 def test_enclose():
 
     c = cylinder(2, 10).face("%CYLINDER")
@@ -604,6 +616,11 @@ def test_enclose():
     assert res.isValid()
     assert res.ShapeType() == "Solid"
     assert res.Volume() == approx(pi)
+
+    res = enclose(c, p1)
+
+    assert isinstance(res, Compound)
+    assert res.size() == 0
 
 
 def test_imprint():

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -66,6 +66,7 @@ from cadquery.occ_impl.shapes import (
     _shape_to_faces_shells,
     _get_faces,
     _combine_hist_dict,
+    enclose,
 )
 
 from OCP.BOPAlgo import BOPAlgo_CheckStatus
@@ -590,6 +591,19 @@ def test_operators():
     assert len(fuse(b1, b3, tol=1e-3).Faces()) == 6
     assert len(cut(b1, b3, tol=1e-3).Faces()) == 0
     assert len(intersect(b1, b3, tol=1e-3).Faces()) == 6
+
+
+def test_enclose():
+
+    c = cylinder(2, 10).face("%CYLINDER")
+    p1 = plane(3, 3)
+    p2 = plane(2, 2).moved(z=1)
+
+    res = enclose(c, p1, p2)
+
+    assert res.isValid()
+    assert res.ShapeType() == "Solid"
+    assert res.Volume() == approx(pi)
 
 
 def test_imprint():

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -610,8 +610,9 @@ def test_enclose():
     c = cylinder(2, 10).face("%CYLINDER")
     p1 = plane(3, 3)
     p2 = plane(2, 2).moved(z=1)
+    p3 = plane(0.1, 0.1).moved(z=1.5)  # internal face to be ignored
 
-    res = enclose(c, p1, p2)
+    res = enclose(c, p1, p2, p3)
 
     assert res.isValid()
     assert res.ShapeType() == "Solid"


### PR DESCRIPTION
This allows to construct solids from overlapping faces using `enclose` op. Does the name make sense to you BTW?
<img width="961" height="648" alt="image" src="https://github.com/user-attachments/assets/c962194e-78d5-4ad3-8350-653fec84b15a" />
<img width="966" height="649" alt="image" src="https://github.com/user-attachments/assets/be821d86-da29-4760-9831-bdbdb708ab25" />

