### PR TITLE
Fix hull failure with collinear circle centres

### DIFF
--- a/cadquery/hull.py
+++ b/cadquery/hull.py
@@ -18,6 +18,9 @@ Points = List["Point"]
 Entity = Union["Arc", "Point"]
 Hull = List[Union["Arc", "Point", "Segment"]]
 
+# minimum arc span; below this makeCircle would return a full circle
+TOL = 1e-9
+
 
 class Point:
 
@@ -348,9 +351,10 @@ def finalize_hull(hull: Hull) -> Wire:
             a1 = degrees(atan2p(el_p.b.x - el.c.x, el_p.b.y - el.c.y))
             a2 = degrees(atan2p(el_n.a.x - el.c.x, el_n.a.y - el.c.y))
 
-            rv.append(
-                Edge.makeCircle(el.r, Vector(el.c.x, el.c.y), angle1=a1, angle2=a2)
-            )
+            if abs(a2 - a1) > TOL:
+                rv.append(
+                    Edge.makeCircle(el.r, Vector(el.c.x, el.c.y), angle1=a1, angle2=a2)
+                )
 
     el1 = hull[1]
     if isinstance(el, Segment) and isinstance(el_n, Arc) and isinstance(el1, Segment):

--- a/cadquery/hull.py
+++ b/cadquery/hull.py
@@ -42,7 +42,7 @@ class Point:
 
     def __eq__(self, other):
 
-        return (self.x, self.y) == (other.x, other.y)
+        return type(self) == type(other) and (self.x, self.y) == (other.x, other.y)
 
 
 class Segment:
@@ -76,6 +76,16 @@ class Arc:
         self.s = Point(r * cos(a1), r * sin(a1))
         self.e = Point(r * cos(a2), r * sin(a2))
         self.ac = 2 * pi - (a1 - a2)
+
+    def __hash__(self):
+
+        return hash((self.c, self.r, self.a1, self.a2))
+
+    def __eq__(self, other):
+
+        return type(self) == type(other) and (
+            (self.c, self.r, self.a1, self.a2) == (other.c, other.r, other.a1, other.a2)
+        )
 
 
 def atan2p(x, y):

--- a/tests/test_hull.py
+++ b/tests/test_hull.py
@@ -1,3 +1,4 @@
+from itertools import permutations
 from math import pi
 
 import pytest
@@ -39,18 +40,34 @@ def test_collinear():
     r = 2.5
     spacing = 8.0
 
-    # collinear centres: the tangent line touches every circle in between
+    # collinear centres let an inner circle enter the hull as a zero span arc;
+    # only some traversal orders reach it, so permute the input
     for n in (3, 4, 5):
 
         expected = spacing * (n - 1) * 2 * r + pi * r ** 2
 
-        # arc order follows id(), so repeat to hit the failing orders
-        for _ in range(20):
+        for order in permutations(range(n)):
 
-            edges = [cq.Edge.makeCircle(r, (i * spacing, 0, 0)) for i in range(n)]
+            edges = [cq.Edge.makeCircle(r, (i * spacing, 0, 0)) for i in order]
 
             h = hull.find_hull(edges)
 
             assert h.IsClosed()
             assert h.isValid()
             assert cq.Face.makeFromWires(h).Area() == pytest.approx(expected)
+
+
+def test_eq():
+
+    a = hull.Arc(hull.Point(0.0, 0.0), 1.0, 0.0, 2 * pi)
+    b = hull.Arc(hull.Point(0.0, 0.0), 1.0, 0.0, 2 * pi)
+    p = hull.Point(0.0, 0.0)
+
+    assert a == b
+    assert hash(a) == hash(b)
+    assert p == hull.Point(0.0, 0.0)
+
+    assert a != hull.Arc(hull.Point(0.0, 0.0), 2.0, 0.0, 2 * pi)
+    assert a != p
+    assert p != a
+    assert a != None

--- a/tests/test_hull.py
+++ b/tests/test_hull.py
@@ -1,3 +1,5 @@
+from math import pi
+
 import pytest
 
 import cadquery as cq
@@ -30,3 +32,25 @@ def test_validation():
         e1 = cq.Edge.makeEllipse(2, 1)
         c1 = cq.Edge.makeCircle(0.5, (-1.5, 0.5, 0))
         hull.find_hull([c1, e1])
+
+
+def test_collinear():
+
+    r = 2.5
+    spacing = 8.0
+
+    # collinear centres: the tangent line touches every circle in between
+    for n in (3, 4, 5):
+
+        expected = spacing * (n - 1) * 2 * r + pi * r ** 2
+
+        # arc order follows id(), so repeat to hit the failing orders
+        for _ in range(20):
+
+            edges = [cq.Edge.makeCircle(r, (i * spacing, 0, 0)) for i in range(n)]
+
+            h = hull.find_hull(edges)
+
+            assert h.IsClosed()
+            assert h.isValid()
+            assert cq.Face.makeFromWires(h).Area() == pytest.approx(expected)


### PR DESCRIPTION
`Sketch.hull()` fails on three equal circles with collinear centres:

```python
s = cq.Sketch()
for x in (0.0, 8.0, 16.0):
    s = s.arc((x, 0.0), 2.5, 0.0, 360.0)
s.hull()   # StdFail_NotDone: BRep_API: command not done
```

The tangent line between the outer two circles also touches the middle one, so it
enters the hull spanning zero degrees. `finalize_hull()` then builds a full circle
instead of a zero-length arc and the wire cannot close.

It only fails about two runs in three: `convert_and_validate()` returns
`list(set(arcs))` and `Arc` is unhashable, so the traversal order follows `id()`.
Hence the repeats in the test.

Same guard as in #1344, which has been open since June 2023 and bundles three
other changes. This is just that guard, plus a test - happy to close it if #1344
is revived instead.
