### PR TITLE
Add importStep class method to Shape

### DIFF
--- a/cadquery/occ_impl/importers/__init__.py
+++ b/cadquery/occ_impl/importers/__init__.py
@@ -83,15 +83,9 @@ def importBin(fileName: str) -> "cq.Workplane":
     return cq.Workplane("XY").newObject([shape])
 
 
-# Loads a STEP file into a CQ.Workplane object
-def importStep(fileName: str, unit: UnitLiterals = "MM") -> "cq.Workplane":
+def _importStep(fileName: str, unit: UnitLiterals = "MM") -> list["Shape"]:
     """
-    Accepts a file name and loads the STEP file into a cadquery Workplane
-
-    :param fileName: The path and name of the STEP file to be imported
-    :param unit: Sets the target OpenCASCADE unit - OCCT scales from the file's
-    declared unit to this unit. Default "MM".
-    :type unit: UnitLiterals
+    Private helper for implementing different STEP importers.
     """
 
     # Set the target cascade unit - OCCT scales from the file's declared unit to this unit
@@ -105,16 +99,23 @@ def importStep(fileName: str, unit: UnitLiterals = "MM") -> "cq.Workplane":
     for i in range(reader.NbRootsForTransfer()):
         reader.TransferRoot(i + 1)
 
-    occ_shapes = []
-    for i in range(reader.NbShapes()):
-        occ_shapes.append(reader.Shape(i + 1))
+    rv = [Shape.cast(reader.Shape(i + 1)) for i in range(reader.NbShapes())]
 
-    # Make sure that we extract all the solids
-    solids = []
-    for shape in occ_shapes:
-        solids.append(Shape.cast(shape))
+    return rv
 
-    return cq.Workplane("XY").newObject(solids)
+
+# Loads a STEP file into a CQ.Workplane object
+def importStep(fileName: str, unit: UnitLiterals = "MM") -> "cq.Workplane":
+    """
+    Accepts a file name and loads the STEP file into a cadquery Workplane
+
+    :param fileName: The path and name of the STEP file to be imported
+    :param unit: Sets the target OpenCASCADE unit - OCCT scales from the file's
+    declared unit to this unit. Default "MM".
+    :type unit: UnitLiterals
+    """
+
+    return cq.Workplane("XY").newObject(_importStep(fileName, unit))
 
 
 def importDXF(

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -200,7 +200,7 @@ from OCP.TopTools import (
 
 from OCP.ShapeFix import ShapeFix_Shape, ShapeFix_Solid, ShapeFix_Face
 
-from OCP.STEPControl import STEPControl_Writer, STEPControl_AsIs, STEPControl_Reader
+from OCP.STEPControl import STEPControl_Writer, STEPControl_AsIs
 
 from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.StlAPI import StlAPI_Writer
@@ -268,7 +268,7 @@ from OCP.BOPAlgo import (
     BOPAlgo_COMMON,
 )
 
-from OCP.IFSelect import IFSelect_ReturnStatus, IFSelect_RetDone
+from OCP.IFSelect import IFSelect_ReturnStatus
 
 from OCP.TopAbs import TopAbs_ShapeEnum, TopAbs_Orientation
 
@@ -616,17 +616,9 @@ class Shape(object):
         :type unit: UnitLiterals
         """
 
-        # Set the target cascade unit - OCCT scales from the file's declared unit to this unit
-        Interface_Static.SetCVal_s("xstep.cascade.unit", unit.upper())
+        from .importers import _importStep
 
-        reader = STEPControl_Reader()
-        if reader.ReadFile(fileName) != IFSelect_RetDone:
-            raise ValueError(f"Could not import {fileName}")
-
-        for i in range(reader.NbRootsForTransfer()):
-            reader.TransferRoot(i + 1)
-
-        shapes = [cls.cast(reader.Shape(i + 1)) for i in range(reader.NbShapes())]
+        shapes = _importStep(fileName, unit)
 
         if not shapes:
             raise ValueError(f"No shape found in {fileName}")

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -200,7 +200,7 @@ from OCP.TopTools import (
 
 from OCP.ShapeFix import ShapeFix_Shape, ShapeFix_Solid, ShapeFix_Face
 
-from OCP.STEPControl import STEPControl_Writer, STEPControl_AsIs
+from OCP.STEPControl import STEPControl_Writer, STEPControl_AsIs, STEPControl_Reader
 
 from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.StlAPI import StlAPI_Writer
@@ -268,7 +268,7 @@ from OCP.BOPAlgo import (
     BOPAlgo_COMMON,
 )
 
-from OCP.IFSelect import IFSelect_ReturnStatus
+from OCP.IFSelect import IFSelect_ReturnStatus, IFSelect_RetDone
 
 from OCP.TopAbs import TopAbs_ShapeEnum, TopAbs_Orientation
 
@@ -604,6 +604,34 @@ class Shape(object):
         BinTools.Read_s(s, f)
 
         return cls.cast(s)
+
+    @classmethod
+    def importStep(cls, fileName: str, unit: UnitLiterals = "MM") -> Shape:
+        """
+        Import shape from a STEP file.
+
+        :param fileName: Path to the STEP file to import.
+        :param unit: Sets the target OpenCASCADE unit - OCCT scales from the file's
+            declared unit to this unit. Default "MM".
+        :type unit: UnitLiterals
+        """
+
+        # Set the target cascade unit - OCCT scales from the file's declared unit to this unit
+        Interface_Static.SetCVal_s("xstep.cascade.unit", unit.upper())
+
+        reader = STEPControl_Reader()
+        if reader.ReadFile(fileName) != IFSelect_RetDone:
+            raise ValueError(f"Could not import {fileName}")
+
+        for i in range(reader.NbRootsForTransfer()):
+            reader.TransferRoot(i + 1)
+
+        shapes = [cls.cast(reader.Shape(i + 1)) for i in range(reader.NbShapes())]
+
+        if not shapes:
+            raise ValueError(f"No shape found in {fileName}")
+
+        return shapes[0] if len(shapes) == 1 else Compound.makeCompound(shapes)
 
     def geomType(self) -> Geoms:
         """

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -259,6 +259,63 @@ def test_bin_import_export():
         Shape.importBin(BytesIO())
 
 
+def test_step_import_export(tmp_path):
+
+    b = box(1, 1, 1)
+
+    fileName = str(tmp_path / "box.step")
+
+    b.exportStep(fileName)
+
+    r = Shape.importStep(fileName)
+
+    assert r.isValid()
+    assert r.ShapeType() == "Solid"
+    assert r.Volume() == approx(1)
+
+    with raises(Exception):
+        Shape.importStep(str(tmp_path / "does_not_exist.step"))
+
+
+def test_step_import_no_shape(tmp_path):
+
+    # a syntactically valid STEP file that has no shape data in it
+    fileName = str(tmp_path / "no_shape.step")
+
+    with open(fileName, "w") as f:
+        f.write(
+            "ISO-10303-21;\n"
+            "HEADER;\n"
+            "FILE_DESCRIPTION((''),'2;1');\n"
+            "FILE_NAME('empty','2024-01-01T00:00:00',(''),(''),'','','');\n"
+            "FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 3 1 1 }'));\n"
+            "ENDSEC;\n"
+            "DATA;\n"
+            "ENDSEC;\n"
+            "END-ISO-10303-21;\n"
+        )
+
+    with raises(ValueError):
+        Shape.importStep(fileName)
+
+
+def test_step_import_multiple_roots(tmp_path):
+
+    b1 = box(1, 1, 1)
+    b2 = box(1, 1, 1).moved(3, 0, 0)
+
+    fileName = str(tmp_path / "boxes.step")
+
+    compound(b1, b2).exportStep(fileName)
+
+    r = Shape.importStep(fileName)
+
+    assert r.isValid()
+    assert r.ShapeType() == "Compound"
+    assert r.Volume() == approx(2)
+    assert len(list(r)) == 2
+
+
 def test_sample():
 
     e = ellipse(10, 1)


### PR DESCRIPTION
When using purely functional CadQuery, `importStep` is a bit awkward as it returns a `Workplane`, so `val()` or `vals()` has to be used to return to the world of `Shape`s.

Since `Shape` already has other import/export class methods, I thought it fitting to add an `importStep` method. Obviously, it needs to strictly return a `Shape`, so if the STEP doesn't contain one, it raises a `ValueError`.

Before:

```python
import cadquery as cq

shape = cq.importers.importStep("plate.step").val()
```

After:

```python
import cadquery as cq

shape = cq.Shape.importStep("plate.step")
```
