### PR TITLE
docs: mention selector chaining

### DIFF
--- a/doc/selectors.rst
+++ b/doc/selectors.rst
@@ -38,6 +38,21 @@ Selectors can be combined logically, currently defined operators include **and**
 
     result = cq.Workplane("XY").box(2, 2, 2).edges("|Z and >Y").chamfer(0.2)
 
+Selector methods can also be chained. Each selector runs against the objects selected by
+the previous step, which is useful when the selection needs to move across shape types.
+For example, this selects the top face first and then selects the positive-Y edge of
+that face before applying a chamfer:
+
+.. cadquery::
+
+    result = (
+        cq.Workplane("XY")
+        .box(2, 2, 2)
+        .faces(">Z")
+        .edges(">Y")
+        .chamfer(0.2)
+    )
+
 Much more complex expressions are possible as well:
 
 .. cadquery::


### PR DESCRIPTION
## Summary
- explicitly document selector chaining in the Selectors reference
- add a focused `faces(">Z").edges(">Y")` example showing how each selector narrows the previous selection

Closes #900.

## Validation
```console
python3 - <<'PY'
from pathlib import Path
s = Path('doc/selectors.rst').read_text()
assert 'Selector methods can also be chained' in s
assert '.faces(">Z")' in s and '.edges(">Y")' in s
assert '.edges("%Line")' not in s
print('doc/selectors.rst contains explicit selector chaining example')
PY
# doc/selectors.rst contains explicit selector chaining example

git diff --check
# no output
```

Note: I did not run the full docs build locally because this checkout does not have the OCP/CadQuery runtime dependencies installed (`ModuleNotFoundError: No module named 'OCP'`).