### PR TITLE
recognize .wrl as a vrml export extension

### DIFF
--- a/cadquery/assembly.py
+++ b/cadquery/assembly.py
@@ -598,6 +598,8 @@ class Assembly(object):
 
         if exportType is None:
             t = path.split(".")[-1].upper()
+            if t == "WRL":
+                t = "VRML"
             if t in ("STEP", "XML", "XBF", "VRML", "VTKJS", "GLTF", "GLB", "STL"):
                 exportType = cast(ExportLiterals, t)
             else:

--- a/cadquery/occ_impl/exporters/__init__.py
+++ b/cadquery/occ_impl/exporters/__init__.py
@@ -74,6 +74,8 @@ def export(
 
     if exportType is None:
         t = fname.split(".")[-1].upper()
+        if t == "WRL":
+            t = ExportTypes.VRML
         if t in ExportTypes.__dict__.values():
             exportType = cast(ExportLiterals, t)
         else:

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1441,7 +1441,7 @@ def test_toJSON(simple_assy, empty_top_assy):
         ("xml", ()),
         ("stp", ("STEP",)),
         ("caf", ("XML",)),
-        ("wrl", ("VRML",)),
+        ("wrl", ()),
         ("stl", ("STL",)),
     ],
 )
@@ -1466,7 +1466,7 @@ def test_save(extension, args, nested_assy, tmpdir):
         ("stl", (), {"ascii": True}),
         ("stp", ("STEP",), {}),
         ("caf", ("XML",), {}),
-        ("wrl", ("VRML",), {}),
+        ("wrl", (), {}),
         ("stl", ("STL",), {}),
     ],
 )

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -629,12 +629,14 @@ class TestExporters(BaseTest):
 
     def testVRML(self):
 
-        exporters.export(self._box(), str(self.tmpdir / "out1.vrml"))
+        for extension in ("vrml", "wrl"):
+            output = self.tmpdir / f"out1.{extension}"
+            exporters.export(self._box(), str(output))
 
-        with open(self.tmpdir / "out1.vrml") as f:
-            res = f.read(10)
+            with open(output) as f:
+                res = f.read(10)
 
-        assert res.startswith("#VRML V2.0")
+            assert res.startswith("#VRML V2.0")
 
         # export again to trigger all paths in the code
         exporters.export(self._box(), str(self.tmpdir / "out2.vrml"))


### PR DESCRIPTION
fixes #740

`.wrl` is the extension most vrml tools recognize, but cadquery only inferred `VRML` from `.vrml`. this maps `.wrl` to the existing vrml exporter for both shapes and assemblies.

the exporter test now verifies that `.vrml` and `.wrl` produce the same vrml header. the assembly save and export cases also infer the format from `.wrl` instead of passing it explicitly.

validation

* ran the cadquery black fork against all four changed files
* compiled the cadquery and test python sources
* ran git diff check

full pytest was not run locally because this checkout does not have the occt runtime installed.