### PR TITLE
docs: document Fixed sketch constraint

### DIFF
--- a/doc/sketch.rst
+++ b/doc/sketch.rst
@@ -147,6 +147,11 @@ Following constraints are implemented. Arguments are passed in as one tuple in :
       - Entities
       - Arguments
       - Description
+    * - Fixed
+      - 1
+      - All
+      - None
+      - Entire entity is fixed in place
     * - FixedPoint
       - 1
       - All


### PR DESCRIPTION
## Summary
- add the documented `Fixed` sketch constraint to the sketch constraints table
- align the table with the example just above it and the implemented sketch solver constraint kinds

Closes #2077.

## Validation
```console
git diff --check
python3 - <<'PY'
from pathlib import Path
text = Path('cadquery/occ_impl/sketch_solver.py').read_text()
doc = Path('doc/sketch.rst').read_text()
assert '"Fixed": (1, ("CIRCLE", "LINE"), NoneType, None)' in text
assert '* - Fixed\n      - 1\n      - All\n      - None\n      - Entire entity is fixed in place' in doc
print('validated Fixed sketch constraint source entry and docs table row')
PY
# validated Fixed sketch constraint source entry and docs table row
```
