### PR TITLE
Raise an error when the requested font is not found

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -224,6 +224,7 @@ from OCP.Font import (
     Font_FA_Italic,
     Font_FA_Bold,
     Font_SystemFont,
+    Font_StrictLevel_Aliases,
 )
 
 from OCP.StdPrs import StdPrs_BRepFont, StdPrs_BRepTextBuilder as Font_BRepTextBuilder
@@ -4864,7 +4865,11 @@ class Compound(Shape, Mixin3D):
             mgr.RegisterFont(font_t, True)
 
         else:
-            font_t = mgr.FindFont(TCollection_AsciiString(font), font_kind)
+            font_t = mgr.FindFont(
+                TCollection_AsciiString(font), Font_StrictLevel_Aliases, font_kind
+            )
+            if font_t is None:
+                raise ValueError(f"Font '{font}' not found")
 
         builder = Font_BRepTextBuilder()
         font_i = StdPrs_BRepFont(
@@ -6635,7 +6640,11 @@ def text(
         mgr.RegisterFont(font_t, True)
 
     else:
-        font_t = mgr.FindFont(TCollection_AsciiString(font), font_kind)
+        font_t = mgr.FindFont(
+            TCollection_AsciiString(font), Font_StrictLevel_Aliases, font_kind
+        )
+        if font_t is None:
+            raise ValueError(f"Font '{font}' not found")
 
     font_i = StdPrs_BRepFont(
         NCollection_Utf8String(font_t.FontName().ToCString()), font_kind, float(size),

--- a/tests/test_cadquery.py
+++ b/tests/test_cadquery.py
@@ -3956,6 +3956,16 @@ class TestCadQuery(BaseTest):
         self.assertLessEqual(rt_bb.xmax, 0)
         self.assertLessEqual(rt_bb.ymax, 0)
 
+    def testTextMissingFont(self):
+        # a font name that cannot be resolved should raise rather than
+        # silently falling back to a default font
+        with self.assertRaises(ValueError):
+            Workplane().text("A", 10, 0, font="NonexistentFontXYZ123")
+
+        # a resolvable font still works
+        r = Workplane().text("A", 10, 0, font="Sans")
+        self.assertTrue(r.val().isValid())
+
     def testParametricCurve(self):
 
         from math import sin, cos, pi

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -504,6 +504,14 @@ def test_spline_params():
     assert p1.toTuple() == approx((0, 1, 0))
 
 
+def test_text_missing_font():
+
+    # a font that cannot be resolved should raise instead of silently
+    # falling back to a default font
+    with raises(ValueError):
+        text("CQ", 10, font="NonexistentFontXYZ123")
+
+
 def test_text():
 
     r1 = text("CQ", 10)


### PR DESCRIPTION
Closes #1920.

`Workplane.text(...)` / `Shape.makeText(...)` silently fell back to the default font when the requested `font` couldn't be found, so a typo'd font name produced text in the wrong font with no indication.

Using `Font_FontMgr.FindFont` with `Font_StrictLevel_Aliases` (instead of the default `Font_StrictLevel_Any`) returns a null handle when the font can't be resolved, so we raise a clear `ValueError` instead. Aliased/valid fonts still resolve as before. Applied to both font-loading paths (`makeText` and the free `text` function), with a test.
