### PR TITLE
Better imprint for assy

### DIFF
--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -37,7 +37,7 @@ from OCP.Quantity import (
 )
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Fuse
 from OCP.TopTools import TopTools_ListOfShape
-from OCP.BOPAlgo import BOPAlgo_GlueEnum, BOPAlgo_MakeConnected
+from OCP.BOPAlgo import BOPAlgo_GlueEnum, BOPAlgo_Builder
 from OCP.TopoDS import TopoDS_Shape
 from OCP.gp import gp_EulerSequence
 
@@ -49,7 +49,7 @@ from vtkmodules.vtkRenderingCore import (
 )
 
 from .geom import Location
-from .shapes import Shape, Solid, Compound
+from .shapes import Shape, Solid, Compound, GlueLiteral, _set_glue, _set_builder_options
 from .exporters.vtk import toString, extractEdgesFaces
 from ..cq import Workplane
 from ..utils import BiDict
@@ -855,7 +855,9 @@ def toFusedCAF(
     return top_level_lbl, doc
 
 
-def imprint(assy: AssemblyProtocol) -> Tuple[Shape, Dict[Shape, Tuple[str, ...]]]:
+def imprint(
+    assy: AssemblyProtocol, tol: float = 0.0, glue: GlueLiteral = "full",
+) -> Tuple[Shape, Dict[Shape, Tuple[str, ...]]]:
     """
     Imprint all the solids and construct a dictionary mapping imprinted solids to names from the input assy.
     """
@@ -868,22 +870,28 @@ def imprint(assy: AssemblyProtocol) -> Tuple[Shape, Dict[Shape, Tuple[str, ...]]
             id_map[s] = name
 
     # connect topologically
-    bldr = BOPAlgo_MakeConnected()
-    bldr.SetRunParallel(True)
-    bldr.SetUseOBB(True)
+    builder = BOPAlgo_Builder()
+
+    _set_glue(builder, glue)
+    _set_builder_options(builder, tol)
 
     for obj in id_map:
-        bldr.AddArgument(obj.wrapped)
+        builder.AddArgument(obj.wrapped)
 
-    bldr.Perform()
-    res = Shape(bldr.Shape())
+    builder.Perform()
+    res = Shape(builder.Shape())
 
     # make the connected solid -> id map
+    ocp_origins = builder.Origins()
     origins: Dict[Shape, Tuple[str, ...]] = {}
 
     for s in res.Solids():
-        ids = tuple(id_map[Solid(el)] for el in bldr.GetOrigins(s.wrapped))
-        # if GetOrigins yields nothing, solid was not modified
+        if ocp_origins.IsBound(s.wrapped):
+            # if GetOrigins yields nothing, solid was not modified
+            ids = tuple(id_map[Solid(el)] for el in ocp_origins.Find(s.wrapped))
+        else:
+            ids = ()
+
         origins[s] = ids if ids else (id_map[s],)
 
     return res, origins

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -860,6 +860,9 @@ def imprint(
 ) -> Tuple[Shape, Dict[Shape, Tuple[str, ...]]]:
     """
     Imprint all the solids and construct a dictionary mapping imprinted solids to names from the input assy.
+
+    Depending on the use case, it might be required do use different `glue` option. Moreover, for large models
+    it might be needed to limit the number of threads using :meth:`cadquery.func.setThreads`
     """
 
     # make the id map

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -856,7 +856,7 @@ def toFusedCAF(
 
 
 def imprint(
-    assy: AssemblyProtocol, tol: float = 0.0, glue: GlueLiteral = "full",
+    assy: AssemblyProtocol, tol: float = 0.0, glue: GlueLiteral = "partial",
 ) -> Tuple[Shape, Dict[Shape, Tuple[str, ...]]]:
     """
     Imprint all the solids and construct a dictionary mapping imprinted solids to names from the input assy.

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -890,7 +890,7 @@ def imprint(
 
     for s in res.Solids():
         if ocp_origins.IsBound(s.wrapped):
-            # if GetOrigins yields nothing, solid was not modified
+            # if ocp_origins does not contain the solid, it was not modified
             ids = tuple(id_map[Solid(el)] for el in ocp_origins.Find(s.wrapped))
         else:
             ids = ()

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -861,7 +861,7 @@ def imprint(
     """
     Imprint all the solids and construct a dictionary mapping imprinted solids to names from the input assy.
 
-    Depending on the use case, it might be required do use different `glue` option. Moreover, for large models
+    Depending on the use case, it might be required to use a different `glue` option. Moreover, for large models
     it might be needed to limit the number of threads using :meth:`cadquery.func.setThreads`
     """
 

--- a/cadquery/occ_impl/assembly.py
+++ b/cadquery/occ_impl/assembly.py
@@ -872,6 +872,12 @@ def imprint(
         for s in obj.moved(loc).Solids():
             id_map[s] = name
 
+    # special cases for only one or no solids present
+    if len(id_map) == 1:
+        return s, {obj: (id_map[s],)}
+    elif len(id_map) == 0:
+        raise ValueError("Cannot imprint assemblies without solids.")
+
     # connect topologically
     builder = BOPAlgo_Builder()
 

--- a/cadquery/occ_impl/nurbs.py
+++ b/cadquery/occ_impl/nurbs.py
@@ -357,7 +357,7 @@ class Surface(NamedTuple):
 @njiti
 def _preprocess(
     u: Array, order: int, knots: Array, periodic: bool
-) -> Tuple[Array, Array, Optional[int], Optional[int], int]:
+) -> Tuple[Array, Array, int, int, int]:
     """
     Helper for handling periodicity. This function extends the knot vector,
     wraps the parameters and calculates the delta span.

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6962,6 +6962,9 @@ def imprint(
 ) -> Shape:
     """
     Imprint arbitrary number of shapes.
+
+    Depending on the use case, it might be required do use different `glue` option. Moreover, for large models
+    it might be needed to limit the number of threads using :meth:`cadquery.func.setThreads`
     """
 
     builder = BOPAlgo_Builder()

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6956,7 +6956,7 @@ def enclose(
 def imprint(
     *shapes: Shape,
     tol: float = 0.0,
-    glue: GlueLiteral = "full",
+    glue: GlueLiteral = "partial",
     history: History | None = None,
     name: str | None = None,
 ) -> Shape:

--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -6963,7 +6963,7 @@ def imprint(
     """
     Imprint arbitrary number of shapes.
 
-    Depending on the use case, it might be required do use different `glue` option. Moreover, for large models
+    Depending on the use case, it might be required to use a different `glue` option. Moreover, for large models
     it might be needed to limit the number of threads using :meth:`cadquery.func.setThreads`
     """
 

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pathlib import PurePath
 from contextlib import chdir
 import re
-from pytest import approx
+from pytest import approx, raises
 
 import cadquery as cq
 
@@ -2364,6 +2364,16 @@ def test_imprinting(touching_assy, disjoint_assy):
 
     for s in r.Solids():
         assert s in o
+
+    # edge usecase with one shape
+    r, o = cq.occ_impl.assembly.imprint(cq.Assembly().add(box(1, 1, 1)))
+
+    assert len(r.Solids()) == 1
+    assert len(r.Faces()) == 6
+
+    # edge usecase with zero shapes
+    with raises(ValueError):
+        cq.occ_impl.assembly.imprint(cq.Assembly())
 
 
 def test_subassy_imprinting(complex_assy):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -10,6 +10,8 @@ import re
 from pytest import approx
 
 import cadquery as cq
+
+from cadquery import Location
 from cadquery.occ_impl.exporters.assembly import (
     exportAssembly,
     exportStepMeta,
@@ -2325,6 +2327,16 @@ def touching_assy():
 
 
 @pytest.fixture
+def complex_assy(touching_assy):
+
+    return (
+        cq.Assembly()
+        .add(touching_assy, name="sub1")
+        .add(touching_assy, loc=Location((5, 0, 0)), name="sub2")
+    )
+
+
+@pytest.fixture
 def disjoint_assy():
 
     b1 = cq.Workplane().box(1, 1, 1)
@@ -2352,6 +2364,26 @@ def test_imprinting(touching_assy, disjoint_assy):
 
     for s in r.Solids():
         assert s in o
+
+
+def test_subassy_imprinting(complex_assy):
+
+    # imprint subassys separately
+    res1, origins1 = cq.occ_impl.assembly.imprint(complex_assy.sub1)
+    res2, origins2 = cq.occ_impl.assembly.imprint(complex_assy.sub2)
+
+    # reference one step imprint
+    ref, _ = cq.occ_impl.assembly.imprint(complex_assy)
+
+    # combine the results
+    res = res1 | res2
+    origins = origins1 | origins2
+
+    assert len(res.Solids()) == len(ref.Solids())
+    assert len(res.Faces()) == len(ref.Faces())
+
+    for s in res.Solids():
+        assert s in origins
 
 
 def test_order_of_transform():


### PR DESCRIPTION
Low level fix enabling faster imprints for well behaved models. 

NB: this PR also contains a typing fix related to Numba version update.

______________

Tangentially related to this PR (I added explicit test for this use case) - it is possible to imprint subassemblies separately and on per subassy basis use different imprint glue settings in order to optimize performance:

```python
res1, origins1 = cq.occ_impl.assembly.imprint(complex_assy.sub1, glue='partial')
res2, origins2 = cq.occ_impl.assembly.imprint(complex_assy.sub2, glue='full')

# combine the results
res: Compound = res1 | res2
origins: dict[Shape, Shape] = origins1 | origins2
```