### PR TITLE
Slugify the branch name used as the docker image tag

### DIFF
--- a/.github/workflows/apptainer_build.yml
+++ b/.github/workflows/apptainer_build.yml
@@ -56,16 +56,21 @@ jobs:
       - name: Check out code for the container builds
         uses: actions/checkout@v6
 
+      - name: Set the image tag
+        run: |
+          # a docker tag cannot contain a slash, which branch names often do
+          echo "IMAGE_TAG=${BRANCH_NAME//\//-}" >> "$GITHUB_ENV"
+
       - name: Build Container
         run: |
-          docker build -t ghcr.io/cadquery/cadquery-docker:${BRANCH_NAME} -f images/dockerfile .
+          docker build -t ghcr.io/cadquery/cadquery-docker:${IMAGE_TAG} -f images/dockerfile .
 
       - name: Test
         run: |
-          docker run --rm -v $(pwd):/host -w /host ghcr.io/cadquery/cadquery-docker:${BRANCH_NAME} pytest tests/
+          docker run --rm -v $(pwd):/host -w /host ghcr.io/cadquery/cadquery-docker:${IMAGE_TAG} pytest tests/
 
       - name: Deploy to GHCR
         if: contains(env.BRANCH_NAME, 'master')
         run: |
-           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin 
-           docker push ghcr.io/cadquery/cadquery-docker:${BRANCH_NAME}
+           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+           docker push ghcr.io/cadquery/cadquery-docker:${IMAGE_TAG}


### PR DESCRIPTION
The Build Docker job tags the image with the raw branch name:

```yaml
BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
...
docker build -t ghcr.io/cadquery/cadquery-docker:${BRANCH_NAME} -f images/dockerfile .
```

A docker tag cannot contain a slash, so any PR from a branch named like `fix/...` or `docs/...` fails the build before it even starts:

```
ERROR: failed to build: invalid tag "ghcr.io/cadquery/cadquery-docker:fix/assembly-load-segfault": invalid reference
##[error]Process completed with exit code 1.
```

That is currently red on #2064, #2065 and #2044.

This replaces the slashes when building the tag. `master` has none, so the tag pushed to GHCR is unchanged.

This branch has a slash in its own name, so the Build Docker job on this PR is the check.
