### PR TITLE
Fix StopIteration when computing mass of a compound containing an empty compound (#2078)

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -825,20 +825,15 @@ class Shape(object):
         # special handling of compounds - first non-compound child is assumed to define the type of the operation
         if type_ == ta.TopAbs_COMPOUND:
 
-            # if the compound is not empty check its children
-            if obj:
-                # first child
-                child = next(iter(obj))
+            # descend to the first non-compound child, if any; the sentinel
+            # guards against an empty compound at the top level or nested inside
+            child = next(iter(obj), None)
+            while child is not None and child.ShapeType() == "Compound":
+                child = next(iter(child), None)
 
-                # if compound, go deeper
-                while child.ShapeType() == "Compound":
-                    child = next(iter(child))
-
-                type_ = shapetype(child.wrapped)
-
-            # if the compound is empty assume it was meant to be a solid
-            else:
-                type_ = ta.TopAbs_SOLID
+            # an empty or empty-nested compound has no child to inspect;
+            # assume it was meant to be a solid (consistent with an empty compound)
+            type_ = ta.TopAbs_SOLID if child is None else shapetype(child.wrapped)
 
         # get the function based on dimensionality of the object
         return shape_properties_LUT[type_]

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -459,6 +459,17 @@ def test_special():
     assert cs[0].Volume() == approx(3 ** 3)
 
 
+def test_nested_empty_compound_mass():
+
+    # a bare empty compound already resolves to zero mass
+    assert compound().Volume() == approx(0)
+
+    # a compound whose first child is an empty compound must not crash and
+    # must stay consistent with the bare empty compound (see issue #2078)
+    assert compound(compound()).Volume() == approx(0)
+    assert compound(compound()).Area() == approx(0)
+
+
 def test_center():
 
     v = vertex(1, 1, 1)


### PR DESCRIPTION
Fixes #2078.

## Repro
```python
from cadquery.occ_impl.shapes import compound

compound().Volume()            # -> 0.0  (fine)
compound(compound()).Volume()  # -> raises StopIteration
```
A bare empty compound reports a mass of `0.0`, but a non-empty compound whose first child is an empty compound raises `StopIteration` instead.

## Root cause
`Shape._mass_calc_function` picks the mass function from the first non-compound descendant of a compound. It guarded the *top-level* empty case with `if obj:` but then descended with a bare `next(iter(child))`:

```python
while child.ShapeType() == "Compound":
    child = next(iter(child))   # empty child compound -> bare StopIteration
```

`Shape.__iter__` yields nothing for an empty compound, so `next()` raises. This is self-inconsistent: a bare empty compound already resolves to `0.0`, so nesting it inside another compound must not flip that into a crash.

## Fix
Use the two-argument `next(..., None)` sentinel so both the top-level-empty case (unchanged) and the nested-empty case resolve to `SOLID -> 0.0`. Non-empty compounds still descend to their first non-compound child exactly as before.

The same helper backs `Volume()`, `Area()`, and `centerOfMass()`, so all three are fixed (verified: nested-empty `centerOfMass()` now returns `(0, 0, 0)`).

## Test
Adds `test_nested_empty_compound_mass` to `tests/test_shapes.py`, asserting the bare-empty control plus `Volume()`/`Area()` of a nested-empty compound are `0.0`. Fails with `StopIteration` before the fix, passes after.

Thanks to @johnbeard for the clear report and minimal repro.

---
AI-assisted: this fix was prepared with the help of an AI coding assistant and reviewed by me.
