### PR TITLE
Fix segfault when loading an assembly with no children from xml/xbf

### DIFF
--- a/cadquery/occ_impl/importers/assembly.py
+++ b/cadquery/occ_impl/importers/assembly.py
@@ -373,14 +373,16 @@ def _importDoc(doc: TDocStd_Document, assy: AssemblyProtocol):
     if shape_tool.IsTopLevel(top_level_label) and shape_tool.IsAssembly_s(
         top_level_label
     ):
-        # Set the name of the top-level assembly to match the top-level label
-        name_attr = TDataStd_Name()
-        top_level_label.FindAttribute(TDataStd_Name.GetID_s(), name_attr)
+        # Set the name of the top-level assembly to match the top-level label. An
+        # assembly without children has no name attribute after an xml/xbf round
+        # trip, and FindAttribute segfaults on a label that does not have it.
+        name = _get_name(top_level_label)
 
-        # Manipulation of .objects is needed to maintain consistency
-        assy.objects.pop(assy.name)
-        assy.name = str(name_attr.Get().ToExtString())
-        assy.objects[assy.name] = assy
+        if name:
+            # Manipulation of .objects is needed to maintain consistency
+            assy.objects.pop(assy.name)
+            assy.name = name
+            assy.objects[assy.name] = assy
 
         if cq_color:
             assy.color = cq_color

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -2603,3 +2603,20 @@ def test_name_geometries(tmpdir):
     assert len([l for l in lines if "top_face" in l]) == 2
     assert len([l for l in lines if "plane_" in l]) == 2
     assert len([l for l in lines if "seg_" in l]) == 3
+
+
+@pytest.mark.parametrize("kind", ["step", "xml", "xbf"])
+def test_assembly_without_children_roundtrip(kind, tmpdir):
+    """
+    An assembly holding a single shape and no children used to segfault when
+    loaded back from xml or xbf.
+    """
+
+    assy = cq.Assembly(box(1, 1, 1))
+
+    path = os.path.join(tmpdir, f"no_children.{kind}")
+    assy.export(path)
+
+    loaded = cq.Assembly.load(path)
+
+    assert loaded.toCompound().Volume() == approx(1)


### PR DESCRIPTION
Loading an assembly that holds a single shape and no children crashes the interpreter:

```python
import cadquery as cq

assy = cq.Assembly(cq.Solid.makeBox(1, 1, 1))
assy.export("a.xml")
cq.Assembly.load("a.xml")     # Fatal Python error: Segmentation fault
```

Same for `.xbf`. Adding a single child makes it go away, which is why the existing round-trip tests do not hit it -- every fixture has children. STEP is unaffected.

Cause: such an assembly has no `TDataStd_Name` on its top-level label after the XCAF round trip, and `_importDoc` calls

```python
name_attr = TDataStd_Name()
top_level_label.FindAttribute(TDataStd_Name.GetID_s(), name_attr)
assy.name = str(name_attr.Get().ToExtString())
```

`FindAttribute` segfaults on a label that does not carry the attribute rather than returning false:

```
Fatal Python error: Segmentation fault
  File "cadquery/occ_impl/importers/assembly.py", line 378 in _importDoc
  File "cadquery/occ_impl/importers/assembly.py", line 227 in importXml
```

The module already has a helper that gets this right -- `_get_name` checks `IsAttribute` before calling `FindAttribute` -- so use it, and keep the generated name when the file does not carry one.

Test: `test_assembly_without_children_roundtrip` parametrized over step/xml/xbf. On master the xml and xbf cases take the whole pytest process down with SIGSEGV.
